### PR TITLE
feat(auth0-auth-js): support v2 logout endpoint for tenants that do not have an end_session_endpoint

### DIFF
--- a/packages/auth0-auth-js/src/auth-client.spec.ts
+++ b/packages/auth0-auth-js/src/auth-client.spec.ts
@@ -804,6 +804,32 @@ test('buildLogoutUrl - should build the logout url', async () => {
   expect(url.searchParams.size).toBe(2);
 });
 
+test('buildLogoutUrl - should build the logout url when not using OIDC Logout', async () => {
+  // @ts-expect-error Ignore the fact that this property is not defined as optional in the test.
+  delete mockOpenIdConfiguration.end_session_endpoint;
+
+  const serverClient = new AuthClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    authorizationParams: {
+      redirect_uri: '/test_redirect_uri',
+    },
+  });
+
+  const url = await serverClient.buildLogoutUrl({
+    returnTo: '/test_return_to',
+  });
+
+  expect(url.host).toBe(domain);
+  expect(url.pathname).toBe('/v2/logout');
+  expect(url.searchParams.get('client_id')).toBe('<client_id>');
+  expect(url.searchParams.get('returnTo')).toBe(
+    '/test_return_to'
+  );
+  expect(url.searchParams.size).toBe(2);
+});
+
 test('verifyLogoutToken - should verify the logout token', async () => {
   const serverClient = new AuthClient({
     domain,


### PR DESCRIPTION
### Description

When a tenant does not have the `end_session_endpoint` configured, the underlying `openid-client` would throw an error, surfacing as 500's in the applications as we never catch those.

Instead, we should ensure we do not call `openid-client` to construct the logout URL, instead we should manually construct the `v2/logout` url


### References

N/A

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
