### PR TITLE
fix: support older entry points

### DIFF
--- a/packages/auth0-api-js/package.json
+++ b/packages/auth0-api-js/package.json
@@ -13,6 +13,9 @@
         "test": "vitest run",
         "test:ci": "vitest --watch false --coverage"
     },
+    "types": "./dist/index.d.ts",
+    "main": "./dist/index.cjs",
+    "module": "./dist/index.js",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",

--- a/packages/auth0-auth-js/package.json
+++ b/packages/auth0-auth-js/package.json
@@ -13,6 +13,9 @@
         "test": "vitest run",
         "test:ci": "vitest --watch false --coverage"
     },
+    "types": "./dist/index.d.ts",
+    "main": "./dist/index.cjs",
+    "module": "./dist/index.js",
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",

--- a/packages/auth0-server-js/package.json
+++ b/packages/auth0-server-js/package.json
@@ -13,6 +13,9 @@
     "test": "vitest run",
     "test:ci": "vitest --watch false --coverage"
   },
+  "types": "./dist/index.d.ts",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
Same as https://github.com/auth0/auth0-fastify/pull/13

Mainly that WebStorm still needs the `types` entrypoint when using Yarn PnP for intellisense/navigation.
