### PR TITLE
fix(auth0-server-js): StatelessStateStore cookie options

### DIFF
--- a/packages/auth0-server-js/src/store/stateless-state-store.ts
+++ b/packages/auth0-server-js/src/store/stateless-state-store.ts
@@ -1,13 +1,15 @@
-import type { EncryptedStoreOptions, SessionConfiguration, StateData } from '../types.js';
+import type { EncryptedStoreOptions, SessionConfiguration, SessionCookieOptions, StateData } from '../types.js';
 import { AbstractSessionStore } from './abstract-session-store.js';
 import type { CookieHandler, CookieSerializeOptions } from './cookie-handler.js';
 
 export class StatelessStateStore<TStoreOptions> extends AbstractSessionStore<TStoreOptions> {
+  readonly #cookieOptions: SessionCookieOptions | undefined;
   readonly #cookieHandler: CookieHandler<TStoreOptions>;
 
   constructor(options: SessionConfiguration & EncryptedStoreOptions, cookieHandler: CookieHandler<TStoreOptions>) {
     super(options);
 
+    this.#cookieOptions = options.cookie;
     this.#cookieHandler = cookieHandler;
   }
 
@@ -20,9 +22,9 @@ export class StatelessStateStore<TStoreOptions> extends AbstractSessionStore<TSt
     const maxAge = this.calculateMaxAge(stateData.internal.createdAt);
     const cookieOpts: CookieSerializeOptions = {
       httpOnly: true,
-      sameSite: 'lax',
+      sameSite: this.#cookieOptions?.sameSite ?? 'lax',
       path: '/',
-      secure: true,
+      secure: this.#cookieOptions?.secure ?? true,
       maxAge,
     };
     const expiration = Math.floor(Date.now() / 1000 + maxAge);

--- a/packages/auth0-server-js/src/store/stateless-state-store.ts
+++ b/packages/auth0-server-js/src/store/stateless-state-store.ts
@@ -1,11 +1,11 @@
-import type { EncryptedStoreOptions, StateData } from './../types.js';
+import type { EncryptedStoreOptions, SessionConfiguration, StateData } from '../types.js';
 import { AbstractSessionStore } from './abstract-session-store.js';
 import type { CookieHandler, CookieSerializeOptions } from './cookie-handler.js';
 
 export class StatelessStateStore<TStoreOptions> extends AbstractSessionStore<TStoreOptions> {
   readonly #cookieHandler: CookieHandler<TStoreOptions>;
 
-  constructor(options: EncryptedStoreOptions, cookieHandler: CookieHandler<TStoreOptions>) {
+  constructor(options: SessionConfiguration & EncryptedStoreOptions, cookieHandler: CookieHandler<TStoreOptions>) {
     super(options);
 
     this.#cookieHandler = cookieHandler;


### PR DESCRIPTION
### Description

Fixes constructor param type to allow age configuration, as the runtime logic already considers.
Allows sameSite & secure to be configured as well.
These changes just mirror the `Stateful` implementation.

```ts
new StatelessStateStore({
  absoluteDuration: '..',
  cookie: { sameSite: 'strict' }
})
```

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
