### PR TITLE
fix(auth0-auth-js): Do not document bindingMessage as optional

### DIFF
--- a/packages/auth0-auth-js/EXAMPLES.md
+++ b/packages/auth0-auth-js/EXAMPLES.md
@@ -306,7 +306,7 @@ const tokenResponse = await authClient.backchannelAuthentication({
 });
 ```
 
-- `bindingMessage`: An optional, human-readable message to be displayed at the consumption device and authentication device. This allows the user to ensure the transaction initiated by the consumption device is the same that triggers the action on the authentication device.
+- `bindingMessage`: A human-readable message to be displayed at the consumption device and authentication device. This allows the user to ensure the transaction initiated by the consumption device is the same that triggers the action on the authentication device.
 - `loginHint.sub`: The `sub` claim of the user that is trying to login using Client-Initiated Backchannel Authentication, and to which a push notification to authorize the login will be sent.
 
 > [!IMPORTANT]  

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -225,16 +225,13 @@ export class AuthClient {
       scope: DEFAULT_SCOPES,
       ...additionalParams,
       client_id: this.#options.clientId,
+      binding_message: options.bindingMessage,
       login_hint: JSON.stringify({
         format: 'iss_sub',
         iss: serverMetadata.issuer,
         sub: options.loginHint.sub,
       }),
     });
-
-    if (options.bindingMessage) {
-      params.append('binding_message', options.bindingMessage);
-    }
 
     try {
       const backchannelAuthenticationResponse =


### PR DESCRIPTION
As our CIBA implementation follows the [FAPI CIBA spec](https://openid.net/specs/openid-financial-api-ciba.html), `bindingMessage` is not optional.

This was taken into consideration in the code, but not in the documentation.

This PR reflects this in the docs for auth0-auth-js as well.