### PR TITLE
docs: fix broken link in README files

### DIFF
--- a/examples/example-fastify-api/README.md
+++ b/examples/example-fastify-api/README.md
@@ -3,7 +3,7 @@
 This example demonstrates how to use the `auth0-api-js` package to protect API's in a Fastify application.
 
 > [!IMPORTANT]  
-> When using Fastify, we recommend using [`@auth0/auth0-fastify-api`](https://github.com/auth0c/auth0-fastify/tree/main/packages/auth0-fastify-api) instead. 
+> When using Fastify, we recommend using [`@auth0/auth0-fastify-api`](https://github.com/auth0/auth0-fastify/tree/main/packages/auth0-fastify-api) instead. 
 >
 > This example is used to demonstrate how the same can be achieved using the `@auth0/auth0-api-js` package, giving you more flexibility, but also requires more effort to implement as opposed to `@auth0/auth0-fastify-api`.
 

--- a/examples/example-fastify-web/README.md
+++ b/examples/example-fastify-web/README.md
@@ -3,7 +3,7 @@
 This example demonstrates how to use the `auth0-server-js` package to authenticate users in a Fastify application.
 
 > [!IMPORTANT]  
-> When using Fastify, we recommend using [`@auth0/auth0-fastify`](https://github.com/auth0c/auth0-fastify/tree/main/packages/auth0-fastify) instead. 
+> When using Fastify, we recommend using [`@auth0/auth0-fastify`](https://github.com/auth0/auth0-fastify/tree/main/packages/auth0-fastify) instead. 
 >
 > This example is used to demonstrate how the same can be achieved using the `@auth0/auth0-server-js` package, giving you more flexibility, but also requires more effort to implement as opposed to `@auth0/auth0-fastify`.
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> This PR corrects a broken link within the Fastify web example's README.md file.
>
> The link to the auth0-fastify package was incorrectly pointing to the auth0c GitHub organization. This has been updated to point to the correct auth0 organization.

### References

> N/A

### Testing

1. Navigate to the examples/example-fastify-web/README.md file in this branch.
2. Click on the updated link for @auth0/fastify.
3. Confirm the link successfully resolves to https://github.com/auth0/auth0-fastify/tree/main/packages/auth0-fastify.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
