### PR TITLE
fix(auth0-auth-js): fix parameter name of requested_expiry

### DIFF
--- a/packages/auth0-auth-js/src/auth-client.spec.ts
+++ b/packages/auth0-auth-js/src/auth-client.spec.ts
@@ -639,14 +639,14 @@ test('backchannelAuthentication - should forward the requestExpiry parameter', a
     },
   });
 
-  // intercept the request to the backchannel authentication endpoint to verify the request_expiry parameter
-  let requestExpiry: string | null = null;
+  // intercept the request to the backchannel authentication endpoint to verify the requested_expiry parameter
+  let requestedExpiry: string | null = null;
   server.use(
     http.post(
       mockOpenIdConfiguration.backchannel_authentication_endpoint,
       async ({ request }) => {
         const info = await request.formData();
-        requestExpiry = info.get('request_expiry') as string;
+        requestedExpiry = info.get('requested_expiry') as string;
         return HttpResponse.json({
           auth_req_id: 'auth_req_123',
           interval: 0.5,
@@ -659,10 +659,10 @@ test('backchannelAuthentication - should forward the requestExpiry parameter', a
   await authClient.backchannelAuthentication({
     bindingMessage: '<binding_message>',
     loginHint: { sub: '<sub>' },
-    requestExpiry: 180,
+    requestedExpiry: 180,
   });
 
-  expect(requestExpiry).toBe('180');
+  expect(requestedExpiry).toBe('180');
 });
 
 test('backchannelAuthentication - should throw an error when bc-authorize failed', async () => {

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -244,8 +244,8 @@ export class AuthClient {
       }),
     });
 
-    if (options.requestExpiry) {
-      params.append('request_expiry', options.requestExpiry.toString());
+    if (options.requestedExpiry) {
+      params.append('requested_expiry', options.requestedExpiry.toString());
     }
 
     if (options.authorizationDetails) {

--- a/packages/auth0-auth-js/src/types.ts
+++ b/packages/auth0-auth-js/src/types.ts
@@ -299,7 +299,7 @@ export interface BackchannelAuthenticationOptions {
   /**
    * Set a custom expiry time for the CIBA flow in seconds. Defaults to 300 seconds (5 minutes) if not set.
    */
-  requestExpiry?: number;
+  requestedExpiry?: number;
   /**
    * Optional authorization details to use Rich Authorization Requests (RAR).
    * @see https://auth0.com/docs/get-started/apis/configure-rich-authorization-requests


### PR DESCRIPTION
### Description

The correct parameter name is `requested_expiry` and not `request_expiry`. This was a typo in the docs that needs to be resolved.

This is a non-breaking change as a release has not yet been cut.


### References

<img width="884" height="482" alt="sh" src="https://github.com/user-attachments/assets/5cb7ebae-e447-49b0-82b5-310a2d1307a5" />

https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-initiated-backchannel-authentication-flow/user-authorization-with-ciba#step-1-client-application-initiates-a-ciba-request

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
