### PR TITLE
feat(auth0-api-js): Add support for Token Vault to exchange access tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16380,7 +16380,7 @@
       "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@auth0/auth0-auth-js": "^1.0.2",
+        "@auth0/auth0-auth-js": "^1.1.0",
         "jose": "^6.0.8",
         "oauth4webapi": "^3.3.0"
       },

--- a/packages/auth0-api-js/EXAMPLES.md
+++ b/packages/auth0-api-js/EXAMPLES.md
@@ -1,0 +1,25 @@
+# Examples
+
+- [Get an access token for a connection](#get-an-access-token-for-a-connection)
+
+## Get an access token for a connection
+
+The `getAccessTokenForConnection` method allows you to exchange an access token for an access token for a specific connection. To use this method, you will need to instantiate the `ApiClient` with the client credentials:
+```ts
+import { ApiClient } from '@auth0/auth0-api-js';
+
+const apiClient = new ApiClient({
+  domain: '<AUTH0_DOMAIN>',
+  audience: '<AUTH0_AUDIENCE>',
+  clientId: '<AUTH0_CLIENT_ID>',
+  clientSecret: '<AUTH0_CLIENT_SECRET>',
+});
+
+const tokenSet = await apiClient.getAccessTokenForConnection({
+  connection: 'my-connection',
+  accessToken: 'my-access-token',
+  loginHint: 'login-hint', // Optional
+});
+```
+
+For additional details, please refer to the [Token Vault documentation](https://auth0.com/docs/secure/tokens/token-vault).

--- a/packages/auth0-api-js/package.json
+++ b/packages/auth0-api-js/package.json
@@ -24,7 +24,7 @@
         }
     },
     "dependencies": {
-        "@auth0/auth0-auth-js": "^1.0.2",
+        "@auth0/auth0-auth-js": "^1.1.0",
         "jose": "^6.0.8",
         "oauth4webapi": "^3.3.0"
     },

--- a/packages/auth0-api-js/src/types.ts
+++ b/packages/auth0-api-js/src/types.ts
@@ -1,5 +1,3 @@
-import { AuthClientOptions } from "@auth0/auth0-auth-js";
-
 export interface ApiClientOptions {
   /**
    * The Auth0 domain to use for authentication.
@@ -11,13 +9,67 @@ export interface ApiClientOptions {
    */
   audience: string;
   /**
+   * The optional client ID of the application.
+   * Required when using the `getAccessTokenForConnection` method.
+   */
+  clientId?: string;
+  /**
+   * The optional client secret of the application.
+   * At least one of `clientSecret` or `clientAssertionSigningKey` is required when using the `getAccessTokenForConnection` method.
+   */
+  clientSecret?: string;
+  /**
+   * The optional client assertion signing key to use.
+   * At least one of `clientSecret` or `clientAssertionSigningKey` is required when using the `getAccessTokenForConnection` method.
+   */
+  clientAssertionSigningKey?: string | CryptoKey;
+  /**
+   * The optional client assertion signing algorithm to use with the `clientAssertionSigningKey`.
+   * If not provided, it will default to `RS256`.
+   */
+  clientAssertionSigningAlg?: string;
+  /**
    * Optional, custom Fetch implementation to use.
    */
   customFetch?: typeof fetch;
+}
+
+export interface AccessTokenForConnectionOptions {
   /**
-   * Optional AuthClient options to instantiate an `authClient` instance.
+   * The name of the connection to get the token for.
    */
-  authClientOptions?: Omit<AuthClientOptions, 'domain'> & { domain?: string }
+  connection: string;
+  /**
+   * The access token used as the subject token to be exchanged.
+   */
+  accessToken: string;
+  /**
+   * An optional login hint to pass to the connection.
+   */
+  loginHint?: string;
+}
+
+export interface ConnectionTokenSet {
+  /**
+   * The access token issued by the connection.
+   */
+  accessToken: string;
+  /**
+   * The scope granted by the connection.
+   */
+  scope: string | undefined;
+  /**
+   * The access token expiration time, represented in seconds since the Unix epoch.
+   */
+  expiresAt: number;
+  /**
+   * The name of the connection the token was requested for.
+   */
+  connection: string;
+  /**
+   * An optional login hint that was passed during the exchange.
+   */
+  loginHint?: string;
 }
 
 export interface VerifyAccessTokenOptions {


### PR DESCRIPTION
### Description

Adds a `getAccessTokenForConnection` method to exchange an access token (`urn:ietf:params:oauth:token-type:access_token`) for a connection's access token using the `urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token` grant.

The API client can now optionally be instantiated by providing a client ID and secret to facilitate the exchange.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

1. Authenticate in a web app and obtain the access token for an audience
2. Pass the access token `getAccessTokenForConnection` method
3. The token set returned should contain the access token for the connection

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
