### PR TITLE
feat(auth0-auth-js): add support for environment variables

### DIFF
--- a/packages/auth0-api-js/src/api-client.spec.ts
+++ b/packages/auth0-api-js/src/api-client.spec.ts
@@ -940,18 +940,18 @@ test('getAccessTokenForConnection - should throw when no clientId configured', a
 });
 
 test('getAccessTokenForConnection - should throw when no clientSecret configured', async () => {
-  const apiClient = new ApiClient({
-    domain,
-    audience: '<audience>',
-    clientId: 'my-client-id',
-  });
+  await expect(async () => {
+    const apiClient = new ApiClient({
+      domain,
+      audience: '<audience>',
+      clientId: 'my-client-id',
+    });
 
-  await expect(
-    apiClient.getAccessTokenForConnection({
+    await apiClient.getAccessTokenForConnection({
       connection: 'my-connection',
       accessToken: 'my-access-token',
-    })
-  ).rejects.toThrow(MissingClientAuthError);
+    });
+  }).rejects.toThrow(MissingClientAuthError);
 });
 
 test('getAccessTokenForConnection - should return a token set when the exchange is successful', async () => {
@@ -1023,18 +1023,18 @@ test('getTokenByExchangeProfile - should throw when no clientId configured', asy
 });
 
 test('getTokenByExchangeProfile - should throw when no clientSecret configured', async () => {
-  const apiClient = new ApiClient({
-    domain,
-    audience: '<audience>',
-    clientId: 'my-client-id',
-  });
+  await expect(async () => {
+    const apiClient = new ApiClient({
+      domain,
+      audience: '<audience>',
+      clientId: 'my-client-id',
+    });
 
-  await expect(
-    apiClient.getTokenByExchangeProfile('my-subject-token', {
+    await apiClient.getTokenByExchangeProfile('my-subject-token', {
       subjectTokenType: 'urn:my-company:mcp-token',
       audience: 'https://api.backend.com',
-    })
-  ).rejects.toThrow(MissingClientAuthError);
+    });
+  }).rejects.toThrow(MissingClientAuthError);
 });
 
 test('getTokenByExchangeProfile - should return tokens when exchange succeeds', async () => {
@@ -1326,17 +1326,17 @@ test('getTokenOnBehalfOf - should throw when no clientId configured', async () =
 });
 
 test('getTokenOnBehalfOf - should throw when no clientSecret configured', async () => {
-  const apiClient = new ApiClient({
-    domain,
-    audience: '<audience>',
-    clientId: 'my-client-id',
-  });
+  await expect(async () => {
+    const apiClient = new ApiClient({
+      domain,
+      audience: '<audience>',
+      clientId: 'my-client-id',
+    });
 
-  await expect(
-    apiClient.getTokenOnBehalfOf('my-access-token', {
+    await apiClient.getTokenOnBehalfOf('my-access-token', {
       audience: 'https://api.backend.com',
-    })
-  ).rejects.toThrow(MissingClientAuthError);
+    });
+  }).rejects.toThrow(MissingClientAuthError);
 });
 
 test('getTokenOnBehalfOf - should exchange an access token using fixed OBO token types', async () => {

--- a/packages/auth0-api-js/src/api-client.spec.ts
+++ b/packages/auth0-api-js/src/api-client.spec.ts
@@ -940,18 +940,18 @@ test('getAccessTokenForConnection - should throw when no clientId configured', a
 });
 
 test('getAccessTokenForConnection - should throw when no clientSecret configured', async () => {
-  await expect(async () => {
-    const apiClient = new ApiClient({
-      domain,
-      audience: '<audience>',
-      clientId: 'my-client-id',
-    });
+  const apiClient = new ApiClient({
+    domain,
+    audience: '<audience>',
+    clientId: 'my-client-id',
+  });
 
-    await apiClient.getAccessTokenForConnection({
+  await expect(
+    apiClient.getAccessTokenForConnection({
       connection: 'my-connection',
       accessToken: 'my-access-token',
-    });
-  }).rejects.toThrow(MissingClientAuthError);
+    })
+  ).rejects.toThrow(MissingClientAuthError);
 });
 
 test('getAccessTokenForConnection - should return a token set when the exchange is successful', async () => {
@@ -1023,18 +1023,18 @@ test('getTokenByExchangeProfile - should throw when no clientId configured', asy
 });
 
 test('getTokenByExchangeProfile - should throw when no clientSecret configured', async () => {
-  await expect(async () => {
-    const apiClient = new ApiClient({
-      domain,
-      audience: '<audience>',
-      clientId: 'my-client-id',
-    });
+  const apiClient = new ApiClient({
+    domain,
+    audience: '<audience>',
+    clientId: 'my-client-id',
+  });
 
-    await apiClient.getTokenByExchangeProfile('my-subject-token', {
+  await expect(
+    apiClient.getTokenByExchangeProfile('my-subject-token', {
       subjectTokenType: 'urn:my-company:mcp-token',
       audience: 'https://api.backend.com',
-    });
-  }).rejects.toThrow(MissingClientAuthError);
+    })
+  ).rejects.toThrow(MissingClientAuthError);
 });
 
 test('getTokenByExchangeProfile - should return tokens when exchange succeeds', async () => {
@@ -1326,17 +1326,17 @@ test('getTokenOnBehalfOf - should throw when no clientId configured', async () =
 });
 
 test('getTokenOnBehalfOf - should throw when no clientSecret configured', async () => {
-  await expect(async () => {
-    const apiClient = new ApiClient({
-      domain,
-      audience: '<audience>',
-      clientId: 'my-client-id',
-    });
+  const apiClient = new ApiClient({
+    domain,
+    audience: '<audience>',
+    clientId: 'my-client-id',
+  });
 
-    await apiClient.getTokenOnBehalfOf('my-access-token', {
+  await expect(
+    apiClient.getTokenOnBehalfOf('my-access-token', {
       audience: 'https://api.backend.com',
-    });
-  }).rejects.toThrow(MissingClientAuthError);
+    })
+  ).rejects.toThrow(MissingClientAuthError);
 });
 
 test('getTokenOnBehalfOf - should exchange an access token using fixed OBO token types', async () => {

--- a/packages/auth0-auth-js/README.md
+++ b/packages/auth0-auth-js/README.md
@@ -41,6 +41,27 @@ const authClient = new AuthClient({
 
 The `AUTH0_DOMAIN`, `AUTH0_CLIENT_ID`, and `AUTH0_CLIENT_SECRET` can be obtained from the [Auth0 Dashboard](https://manage.auth0.com) once you've created an application.
 
+#### Environment Variable Support
+
+The SDK supports automatic fallback to environment variables if configuration options are not provided:
+
+```ts
+// If AUTH0_DOMAIN, AUTH0_CLIENT_ID, and AUTH0_CLIENT_SECRET are set in your environment
+const authClient = new AuthClient();
+
+// Or mix and match
+const authClient = new AuthClient({
+  domain: 'custom-domain.auth0.com', // Override env var
+  // clientId and clientSecret will fall back to AUTH0_CLIENT_ID and AUTH0_CLIENT_SECRET
+});
+```
+
+Supported environment variables:
+- `AUTH0_DOMAIN` - Your Auth0 tenant domain
+- `AUTH0_CLIENT_ID` - Your application's client ID
+- `AUTH0_CLIENT_SECRET` - Your application's client secret (optional - depending on the authentication method you want to use)
+- `AUTH0_CLIENT_ASSERTION_SIGNING_KEY` - Your application's client assertion signing key (optional - depending on the authentication method you want to use)
+
 ### 3. Build the Authorization URL
 
 Build the URL to redirect the user-agent to to request authorization at Auth0.

--- a/packages/auth0-auth-js/src/auth-client-env.spec.ts
+++ b/packages/auth0-auth-js/src/auth-client-env.spec.ts
@@ -1,0 +1,173 @@
+import { expect, test, describe, beforeEach, afterEach } from 'vitest';
+import { AuthClient } from './auth-client.js';
+
+describe('AuthClient - Environment Variable Support', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    // Reset process.env before each test
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    // Restore original environment
+    process.env = originalEnv;
+  });
+
+  describe('Environment variable usage', () => {
+    test('should use all configuration from environment variables', () => {
+      process.env.AUTH0_DOMAIN = 'env-domain.auth0.com';
+      process.env.AUTH0_CLIENT_ID = 'env-client-id';
+      process.env.AUTH0_CLIENT_SECRET = 'env-client-secret';
+
+      const authClient = new AuthClient({});
+
+      // Verify the client was created successfully with env vars
+      expect(authClient).toBeDefined();
+      expect(authClient.mfa).toBeDefined();
+    });
+
+    test('should use mixed environment variables and explicit options', () => {
+      process.env.AUTH0_DOMAIN = 'env-domain.auth0.com';
+      // No CLIENT_ID in env
+
+      const authClient = new AuthClient({
+        clientId: 'explicit-client-id',
+        clientSecret: 'explicit-client-secret',
+      });
+
+      expect(authClient).toBeDefined();
+    });
+  });
+
+  describe('Explicit options override environment variables', () => {
+    test('should override AUTH0_DOMAIN with explicit domain option', () => {
+      // Set env var to empty string which would normally fail
+      process.env.AUTH0_DOMAIN = '';
+      process.env.AUTH0_CLIENT_ID = 'client-id';
+      process.env.AUTH0_CLIENT_SECRET = 'client-secret';
+
+      // But providing explicit domain should work, proving override is working
+      const authClient = new AuthClient({
+        domain: 'correct-domain.auth0.com',
+      });
+
+      expect(authClient).toBeDefined();
+    });
+
+    test('should override AUTH0_CLIENT_ID with explicit clientId option', () => {
+      // Set env var to empty string which would normally fail
+      process.env.AUTH0_DOMAIN = 'domain.auth0.com';
+      process.env.AUTH0_CLIENT_ID = '';
+      process.env.AUTH0_CLIENT_SECRET = 'client-secret';
+
+      // But providing explicit clientId should work, proving override is working
+      const authClient = new AuthClient({
+        clientId: 'correct-client-id',
+      });
+
+      expect(authClient).toBeDefined();
+    });
+
+    test('should override AUTH0_CLIENT_SECRET with explicit clientSecret option', () => {
+      process.env.AUTH0_DOMAIN = 'domain.auth0.com';
+      process.env.AUTH0_CLIENT_ID = 'client-id';
+      // No CLIENT_SECRET in env, would normally require requireClientAuth: false
+
+      // But providing explicit clientSecret should allow requireClientAuth: true
+      const authClient = new AuthClient({
+        clientSecret: 'explicit-secret',
+      });
+
+      expect(authClient).toBeDefined();
+    });
+
+    test('should treat undefined options as "use environment variable"', () => {
+      process.env.AUTH0_DOMAIN = 'env-domain.auth0.com';
+      process.env.AUTH0_CLIENT_ID = 'env-client-id';
+      process.env.AUTH0_CLIENT_SECRET = 'env-client-secret';
+
+      const authClient = new AuthClient({
+        domain: undefined,
+        clientId: undefined,
+        clientSecret: undefined,
+      });
+
+      expect(authClient).toBeDefined();
+    });
+  });
+
+  describe('Required field validation', () => {
+    test('should throw MissingRequiredArgumentError when domain is missing from both options and environment', async () => {
+      process.env.AUTH0_CLIENT_ID = 'client-id';
+      process.env.AUTH0_CLIENT_SECRET = 'client-secret';
+      delete process.env.AUTH0_DOMAIN;
+
+      const authClient = new AuthClient({});
+
+      await expect(authClient.buildAuthorizationUrl()).rejects.toThrowError(
+        expect.objectContaining({
+          name: 'MissingRequiredArgumentError',
+          code: 'missing_required_argument_error',
+          message: 'The argument \'domain\' is required but was not provided.',
+        })
+      );
+    });
+
+    test('should throw MissingRequiredArgumentError when clientId is missing from both options and environment', async () => {
+      process.env.AUTH0_DOMAIN = 'domain.auth0.com';
+      process.env.AUTH0_CLIENT_SECRET = 'client-secret';
+      delete process.env.AUTH0_CLIENT_ID;
+
+      const authClient = new AuthClient({});
+
+      await expect(authClient.buildAuthorizationUrl()).rejects.toThrowError(
+        expect.objectContaining({
+          name: 'MissingRequiredArgumentError',
+          code: 'missing_required_argument_error',
+          message: 'The argument \'clientId\' is required but was not provided.',
+        })
+      );
+    });
+
+    test('should treat empty string as missing value (not fall back to env)', async () => {
+      process.env.AUTH0_DOMAIN = 'env-domain.auth0.com';
+      process.env.AUTH0_CLIENT_ID = 'env-client-id';
+      process.env.AUTH0_CLIENT_SECRET = 'client-secret';
+
+      const authClient = new AuthClient({
+        domain: '',
+        clientId: '',
+      });
+
+      await expect(authClient.buildAuthorizationUrl()).rejects.toThrowError(
+        expect.objectContaining({
+          name: 'MissingRequiredArgumentError',
+          code: 'missing_required_argument_error',
+        })
+      );
+    });
+  });
+
+  describe('Client authentication', () => {
+    test('should use AUTH0_CLIENT_SECRET from environment when available', () => {
+      process.env.AUTH0_DOMAIN = 'domain.auth0.com';
+      process.env.AUTH0_CLIENT_ID = 'client-id';
+      process.env.AUTH0_CLIENT_SECRET = 'client-secret';
+
+      const authClient = new AuthClient({});
+
+      expect(authClient).toBeDefined();
+    });
+
+    test('should use AUTH0_CLIENT_ASSERTION_SIGNING_KEY from environment when available', () => {
+      process.env.AUTH0_DOMAIN = 'domain.auth0.com';
+      process.env.AUTH0_CLIENT_ID = 'client-id';
+      process.env.AUTH0_CLIENT_ASSERTION_SIGNING_KEY = '-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----';
+
+      const authClient = new AuthClient();
+
+      expect(authClient).toBeDefined();
+    });
+  });
+});

--- a/packages/auth0-auth-js/src/auth-client.spec.ts
+++ b/packages/auth0-auth-js/src/auth-client.spec.ts
@@ -1,9 +1,18 @@
 import { expect, test, afterAll, beforeAll, beforeEach, vi, afterEach, describe } from 'vitest';
 import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
+import { importPKCS8 } from 'jose';
 import { AuthClient } from './auth-client.js';
 import { NotSupportedError, isMfaRequiredError, TokenByPasswordError } from './errors.js';
 import { ExchangeProfileOptions } from './types.js';
+
+vi.mock('jose', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('jose')>();
+  return {
+    ...actual,
+    importPKCS8: vi.fn(actual.importPKCS8),
+  };
+});
 
 import { generateToken, jwks } from './test-utils/tokens.js';
 import { pemToArrayBuffer } from './test-utils/pem.js';
@@ -588,22 +597,6 @@ describe('discovery cache behavior', () => {
       })
     );
 
-    const options: {
-      domain: string;
-      clientId: string;
-      clientAssertionSigningKey: string;
-      discoveryCache: { ttl: number; maxEntries: number };
-    } = {
-      domain: cacheDomain,
-      clientId: '<client_id>',
-      clientAssertionSigningKey: '-----BEGIN PRIVATE KEY-----\ninvalid\n-----END PRIVATE KEY-----',
-      discoveryCache: { ttl: 32, maxEntries: 5 },
-    };
-
-    const authClient = new AuthClient(options);
-    await expect(authClient.buildAuthorizationUrl()).rejects.toThrow();
-    expect(discoveryCalls).toBe(0);
-
     const keyPair = (await crypto.subtle.generateKey(
       {
         name: 'RSASSA-PKCS1-v1_5',
@@ -615,7 +608,17 @@ describe('discovery cache behavior', () => {
       ['sign', 'verify']
     )) as CryptoKeyPair;
 
-    options.clientAssertionSigningKey = await exportPrivateKeyToPem(keyPair.privateKey);
+    const authClient = new AuthClient({
+      domain: cacheDomain,
+      clientId: '<client_id>',
+      clientAssertionSigningKey: await exportPrivateKeyToPem(keyPair.privateKey),
+      discoveryCache: { ttl: 32, maxEntries: 5 },
+    });
+
+    vi.mocked(importPKCS8).mockRejectedValueOnce(new Error('initial import failure'));
+
+    await expect(authClient.buildAuthorizationUrl()).rejects.toThrow();
+    expect(discoveryCalls).toBe(0);
 
     const { authorizationUrl } = await authClient.buildAuthorizationUrl();
     expect(authorizationUrl.host).toBe(cacheDomain);
@@ -2821,23 +2824,23 @@ ca/T0LLtgmbMmxSv/MmzIg==
   });
 
   test('should fail Custom Token Exchange when no client credentials provided', async () => {
-    const authClient = new AuthClient({
-      domain,
-      clientId: '<client_id>',
-      // No clientSecret or clientAssertionSigningKey
-    });
+    await expect(async () => {
+      const authClient = new AuthClient({
+        domain,
+        clientId: '<client_id>',
+        // No clientSecret or clientAssertionSigningKey
+      });
 
-    await expect(
-      authClient.exchangeToken({
+      await authClient.exchangeToken({
         subjectTokenType: 'urn:test:mcp-token',
         subjectToken: 'test-token',
         audience: 'https://api.example.com',
-      })
-    ).rejects.toThrowError(
+      });
+    }).rejects.toThrowError(
       expect.objectContaining({
         name: 'MissingClientAuthError',
         code: 'missing_client_auth_error',
-      })
+      }),
     );
   });
 });

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -17,6 +17,7 @@ import {
   TokenByRefreshTokenError,
   TokenForConnectionError,
   VerifyLogoutTokenError,
+  MissingRequiredArgumentError,
 } from './errors.js';
 import { stripUndefinedProperties } from './utils.js';
 import { MfaClient } from './mfa/mfa-client.js';
@@ -229,6 +230,11 @@ const REQUESTED_TOKEN_TYPE_FEDERATED_CONNECTION_ACCESS_TOKEN =
   'http://auth0.com/oauth/token-type/federated-connection-access-token';
 
 /**
+ * Internal type for resolved AuthClientOptions with required fields guaranteed to be present.
+ */
+type InternalAuthClientOptions = Required<Pick<AuthClientOptions, 'domain' | 'clientId'>> & Omit<AuthClientOptions, 'domain' | 'clientId'>;
+
+/**
  * Auth0 authentication client for handling OAuth 2.0 and OIDC flows.
  *
  * Provides methods for authorization, token exchange, token refresh, and verification
@@ -239,7 +245,7 @@ export class AuthClient {
   #configuration: client.Configuration | undefined;
   #serverMetadata: client.ServerMetadata | undefined;
   #clientAuthPromise: Promise<client.ClientAuth> | undefined;
-  readonly #options: AuthClientOptions;
+  readonly #options: InternalAuthClientOptions;
   readonly #customFetch: typeof fetch;
   #jwks?: ReturnType<typeof createRemoteJWKSet>;
   readonly #discoveryCache: DiscoveryCache<string, DiscoveryCacheEntry>;
@@ -248,11 +254,18 @@ export class AuthClient {
   public mfa: MfaClient;
   public passkey: PasskeyClient;
 
-  constructor(options: AuthClientOptions) {
-    this.#options = options;
+  constructor(options: AuthClientOptions = {}) {
+    // Resolve configuration with environment variable fallbacks
+    this.#options = {
+      ...options,
+      domain: options.domain ?? process.env.AUTH0_DOMAIN,
+      clientId: options.clientId ?? process.env.AUTH0_CLIENT_ID,
+      clientSecret: options.clientSecret ?? process.env.AUTH0_CLIENT_SECRET,
+      clientAssertionSigningKey: options.clientAssertionSigningKey ?? process.env.AUTH0_CLIENT_ASSERTION_SIGNING_KEY,
+    } as InternalAuthClientOptions;
 
     // When mTLS is being used, a custom fetch implementation is required.
-    if (options.useMtls && !options.customFetch) {
+    if (this.#options.useMtls && !this.#options.customFetch) {
       throw new NotSupportedError(
         NotSupportedErrorCode.MTLS_WITHOUT_CUSTOMFETCH_NOT_SUPPORT,
         'Using mTLS without a custom fetch implementation is not supported'
@@ -260,8 +273,8 @@ export class AuthClient {
     }
 
     this.#customFetch = createTelemetryFetch(
-      options.customFetch ?? ((...args) => fetch(...args)),
-      getTelemetryConfig(options.telemetry)
+      this.#options.customFetch ?? ((...args) => fetch(...args)),
+      getTelemetryConfig(this.#options.telemetry),
     );
 
     // Use factory to create appropriate cache implementations
@@ -323,6 +336,13 @@ export class AuthClient {
         configuration: this.#configuration,
         serverMetadata: this.#serverMetadata,
       };
+    }
+
+    if (!this.#options.domain) {
+      throw new MissingRequiredArgumentError('domain');
+    }
+    if (!this.#options.clientId) {
+      throw new MissingRequiredArgumentError('clientId');
     }
 
     const cacheKey = this.#getDiscoveryCacheKey();

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -19,7 +19,7 @@ import {
   VerifyLogoutTokenError,
   MissingRequiredArgumentError,
 } from './errors.js';
-import { stripUndefinedProperties } from './utils.js';
+import { readEnv, stripUndefinedProperties } from './utils.js';
 import { MfaClient } from './mfa/mfa-client.js';
 import { PasskeyClient } from './passkey/passkey-client.js';
 import { createTelemetryFetch, getTelemetryConfig } from './telemetry.js';
@@ -258,10 +258,10 @@ export class AuthClient {
     // Resolve configuration with environment variable fallbacks
     this.#options = {
       ...options,
-      domain: options.domain ?? process.env.AUTH0_DOMAIN,
-      clientId: options.clientId ?? process.env.AUTH0_CLIENT_ID,
-      clientSecret: options.clientSecret ?? process.env.AUTH0_CLIENT_SECRET,
-      clientAssertionSigningKey: options.clientAssertionSigningKey ?? process.env.AUTH0_CLIENT_ASSERTION_SIGNING_KEY,
+      domain: options.domain ?? readEnv('AUTH0_DOMAIN'),
+      clientId: options.clientId ?? readEnv('AUTH0_CLIENT_ID'),
+      clientSecret: options.clientSecret ?? readEnv('AUTH0_CLIENT_SECRET'),
+      clientAssertionSigningKey: options.clientAssertionSigningKey ?? readEnv('AUTH0_CLIENT_ASSERTION_SIGNING_KEY'),
     } as InternalAuthClientOptions;
 
     // When mTLS is being used, a custom fetch implementation is required.

--- a/packages/auth0-auth-js/src/errors.ts
+++ b/packages/auth0-auth-js/src/errors.ts
@@ -39,6 +39,18 @@ export enum NotSupportedErrorCode {
 }
 
 /**
+ * Error thrown when a required argument is missing.
+ */
+export class MissingRequiredArgumentError extends Error {
+  public code: string = 'missing_required_argument_error';
+
+  constructor(argument: string) {
+    super(`The argument '${argument}' is required but was not provided.`);
+    this.name = 'MissingRequiredArgumentError';
+  }
+}
+
+/**
  * Error thrown when a feature is not supported.
  * For example, when trying to use Pushed Authorization Requests (PAR) but the Auth0 tenant was not configured to support it.
  */

--- a/packages/auth0-auth-js/src/types.ts
+++ b/packages/auth0-auth-js/src/types.ts
@@ -6,19 +6,24 @@ export type { TelemetryConfig } from './telemetry.js';
 export interface AuthClientOptions {
   /**
    * The Auth0 domain to use for authentication.
+   * Falls back to AUTH0_DOMAIN environment variable if not provided.
    * @example 'example.auth0.com' (without https://)
    */
-  domain: string;
+  domain?: string;
   /**
    * The client ID of the application.
+   * Falls back to AUTH0_CLIENT_ID environment variable if not provided.
    */
-  clientId: string;
+  clientId?: string;
   /**
    * The client secret of the application.
+   * Falls back to AUTH0_CLIENT_SECRET environment variable if not provided.
    */
   clientSecret?: string;
   /**
    * The client assertion signing key to use.
+   * 
+   * Falls back to AUTH0_CLIENT_ASSERTION_SIGNING_KEY environment variable if not provided.
    */
   clientAssertionSigningKey?: string | CryptoKey;
   /**

--- a/packages/auth0-auth-js/src/utils.ts
+++ b/packages/auth0-auth-js/src/utils.ts
@@ -1,4 +1,15 @@
 /**
+ * Reads an environment variable in a way that is safe across runtimes.
+ *
+ * Some runtimes (e.g. Cloudflare Workers without `nodejs_compat`) do not expose a
+ * `process` global, so a bare `process.env` reference would throw. This guards the
+ * access and returns `undefined` when no environment is available.
+ */
+export function readEnv(name: string): string | undefined {
+  return typeof process !== 'undefined' && process.env ? process.env[name] : undefined;
+}
+
+/**
  * Helper function that removes properties from an object when the value is undefined.
  * @returns The object, without the properties whose values are undefined.
  */


### PR DESCRIPTION
### Description

This PR adds support for the following environment variables:

- `AUTH0_DOMAIN` - Your Auth0 tenant domain
- `AUTH0_CLIENT_ID` - Your application's client ID
- `AUTH0_CLIENT_SECRET` - Your application's client secret (optional - depending on the authentication method you want to use)
- `AUTH0_CLIENT_ASSERTION_SIGNING_KEY` - Your application's client assertion signing key (optional - depending on the authentication method you want to use)

When both constructor options and environment variables are configured, the constructor option takes precedence. An explicitly provided empty string is treated as a missing value and does **not** fall back to the environment variable.

### Validation is lazy (no throw at construction)

Because `domain` and `clientId` are now optional on `AuthClientOptions` (they can come from the environment), the SDK can no longer rely on TypeScript to guarantee they're present. To fill that gap without introducing a breaking change, configuration is validated **lazily on first use** rather than in the constructor:

- The constructor only resolves environment-variable fallbacks; it never throws for missing config.
- `MissingRequiredArgumentError` (for a missing `domain`/`clientId`) is thrown on the first operation that needs it (i.e. via the internal discovery step).
- `MissingClientAuthError` remains lazy, as it was previously.

This avoids breaking consumers whose CI imports a module that constructs an `AuthClient`/`ApiClient` at module scope (e.g. `npm run build`) without env vars set and without ever calling the SDK at runtime.

### References

N/A

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AuthClient now supports initialization from environment variables (`AUTH0_DOMAIN`, `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET`, `AUTH0_CLIENT_ASSERTION_SIGNING_KEY`). Can initialize without arguments when credentials are configured via environment.

* **Documentation**
  * Updated README with environment variable support and configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->