### PR TITLE
fix(auth0-auth-js): derive challenge type from authenticator_type and oob_channel

### DIFF
--- a/packages/auth0-auth-js/src/mfa/index.ts
+++ b/packages/auth0-auth-js/src/mfa/index.ts
@@ -4,6 +4,7 @@ export type {
   AuthenticatorResponse,
   AuthenticatorType,
   OobChannel,
+  ChallengeType,
   ListAuthenticatorsOptions,
   DeleteAuthenticatorOptions,
   EnrollOtpOptions,

--- a/packages/auth0-auth-js/src/mfa/mfa-client.spec.ts
+++ b/packages/auth0-auth-js/src/mfa/mfa-client.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, describe, beforeAll, afterAll, afterEach, vi } from 'vite
 import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
 import { MfaClient } from './mfa-client.js';
+import { deriveChallengeType } from './utils.js';
 import {
   MfaListAuthenticatorsError,
   MfaDeleteAuthenticatorError,
@@ -26,6 +27,7 @@ const mockAuthenticators = [
     active: true,
     name: 'SMS',
     oob_channels: ['sms'],
+    oob_channel: 'sms',
   },
 ];
 
@@ -169,6 +171,40 @@ beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterAll(() => server.close());
 afterEach(() => server.resetHandlers());
 
