### PR TITLE
feat(auth0-auth-js): add support for access token subject type to Token Vault

### DIFF
--- a/packages/auth0-auth-js/EXAMPLES.md
+++ b/packages/auth0-auth-js/EXAMPLES.md
@@ -349,9 +349,12 @@ const loginHint = '<login_hint>';
 const tokenResponseForGoogle = await authClient.getTokenForConnection({ connection, refreshToken });
 ```
 
-- `refreshToken`: The refresh token to use to retrieve the access token.
+- `refreshToken`: The refresh token to use to retrieve the access token for the connection.
+- `accessToken`: The access token to use to exchange for an access token for the connection.
 - `connection`: The connection for which an access token should be retrieved, e.g. `google-oauth2` for Google.
-- `loginHint`: Optional login hint to inform which connection account to use, can be useful when multiple accounts for the connection exist for the same user. 
+- `loginHint`: Optional login hint to inform which connection account to use, can be useful when multiple accounts for the connection exist for the same user.
+
+Either the `refreshToken` or `accessToken` parameter can be specified, but not both.
 
 Note that, when using `google-oauth2`, it's required to set both `authorizationParams.access_type` and `authorizationParams.prompt` to `offline` and `consent` respectively when building the authorization URL.
 

--- a/packages/auth0-auth-js/src/auth-client.spec.ts
+++ b/packages/auth0-auth-js/src/auth-client.spec.ts
@@ -739,7 +739,7 @@ test('getTokenByRefreshToken - should throw when token exchange failed', async (
   );
 });
 
-test('getTokenForConnection - should return the tokens', async () => {
+test('getTokenForConnection - should return the tokens when called with a refresh token subject token', async () => {
   const authClient = new AuthClient({
     domain,
     clientId: '<client_id>',
@@ -754,6 +754,65 @@ test('getTokenForConnection - should return the tokens', async () => {
 
   expect(result).toBeDefined();
   expect(result.accessToken).toBe(accessToken);
+});
+
+test('getTokenForConnection - should return the tokens when called with an access token subject token', async () => {
+  const authClient = new AuthClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+  });
+
+  const result = await authClient.getTokenForConnection({
+    connection: '<connection>',
+    accessToken: '<access_token>',
+    loginHint: '<sub>',
+  });
+
+  expect(result).toBeDefined();
+  expect(result.accessToken).toBe(accessToken);
+});
+
+test('getTokenForConnection - should throw when both an access and refresh tokens are specified', async () => {
+  const authClient = new AuthClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+  });
+
+  await expect(
+    authClient.getTokenForConnection({
+      connection: '<connection>',
+      refreshToken: '<refresh_token>',
+      accessToken: '<access_token>',
+    })
+  ).rejects.toThrowError(
+    expect.objectContaining({
+      code: 'token_for_connection_error',
+      message:
+        'Either a refresh or access token should be specified, but not both.'
+    })
+  );
+});
+
+test('getTokenForConnection - should throw when neither an access nor a refresh token is specified', async () => {
+  const authClient = new AuthClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+  });
+
+  await expect(
+    authClient.getTokenForConnection({
+      connection: '<connection>',
+    })
+  ).rejects.toThrowError(
+    expect.objectContaining({
+      code: 'token_for_connection_error',
+      message:
+        'Either a refresh or access token must be specified.'
+    })
+  );
 });
 
 test('getTokenForConnection - should throw when token exchange failed', async () => {

--- a/packages/auth0-auth-js/src/types.ts
+++ b/packages/auth0-auth-js/src/types.ts
@@ -164,7 +164,11 @@ export interface TokenForConnectionOptions {
   /**
    * The refresh token to use to get an access token for the connection.
    */
-  refreshToken: string;
+  refreshToken?: string;
+  /**
+   * The access token to use to get an access token for the connection.
+   */
+  accessToken?: string;
 }
 
 export interface BuildLogoutUrlOptions {


### PR DESCRIPTION
### Description

This PR adds support for the access token subject type to be exchanged for a connection token.

With this change, the `getTokenForConnection` method can accept either a `refreshToken` or an `accessToken`, but not both.

### Testing

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
