### PR TITLE
feat(auth0-server-js): return token set from CIBA flow

### DIFF
--- a/packages/auth0-server-js/EXAMPLES.md
+++ b/packages/auth0-server-js/EXAMPLES.md
@@ -563,6 +563,17 @@ await serverClient.loginBackchannel({
 });
 ```
 
+To obtain the tokens directly without establishing or updating a session, you can use the `getTokenByBackchannelAuth()` method. This is useful when CIBA is used out-of-band such as authorizing an AI agent to act on behalf of a user. The method accepts the same parameters as `loginBackchannel()` and returns the token response directly:
+
+```ts
+const tokenResponse = await serverClient.getTokenByBackchannelAuth({
+  bindingMessage: '',
+  loginHint: {
+    sub: 'auth0|123456789'
+  }
+});
+```
+
 - `bindingMessage`: A human-readable message to be displayed at the consumption device and authentication device. This allows the user to ensure the transaction initiated by the consumption device is the same that triggers the action on the authentication device.
 - `loginHint.sub`: The `sub` claim of the user that is trying to login using Client-Initiated Backchannel Authentication, and to which a push notification to authorize the login will be sent.
 

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -1129,6 +1129,33 @@ test('loginBackchannel - should throw an error when token exchange failed', asyn
   );
 });
 
+test('getTokenByBackchannelAuth - should return the access token from the token endpoint', async () => {
+  const mockTransactionStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+  };
+
+  const mockStateStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: mockTransactionStore,
+    stateStore: mockStateStore,
+  });
+
+  const tokenResponse = await serverClient.getTokenByBackchannelAuth({ loginHint: { sub: '<sub>' }, bindingMessage: '<binding_message>' });
+
+  expect(tokenResponse.accessToken).toBe(accessToken);
+});
+
 test('getUser - should return from the cache', async () => {
   const mockStateStore = {
     get: vi.fn(),

--- a/packages/auth0-server-js/src/server-client.ts
+++ b/packages/auth0-server-js/src/server-client.ts
@@ -26,6 +26,7 @@ import {
   AuthClient,
   AuthorizationDetails,
   TokenByRefreshTokenError,
+  TokenResponse,
 } from '@auth0/auth0-auth-js';
 import { compareScopes } from './utils.js';
 
@@ -259,7 +260,7 @@ export class ServerClient<TStoreOptions = unknown> {
   }
 
   /**
-   * Logs in using Client-Initiated Backchannel Authentication.
+   * Logs in using Client-Initiated Backchannel Authentication and establishes or updates the session.
    *
    * Using Client-Initiated Backchannel Authentication requires the feature to be enabled in the Auth0 dashboard.
    * @see https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-initiated-backchannel-authentication-flow
@@ -293,6 +294,28 @@ export class ServerClient<TStoreOptions = unknown> {
     return {
       authorizationDetails: tokenEndpointResponse.authorizationDetails,
     };
+  }
+
+  /**
+   * Performs a Client-Initiated Backchannel Authentication and returns the tokens.
+   * 
+   * Using Client-Initiated Backchannel Authentication requires the feature to be enabled in the Auth0 dashboard.
+   * @see https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-initiated-backchannel-authentication-flow
+   * 
+   * @param options Options used to configure the backchannel login process.
+   * 
+   * @throws {BackchannelAuthenticationError} If there was an issue when doing backchannel authentication.
+   * 
+   * @returns A promise resolving to the TokenResponse as returned from Auth0.
+   */
+  public async getTokenByBackchannelAuth(options: LoginBackchannelOptions): Promise<TokenResponse> {
+    const tokenEndpointResponse = await this.#authClient.backchannelAuthentication({
+      bindingMessage: options.bindingMessage,
+      loginHint: options.loginHint,
+      authorizationParams: options.authorizationParams,
+    });
+
+    return tokenEndpointResponse;
   }
 
   /**


### PR DESCRIPTION
### Description

Returns the token response from the CIBA flow to the caller. This is useful in cases where the CIBA flow happens out of band, such as when an AI agent acts on behalf of a user and a session may not exist.

The method is exposed as `getTokenByBackchannelAuth`.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
