### PR TITLE
fix: suppress cached turbo log replay to avoid terminal escape noise

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -3,18 +3,22 @@
     "tasks": {
       "build": {
         "dependsOn": ["^build"],
-        "outputs": ["dist/**"]
+        "outputs": ["dist/**"],
+        "outputLogs": "new-only"
       },
       "clean": {
-        "dependsOn": ["^clean"]
+        "dependsOn": ["^clean"],
+        "outputLogs": "new-only"
       },
       "test": {
-        "dependsOn": ["^test"]
+        "dependsOn": ["^test"],
+        "outputLogs": "new-only"
       },
       "lint": {
         "dependsOn": [
           "^lint"
-        ]
+        ],
+        "outputLogs": "new-only"
       }
     }
   }


### PR DESCRIPTION
## Summary

Root `npm run build` and `npm run test` were replaying cached Turborepo logs that contained terminal control sequences. On cache hits, those sequences leaked back into the shell and showed up as random text after the prompt.

This change updates the root Turbo task configuration to use `outputLogs: "new-only"` for `build`, `test`, `lint`, and `clean`.

## Why

The issue was not coming from `tsup`, `tsc`, or `vitest` directly. It was happening during Turbo cached log replay.

By suppressing cached task logs while still showing output for cache misses, we keep normal developer feedback for fresh runs and avoid replaying the stored terminal escape sequences.