+describe('deriveChallengeType', () => {
+  test('derives "otp" for OTP authenticators', () => {
+    expect(deriveChallengeType('otp')).toBe('otp');
+  });
+
+  test('derives "recovery-code" for recovery code authenticators', () => {
+    expect(deriveChallengeType('recovery-code')).toBe('recovery-code');
+  });
+
+  test('derives "phone" for SMS OOB authenticators', () => {
+    expect(deriveChallengeType('oob', 'sms')).toBe('phone');
+  });
+
+  test('derives "phone" for voice OOB authenticators', () => {
+    expect(deriveChallengeType('oob', 'voice')).toBe('phone');
+  });
+
+  test('derives "push-notification" for auth0 OOB authenticators', () => {
+    expect(deriveChallengeType('oob', 'auth0')).toBe('push-notification');
+  });
+
+  test('derives "email" for email OOB authenticators', () => {
+    expect(deriveChallengeType('oob', 'email')).toBe('email');
+  });
+
+  test('returns undefined for OOB without a channel', () => {
+    expect(deriveChallengeType('oob')).toBeUndefined();
+  });
+
+  test('returns undefined for unknown authenticator types', () => {
+    expect(deriveChallengeType('webauthn-roaming' as never)).toBeUndefined();
+  });
+});
+
 describe('MfaClient', () => {
   describe('constructor', () => {
     test('should create an instance with required options', () => {
@@ -190,7 +226,7 @@ describe('MfaClient', () => {
         active: true,
         name: 'Google Authenticator',
         oobChannels: undefined,
-        type: undefined,
+        type: 'otp',
       });
       expect(authenticators[1]).toEqual({
         id: 'sms|dev_456',
@@ -198,7 +234,7 @@ describe('MfaClient', () => {
         active: true,
         name: 'SMS',
         oobChannels: ['sms'],
-        type: undefined,
+        type: 'phone',
       });
     });
 

--- a/packages/auth0-auth-js/src/mfa/types.ts
+++ b/packages/auth0-auth-js/src/mfa/types.ts
@@ -30,6 +30,12 @@ export type AuthenticatorType = 'otp' | 'oob' | 'recovery-code';
 export type OobChannel = 'sms' | 'voice' | 'auth0' | 'email';
 
 /**
+ * Challenge types derived from authenticator_type and oob_channel.
+ * Used by downstream consumers (e.g. auth0-spa-js) to filter authenticators.
+ */
+export type ChallengeType = 'otp' | 'recovery-code' | 'phone' | 'push-notification' | 'email';
+
+/**
  * Represents an MFA authenticator enrolled by a user.
  */
 export interface AuthenticatorResponse {
@@ -43,8 +49,8 @@ export interface AuthenticatorResponse {
   name?: string;
   /** Delivery channels for OOB authenticators (only present for authenticatorType: 'oob') */
   oobChannels?: OobChannel[];
-  /** Additional type information */
-  type?: string;
+  /** Challenge type derived from authenticator_type and oob_channel */
+  type?: ChallengeType;
 }
 
 /**
@@ -187,7 +193,7 @@ export interface AuthenticatorApiResponse {
   active: boolean;
   name?: string;
   oob_channels?: OobChannel[];
-  type?: string;
+  oob_channel?: OobChannel;
 }
 
 /**

--- a/packages/auth0-auth-js/src/mfa/types.ts
+++ b/packages/auth0-auth-js/src/mfa/types.ts
@@ -31,7 +31,6 @@ export type OobChannel = 'sms' | 'voice' | 'auth0' | 'email';
 
 /**
  * Challenge types derived from authenticator_type and oob_channel.
- * Used by downstream consumers (e.g. auth0-spa-js) to filter authenticators.
  */
 export type ChallengeType = 'otp' | 'recovery-code' | 'phone' | 'push-notification' | 'email';
 

--- a/packages/auth0-auth-js/src/mfa/utils.ts
+++ b/packages/auth0-auth-js/src/mfa/utils.ts
@@ -13,9 +13,8 @@ import type {
 /**
  * Derives a challenge type from the authenticator type and OOB channel.
  *
- * The Auth0 API returns `authenticator_type` and `oob_channel` separately,
- * but downstream consumers (e.g. auth0-spa-js) need a single `type` value
- * to filter authenticators by challenge type.
+ * The Auth0 API returns `authenticator_type` and `oob_channel` separately.
+ * This function maps them to a single challenge type value.
  * @internal
  */
 export function deriveChallengeType(authenticatorType: AuthenticatorType, oobChannel?: OobChannel): ChallengeType | undefined {

--- a/packages/auth0-auth-js/src/mfa/utils.ts
+++ b/packages/auth0-auth-js/src/mfa/utils.ts
@@ -1,11 +1,33 @@
 import type {
   AuthenticatorResponse,
   AuthenticatorApiResponse,
+  ChallengeType,
+  AuthenticatorType,
+  OobChannel,
   EnrollmentResponse,
   EnrollmentApiResponse,
   ChallengeResponse,
   ChallengeApiResponse,
 } from './types.js';
+
+/**
+ * Derives a challenge type from the authenticator type and OOB channel.
+ *
+ * The Auth0 API returns `authenticator_type` and `oob_channel` separately,
+ * but downstream consumers (e.g. auth0-spa-js) need a single `type` value
+ * to filter authenticators by challenge type.
+ * @internal
+ */
+export function deriveChallengeType(authenticatorType: AuthenticatorType, oobChannel?: OobChannel): ChallengeType | undefined {
+  if (authenticatorType === 'otp') return 'otp';
+  if (authenticatorType === 'recovery-code') return 'recovery-code';
+  if (authenticatorType === 'oob') {
+    if (oobChannel === 'sms' || oobChannel === 'voice') return 'phone';
+    if (oobChannel === 'auth0') return 'push-notification';
+    if (oobChannel === 'email') return 'email';
+  }
+  return undefined;
+}
 
 /**
  * Transforms API authenticator response (snake_case) to SDK format (camelCase).
@@ -18,7 +40,7 @@ export function transformAuthenticatorResponse(api: AuthenticatorApiResponse): A
     active: api.active,
     name: api.name,
     oobChannels: api.oob_channels,
-    type: api.type,
+    type: deriveChallengeType(api.authenticator_type, api.oob_channel),
   };
 }
 


### PR DESCRIPTION
### Description

`mfa.getAuthenticators()` in `@auth0/auth0-spa-js` always returns an empty array, even when the user has active MFA authenticators enrolled.

The bug spans two packages:

**Layer 1 — `@auth0/auth0-auth-js` (this fix):** `transformAuthenticatorResponse` in `utils.ts` maps `api.type` to the response, but the Auth0 `GET /mfa/authenticators` endpoint does not return a `type` field. Per the [official API docs](https://auth0.com/docs/secure/multi-factor-authentication/manage-mfa-auth0-apis/manage-authenticator-factors-mfa-api#list-authenticators), the response uses `authenticator_type` and `oob_channel`:

```json
[
  {"authenticator_type": "recovery-code", "id": "recovery-code|dev_...", "active": true},
  {"authenticator_type": "otp", "id": "totp|dev_...", "active": true},
  {"authenticator_type": "oob", "oob_channel": "sms", "id": "sms|dev_...", "name": "+1123XXXXX", "active": true}
]
```

Since `api.type` is always `undefined`, every transformed authenticator has `type: undefined`.

**Layer 2 — `@auth0/auth0-spa-js` (downstream):** `MfaApiClient.getAuthenticators` filters authenticators with `if (!auth.type) return false`, which rejects everything because `type` is always `undefined`.

**The fix** adds a `deriveChallengeType(authenticatorType, oobChannel)` function that maps the API fields to the challenge types `auth0-spa-js` expects:

| `authenticator_type` | `oob_channel` | Derived `type` |
|---|---|---|
| `otp` | — | `otp` |
| `recovery-code` | — | `recovery-code` |
| `oob` | `sms` | `phone` |
| `oob` | `voice` | `phone` |
| `oob` | `auth0` | `push-notification` |
| `oob` | `email` | `email` |

Also adds `oob_channel` (singular) to `AuthenticatorApiResponse` and exports a new `ChallengeType` union type.

### References

- Auth0 MFA Authenticators API docs: https://auth0.com/docs/secure/multi-factor-authentication/manage-mfa-auth0-apis/manage-authenticator-factors-mfa-api#list-authenticators
- `@auth0/auth0-spa-js` `ChallengeType` definition: `src/mfa/types.ts`
- `@auth0/auth0-spa-js` filter in `MfaApiClient.getAuthenticators`: `src/mfa/MfaApiClient.ts`

### Testing

Added 8 unit tests for `deriveChallengeType` covering all authenticator type / OOB channel combinations and edge cases (unknown types, missing channel). Updated existing `listAuthenticators` tests to assert the derived `type` values (`'otp'`, `'phone'`) instead of `undefined`. Updated mock data to include `oob_channel` to match real API response shapes.

All 146 existing tests pass.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch