### PR TITLE
chore: use shared tsconfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -537,6 +537,10 @@
       "resolved": "packages/auth0-server-js",
       "link": true
     },
+    "node_modules/@auth0/typescript-config": {
+      "resolved": "packages/typescript-config",
+      "link": true
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.26.2",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
@@ -10054,13 +10058,14 @@
     },
     "packages/auth0-api-js": {
       "name": "@auth0/auth0-api-js",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "jose": "^6.0.8",
         "oauth4webapi": "^3.3.0"
       },
       "devDependencies": {
+        "@auth0/typescript-config": "*",
         "@eslint/js": "^9.20.0",
         "@vitest/coverage-v8": "^3.0.6",
         "eslint": "^9.20.1",
@@ -10073,13 +10078,14 @@
     },
     "packages/auth0-auth-js": {
       "name": "@auth0/auth0-auth-js",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "jose": "^6.0.8",
         "openid-client": "^6.3.0"
       },
       "devDependencies": {
+        "@auth0/typescript-config": "*",
         "@eslint/js": "^9.20.0",
         "@vitest/coverage-v8": "^3.0.6",
         "eslint": "^9.20.1",
@@ -10092,13 +10098,14 @@
     },
     "packages/auth0-server-js": {
       "name": "@auth0/auth0-server-js",
-      "version": "1.0.1",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@auth0/auth0-auth-js": "^1.0.0",
         "jose": "^6.0.8"
       },
       "devDependencies": {
+        "@auth0/typescript-config": "*",
         "@eslint/js": "^9.20.0",
         "@vitest/coverage-v8": "^3.0.6",
         "eslint": "^9.20.1",
@@ -10108,6 +10115,10 @@
         "typescript-eslint": "^8.24.0",
         "vitest": "^3.0.5"
       }
+    },
+    "packages/typescript-config": {
+      "version": "0.0.0",
+      "license": "MIT"
     }
   }
 }

--- a/packages/auth0-api-js/package.json
+++ b/packages/auth0-api-js/package.json
@@ -28,6 +28,7 @@
         "oauth4webapi": "^3.3.0"
     },
     "devDependencies": {
+        "@auth0/typescript-config": "*",
         "@eslint/js": "^9.20.0",
         "@vitest/coverage-v8": "^3.0.6",
         "eslint": "^9.20.1",

--- a/packages/auth0-api-js/tsconfig.json
+++ b/packages/auth0-api-js/tsconfig.json
@@ -1,27 +1,8 @@
 {
-    "$schema": "https://json.schemastore.org/tsconfig",
-    "compilerOptions": {
-        "declaration": true,
-        "declarationMap": true,
-        "esModuleInterop": true,
-        "incremental": false,
-        "isolatedModules": true,
-        "lib": [
-            "es2022",
-            "DOM",
-            "DOM.Iterable"
-        ],
-        "module": "NodeNext",
-        "moduleDetection": "force",
-        "moduleResolution": "NodeNext",
-        "noUncheckedIndexedAccess": true,
-        "resolveJsonModule": true,
-        "skipLibCheck": true,
-        "strict": true,
-        "target": "ES2022",
-        "outDir": "dist",
-        "baseUrl": "."
-    },
-    "include": ["src/**/*"],
-    "exclude": ["node_modules"]
+  "extends": "@auth0/typescript-config/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/auth0-auth-js/package.json
+++ b/packages/auth0-auth-js/package.json
@@ -28,6 +28,7 @@
         "openid-client": "^6.3.0"
     },
     "devDependencies": {
+        "@auth0/typescript-config": "*",
         "@eslint/js": "^9.20.0",
         "@vitest/coverage-v8": "^3.0.6",
         "eslint": "^9.20.1",

--- a/packages/auth0-auth-js/tsconfig.json
+++ b/packages/auth0-auth-js/tsconfig.json
@@ -1,27 +1,8 @@
 {
-    "$schema": "https://json.schemastore.org/tsconfig",
-    "compilerOptions": {
-        "declaration": true,
-        "declarationMap": true,
-        "esModuleInterop": true,
-        "incremental": false,
-        "isolatedModules": true,
-        "lib": [
-            "es2022",
-            "DOM",
-            "DOM.Iterable"
-        ],
-        "module": "NodeNext",
-        "moduleDetection": "force",
-        "moduleResolution": "NodeNext",
-        "noUncheckedIndexedAccess": true,
-        "resolveJsonModule": true,
-        "skipLibCheck": true,
-        "strict": true,
-        "target": "ES2022",
-        "outDir": "dist",
-        "baseUrl": "."
-    },
-    "include": ["src/**/*"],
-    "exclude": ["node_modules"]
+  "extends": "@auth0/typescript-config/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/auth0-server-js/package.json
+++ b/packages/auth0-server-js/package.json
@@ -28,6 +28,7 @@
     "jose": "^6.0.8"
   },
   "devDependencies": {
+    "@auth0/typescript-config": "*",
     "@eslint/js": "^9.20.0",
     "@vitest/coverage-v8": "^3.0.6",
     "eslint": "^9.20.1",

--- a/packages/auth0-server-js/tsconfig.json
+++ b/packages/auth0-server-js/tsconfig.json
@@ -1,27 +1,8 @@
 {
-    "$schema": "https://json.schemastore.org/tsconfig",
-    "compilerOptions": {
-        "declaration": true,
-        "declarationMap": true,
-        "esModuleInterop": true,
-        "incremental": false,
-        "isolatedModules": true,
-        "lib": [
-            "es2022",
-            "DOM",
-            "DOM.Iterable"
-        ],
-        "module": "NodeNext",
-        "moduleDetection": "force",
-        "moduleResolution": "NodeNext",
-        "noUncheckedIndexedAccess": true,
-        "resolveJsonModule": true,
-        "skipLibCheck": true,
-        "strict": true,
-        "target": "ES2022",
-        "outDir": "dist",
-        "baseUrl": "."
-    },
-    "include": ["src/**/*"],
-    "exclude": ["node_modules"]
+  "extends": "@auth0/typescript-config/tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
 }

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@auth0/typescript-config",
+  "version": "0.0.0",
+  "private": true,
+  "license": "MIT"
+}

--- a/packages/typescript-config/tsconfig.json
+++ b/packages/typescript-config/tsconfig.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig",
+    "compilerOptions": {
+        "declaration": true,
+        "declarationMap": true,
+        "esModuleInterop": true,
+        "incremental": false,
+        "isolatedModules": true,
+        "lib": [
+            "es2022",
+            "DOM",
+            "DOM.Iterable"
+        ],
+        "module": "NodeNext",
+        "moduleDetection": "force",
+        "moduleResolution": "NodeNext",
+        "noUncheckedIndexedAccess": true,
+        "resolveJsonModule": true,
+        "skipLibCheck": true,
+        "strict": true,
+        "target": "ES2022",
+        "outDir": "dist",
+        "baseUrl": "."
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### Description

Centralize the TS Config by using a `typescript-config` package to make it easier to packages to reuse the same tsconfig.

### References

N/A

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
