### PR TITLE
chore: Use AbstractTransactionStore in sample applications

### DIFF
--- a/examples/example-fastify-web/src/store/cookie-transaction-store.ts
+++ b/examples/example-fastify-web/src/store/cookie-transaction-store.ts
@@ -1,8 +1,8 @@
 import { CookieSerializeOptions } from '@fastify/cookie';
-import { TransactionData, TransactionStore } from '@auth0/auth0-server-js';
+import { TransactionData, AbstractTransactionStore } from '@auth0/auth0-server-js';
 import { StoreOptions } from '../types.js';
 
-export class CookieTransactionStore implements TransactionStore<StoreOptions> {
+export class CookieTransactionStore extends AbstractTransactionStore<StoreOptions> {
   async set(
     identifier: string,
     transactionData: TransactionData,
@@ -16,8 +16,10 @@ export class CookieTransactionStore implements TransactionStore<StoreOptions> {
 
     const maxAge = 60 * 60;
     const cookieOpts: CookieSerializeOptions = { httpOnly: true, sameSite: 'lax', path: '/', maxAge };
+    const expiration = Math.floor(Date.now() / 1000 + maxAge);
+    const encryptedStateData = await this.encrypt(identifier, transactionData, expiration);
     
-    options.reply.setCookie(identifier, JSON.stringify(transactionData), cookieOpts);
+    options.reply.setCookie(identifier, encryptedStateData, cookieOpts);
   }
 
   async get(identifier: string, options?: StoreOptions): Promise<TransactionData | undefined> {
@@ -29,7 +31,7 @@ export class CookieTransactionStore implements TransactionStore<StoreOptions> {
     const cookieValue = options.request.cookies[identifier];
 
     if (cookieValue) {
-      return JSON.parse(cookieValue) as TransactionData;
+      return await this.decrypt(identifier, cookieValue);
     }
   }
 


### PR DESCRIPTION
Even though the current example apps work fine, using the abstract AbstractTransactionStore instead of the TransactionStore interface enables us to use encryption.