### PR TITLE
docs: add DeepWiki badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Auth0-Auth-JS Mono Repo, containing SDKs for implementing user authentication in
 ![Release](https://img.shields.io/npm/v/@auth0/auth0-auth-js)
 ![Downloads](https://img.shields.io/npm/dw/@auth0/auth0-auth-js)
 [![License](https://img.shields.io/:license-mit-blue.svg?style=flat)](https://opensource.org/licenses/MIT)
+[<img src="https://devin.ai/assets/deepwiki-badge.png" alt="Ask questions about auth0-mcp-server on DeepWiki" height="20"/>](https://deepwiki.com/auth0/auth0-auth-js)
 
 📚 [Packages](#packages) - 💬 [Feedback](#feedback)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Auth0-Auth-JS Mono Repo, containing SDKs for implementing user authentication in
 ![Release](https://img.shields.io/npm/v/@auth0/auth0-auth-js)
 ![Downloads](https://img.shields.io/npm/dw/@auth0/auth0-auth-js)
 [![License](https://img.shields.io/:license-mit-blue.svg?style=flat)](https://opensource.org/licenses/MIT)
-[<img src="https://devin.ai/assets/deepwiki-badge.png" alt="Ask questions about auth0-mcp-server on DeepWiki" height="20"/>](https://deepwiki.com/auth0/auth0-auth-js)
+[<img src="https://devin.ai/assets/deepwiki-badge.png" alt="Ask questions about auth0-auth-js mono repository on DeepWiki" height="20"/>](https://deepwiki.com/auth0/auth0-auth-js)
 
 📚 [Packages](#packages) - 💬 [Feedback](#feedback)
 


### PR DESCRIPTION
### Description

Add DeepWiki badge to README.md for easy access to project documentation on DeepWiki.com. This allows users to quickly access contextual information about the repository through DeepWiki's AI-powered documentation platform.

### References

N/A

### Testing

N/A

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
