### PR TITLE
feat(auth0-auth-js): make `requestExpiry` and `authorizationDetails` params explicit

### DIFF
--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -242,6 +242,17 @@ export class AuthClient {
       }),
     });
 
+    if (options.requestExpiry) {
+      params.append('request_expiry', options.requestExpiry.toString());
+    }
+
+    if (options.authorizationDetails) {
+      params.append(
+        'authorization_details',
+        JSON.stringify(options.authorizationDetails)
+      );
+    }
+
     try {
       const backchannelAuthenticationResponse =
         await client.initiateBackchannelAuthentication(configuration, params);

--- a/packages/auth0-auth-js/src/types.ts
+++ b/packages/auth0-auth-js/src/types.ts
@@ -286,6 +286,15 @@ export interface BackchannelAuthenticationOptions {
     sub: string;
   };
   /**
+   * Set a custom expiry time for the CIBA flow in seconds. Defaults to 300 seconds (5 minutes) if not set.
+   */
+  requestExpiry?: number;
+  /**
+   * Optional authorization details to use Rich Authorization Requests (RAR).
+   * @see https://auth0.com/docs/get-started/apis/configure-rich-authorization-requests
+   */
+  authorizationDetails?: AuthorizationDetails[];
+  /**
    * Authorization Parameters to be sent with the authorization request.
    */
   authorizationParams?: AuthorizationParameters;


### PR DESCRIPTION
### Description

Exposes the `requestExpiry` and `authorizationDetails` params as explicit options on `BackchannelAuthenticationOptions` to align with the existing `loginHint` and `bindingMessage` parameters and offer better type hints.

Previously, a developer would have to pass those parameters as part of the `authorizationParams` object and would be missing type information.

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
