### PR TITLE
chore(auth0-auth-js): bump `openid-connect` lib to `6.8.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10203,9 +10203,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.0.12",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.12.tgz",
-      "integrity": "sha512-T8xypXs8CpmiIi78k0E+Lk7T2zlK4zDyg+o1CZ4AkOHgDg98ogdP2BeZ61lTFKFyoEwJ9RgAgN+SdM3iPgNonQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.0.tgz",
+      "integrity": "sha512-TTQJyoEoKcC1lscpVDCSsVgYzUDg/0Bt3WE//WiTPK6uOCQC2KZS4MpugbMWt/zyjkopgZoXhZuCi00gLudfUA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -11116,9 +11116,10 @@
       }
     },
     "node_modules/oauth4webapi": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.3.1.tgz",
-      "integrity": "sha512-ZwX7UqYrP3Lr+Glhca3a1/nF2jqf7VVyJfhGuW5JtrfDUxt0u+IoBPzFjZ2dd7PJGkdM6CFPVVYzuDYKHv101A==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.1.tgz",
+      "integrity": "sha512-olkZDELNycOWQf9LrsELFq8n05LwJgV8UkrS0cburk6FOwf8GvLam+YB+Uj5Qvryee+vwWOfQVeI5Vm0MVg7SA==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -11207,12 +11208,13 @@
       }
     },
     "node_modules/openid-client": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.3.4.tgz",
-      "integrity": "sha512-CGZGk9Y6Bv9R4bXlrzVoxzD1n4h8iP914UhjVyRSftqzqO4CWaRqKpOmW253Jmpv4EWkz7/Gut/90iiWW8t0ow==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.0.tgz",
+      "integrity": "sha512-oG1d1nAVhIIE+JSjLS+7E9wY1QOJpZltkzlJdbZ7kEn7Hp3hqur2TEeQ8gLOHoHkhbRAGZJKoOnEQcLOQJuIyg==",
+      "license": "MIT",
       "dependencies": {
-        "jose": "^6.0.10",
-        "oauth4webapi": "^3.3.1"
+        "jose": "^6.1.0",
+        "oauth4webapi": "^3.8.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -14805,7 +14807,7 @@
       "license": "MIT",
       "dependencies": {
         "jose": "^6.0.8",
-        "openid-client": "^6.3.0"
+        "openid-client": "^6.8.0"
       },
       "devDependencies": {
         "@auth0/typescript-config": "*",

--- a/packages/auth0-auth-js/package.json
+++ b/packages/auth0-auth-js/package.json
@@ -25,7 +25,7 @@
     },
     "dependencies": {
         "jose": "^6.0.8",
-        "openid-client": "^6.3.0"
+        "openid-client": "^6.8.0"
     },
     "devDependencies": {
         "@auth0/typescript-config": "*",


### PR DESCRIPTION
### 📋 Changes

Bump `openid-connect` lib to `6.8.0`:

- respect retry-after in CIBA and Device Authorization Grant polling ([6ce3411](https://github.com/panva/openid-client/commit/6ce3411befb0da106ad6f62555219a6d1e784017))

### 📎 References

- https://github.com/panva/openid-client/releases/tag/v6.8.0
