### PR TITLE
docs(auth0-server-js): Update TransactionStore guidance to use AbstractTransactionStore

### DIFF
--- a/packages/auth0-server-js/README.md
+++ b/packages/auth0-server-js/README.md
@@ -72,7 +72,7 @@ import { FastifyReply, FastifyRequest } from 'fastify';
 import { CookieSerializeOptions } from '@fastify/cookie';
 import { 
   AbstractStateStore,
-  TransactionStore,
+  AbstractTransactionStore,
   ServerClient,
   StateData,
   TransactionData
@@ -88,7 +88,7 @@ const auth0 = new ServerClient<StoreOptions>({
   stateStore: new StatelessStateStore({ secret: options.secret }),
 });
 
-export class StatelessTransactionStore implements TransactionStore<StoreOptions> {
+export class StatelessTransactionStore extends AbstractTransactionStore<StoreOptions> {
   async set(identifier: string, transactionData: TransactionData, removeIfExists?: boolean, options?: StoreOptions): Promise<void> {
     // We can not handle cookies in Fastify when the `StoreOptions` are not provided.
     if (!options) {
@@ -99,8 +99,10 @@ export class StatelessTransactionStore implements TransactionStore<StoreOptions>
 
     const maxAge = 60 * 60;
     const cookieOpts: CookieSerializeOptions = { httpOnly: true, sameSite: 'lax', path: '/', maxAge };
-
-    options.reply.setCookie(identifier, JSON.stringify(transactionData), cookieOpts);
+    const expiration = Math.floor(Date.now() / 1000 + maxAge);
+    const encryptedStateData = await this.encrypt(identifier, transactionData, expiration);
+    
+    options.reply.setCookie(identifier, encryptedStateData, cookieOpts);
   }
 
   async get(identifier: string, options?: StoreOptions): Promise<TransactionData | undefined> {
@@ -110,9 +112,9 @@ export class StatelessTransactionStore implements TransactionStore<StoreOptions>
     }
 
     const cookieValue = options.request.cookies[identifier];
-    
+
     if (cookieValue) {
-      return JSON.parse(cookieValue) as TransactionData;
+      return await this.decrypt(identifier, cookieValue);
     }
   }
 


### PR DESCRIPTION
Even though the current guidance works, using the abstract `AbstractTransactionStore` instead of the `TransactionStore` interface would enable users to easily add encryption.