### PR TITLE
fix: pin npm to 11.10.0 to avoid promise-retry failure on Node 22.22.2

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -27,7 +27,7 @@ runs:
     
     - name: Update npm
       shell: bash
-      run: npm install -g npm@11.10.0
+      run: npm install -g npm@latest
 
     - name: Install dependencies
       shell: bash

--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -27,7 +27,7 @@ runs:
     
     - name: Update npm
       shell: bash
-      run: npm install -g npm@latest
+      run: npm install -g npm@11.10.0
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,11 +70,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           package-manager-cache: false
 
       - name: Update npm
-        run: npm install -g npm@11.10.0
+        run: npm install -g npm@latest
     
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           package-manager-cache: false
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.10.0
 
       - name: Install dependencies
         run: npm install
@@ -74,7 +74,7 @@ jobs:
           package-manager-cache: false
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.10.0
     
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
## Summary

- Pins `npm install -g npm@11` to `npm@11.10.0` in the publish action
- Node 22.22.2 bundles npm 10.9.7, which lazily requires `promise-retry`; npm 11.12.0+ removes that module from its bundle, causing a `MODULE_NOT_FOUND` crash during the self-upgrade
- npm 11.10.0 still bundles `promise-retry`, avoiding the race condition

The upstream fix landed in npm/cli#9152 (merged into npm 10.9.8 / 11.12.1). This pin can be dropped once a Node 22 patch release ships with npm ≥ 10.9.8.

## References

- https://github.com/npm/cli/pull/9152
- https://github.com/nodejs/node/issues/62425