### PR TITLE
chore(auth0-api-js): expose the `authClient` for Token Vault

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11459,6 +11459,7 @@
       "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
+        "@auth0/auth0-auth-js": "^1.0.2",
         "jose": "^6.0.8",
         "oauth4webapi": "^3.3.0"
       },

--- a/packages/auth0-api-js/package.json
+++ b/packages/auth0-api-js/package.json
@@ -24,6 +24,7 @@
         }
     },
     "dependencies": {
+        "@auth0/auth0-auth-js": "^1.0.2",
         "jose": "^6.0.8",
         "oauth4webapi": "^3.3.0"
     },

--- a/packages/auth0-api-js/src/api-client.ts
+++ b/packages/auth0-api-js/src/api-client.ts
@@ -1,5 +1,6 @@
 import * as oauth from 'oauth4webapi';
 import { createRemoteJWKSet, jwtVerify, customFetch } from 'jose';
+import { AuthClient } from '@auth0/auth0-auth-js';
 import { ApiClientOptions, VerifyAccessTokenOptions } from './types.js';
 import {
   MissingRequiredArgumentError,
@@ -11,8 +12,17 @@ export class ApiClient {
   readonly #options: ApiClientOptions;
   #jwks?: ReturnType<typeof createRemoteJWKSet>;
 
+  /**
+   * The underlying `authClient` instance that can be used to interact with the Auth0 Authentication API.
+   */
+  readonly authClient: AuthClient | undefined;
+
   constructor(options: ApiClientOptions) {
     this.#options = options;
+
+    if (options.authClientOptions) {
+      this.authClient = new AuthClient(options.authClientOptions);
+    }
 
     if (!this.#options.audience) {
       throw new MissingRequiredArgumentError('audience');

--- a/packages/auth0-api-js/src/types.ts
+++ b/packages/auth0-api-js/src/types.ts
@@ -1,3 +1,5 @@
+import { AuthClientOptions } from "@auth0/auth0-auth-js";
+
 export interface ApiClientOptions {
   /**
    * The Auth0 domain to use for authentication.
@@ -12,6 +14,10 @@ export interface ApiClientOptions {
    * Optional, custom Fetch implementation to use.
    */
   customFetch?: typeof fetch;
+  /**
+   * Optional AuthClient options to instantiate an `authClient` instance.
+   */
+  authClientOptions?: AuthClientOptions
 }
 
 export interface VerifyAccessTokenOptions {


### PR DESCRIPTION
### Description

Allows passing `AuthClientOptions` when instantiating an `ApiClient` to create an instance of an `AuthClient` for use with features such as Token Vault. For example:

```ts
const apiClient = new ApiClient({
  domain: options.domain,
  audience: options.audience,
  authClientOptions: {
    clientId: options.clientId,
    clientSecret: options.clientSecret,
  }
});

await apiClient.authClient.getTokenForConnection({
  connection: "google-oauth2",
  accessToken: "..."
});
```

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
