### PR TITLE
fix(auth0-server-js): Do not document bindingMessage as optional

### DIFF
--- a/packages/auth0-server-js/EXAMPLES.md
+++ b/packages/auth0-server-js/EXAMPLES.md
@@ -701,7 +701,7 @@ await serverClient.loginBackchannel({
 });
 ```
 
-- `bindingMessage`: An optional, human-readable message to be displayed at the consumption device and authentication device. This allows the user to ensure the transaction initiated by the consumption device is the same that triggers the action on the authentication device.
+- `bindingMessage`: A human-readable message to be displayed at the consumption device and authentication device. This allows the user to ensure the transaction initiated by the consumption device is the same that triggers the action on the authentication device.
 - `loginHint.sub`: The `sub` claim of the user that is trying to login using Client-Initiated Backchannel Authentication, and to which a push notification to authorize the login will be sent.
 
 > [!IMPORTANT]


### PR DESCRIPTION
As our CIBA implementation follows the [FAPI CIBA spec](https://openid.net/specs/openid-financial-api-ciba.html), `bindingMessage` is not optional.

This was taken into consideration in the code, but not in the documentation.

This PR reflects this in the docs for auth0-server-js as well.