### PR TITLE
fix(auth0-server-js): wipe session state on iss/sub mismatch

### DIFF
--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -3094,7 +3094,7 @@ test('getAccessToken - should return from auth0 when access_token expired', asyn
   });
 
   const stateData: StateData = {
-    user: { sub: '<sub>' },
+    user: { sub: 'user_123' },
     idToken: '<id_token>',
     refreshToken: '<refresh_token>',
     tokenSets: [
@@ -3149,7 +3149,7 @@ test('getAccessToken - should return from auth0 and append to the state when aud
   });
 
   const stateData: StateData = {
-    user: { sub: '<sub>' },
+    user: { sub: 'user_123' },
     idToken: '<id_token>',
     refreshToken: '<refresh_token>',
     tokenSets: [
@@ -3199,7 +3199,7 @@ test('getAccessToken - should return from auth0 and append to the state when sco
   });
 
   const stateData: StateData = {
-    user: { sub: '<sub>' },
+    user: { sub: 'user_123' },
     idToken: '<id_token>',
     refreshToken: '<refresh_token>',
     tokenSets: [

--- a/packages/auth0-server-js/src/state/utils.spec.ts
+++ b/packages/auth0-server-js/src/state/utils.spec.ts
@@ -225,6 +225,113 @@ test('updateStateData - should preserve existing idToken when response does not 
   expect(updatedState.tokenSets[0]!.accessToken).toBe('<access_token_2>');
 });
 
+test('updateStateData - should wipe state and create fresh session when sub does not match', () => {
+  const initialState: StateData = {
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [
+      {
+        accessToken: '<access_token>',
+        scope: '<scope>',
+        audience: '<audience>',
+        expiresAt: Date.now() + 500,
+      },
+    ],
+    connectionTokenSets: [],
+    user: { sub: '<sub>', iss: '<iss>' },
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+
+  const response = {
+    idToken: '<id_token_new>',
+    accessToken: '<access_token_new>',
+    refreshToken: '<refresh_token_new>',
+    expiresAt: Date.now() / 1000 + 500,
+    scope: '<scope>',
+    claims: { iss: '<iss>', aud: '<audience>', sub: '<different_sub>', iat: Date.now(), exp: Date.now() + 500 },
+  } as TokenResponse;
+
+  const updatedState = updateStateData('<audience>', initialState, response);
+
+  // Should be a fresh session for the new user, not merged with the old one
+  expect(updatedState.user!.sub).toBe('<different_sub>');
+  expect(updatedState.idToken).toBe('<id_token_new>');
+  expect(updatedState.refreshToken).toBe('<refresh_token_new>');
+  expect(updatedState.tokenSets.length).toBe(1);
+  expect(updatedState.tokenSets[0]!.accessToken).toBe('<access_token_new>');
+});
+
+test('updateStateData - should wipe state and create fresh session when iss does not match', () => {
+  const initialState: StateData = {
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [
+      {
+        accessToken: '<access_token>',
+        scope: '<scope>',
+        audience: '<audience>',
+        expiresAt: Date.now() + 500,
+      },
+    ],
+    connectionTokenSets: [],
+    user: { sub: '<sub>', iss: '<iss>' },
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+
+  const response = {
+    idToken: '<id_token_new>',
+    accessToken: '<access_token_new>',
+    refreshToken: '<refresh_token_new>',
+    expiresAt: Date.now() / 1000 + 500,
+    scope: '<scope>',
+    claims: { iss: '<different_iss>', aud: '<audience>', sub: '<sub>', iat: Date.now(), exp: Date.now() + 500 },
+  } as TokenResponse;
+
+  const updatedState = updateStateData('<audience>', initialState, response);
+
+  // Should be a fresh session for the new issuer, not merged with the old one
+  expect(updatedState.user!.sub).toBe('<sub>');
+  expect(updatedState.user!.iss).toBe('<different_iss>');
+  expect(updatedState.idToken).toBe('<id_token_new>');
+  expect(updatedState.refreshToken).toBe('<refresh_token_new>');
+  expect(updatedState.tokenSets.length).toBe(1);
+  expect(updatedState.tokenSets[0]!.accessToken).toBe('<access_token_new>');
+});
+
+test('updateStateData - should merge state when iss and sub both match', () => {
+  const initialState: StateData = {
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [
+      {
+        accessToken: '<access_token>',
+        scope: '<scope>',
+        audience: '<audience>',
+        expiresAt: Date.now() + 500,
+      },
+    ],
+    connectionTokenSets: [],
+    user: { sub: '<sub>', iss: '<iss>' },
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+
+  const response = {
+    idToken: '<id_token_2>',
+    accessToken: '<access_token_2>',
+    refreshToken: '<refresh_token_2>',
+    expiresAt: Date.now() / 1000 + 500,
+    scope: '<scope>',
+    claims: { iss: '<iss>', aud: '<audience>', sub: '<sub>', iat: Date.now(), exp: Date.now() + 500 },
+  } as TokenResponse;
+
+  const updatedState = updateStateData('<audience>', initialState, response);
+
+  // Same user, should merge (update token set in place)
+  expect(updatedState.user!.sub).toBe('<sub>');
+  expect(updatedState.tokenSets.length).toBe(1);
+  expect(updatedState.tokenSets[0]!.accessToken).toBe('<access_token_2>');
+});
+
 test('updateStateDataForConnectionTokenSet - should add when connectionTokenSets are empty', () => {
   const initialState: StateData = {
     idToken: '<id_token>',

--- a/packages/auth0-server-js/src/state/utils.ts
+++ b/packages/auth0-server-js/src/state/utils.ts
@@ -27,6 +27,23 @@ export function updateStateData(
   tokenEndpointResponse: TokenResponse,
   context?: { domain?: string }
 ): StateData {
+  // If we already have a session and the new token belongs to a different user (iss or sub mismatch),
+  // wipe the existing state to start a fresh session. This handles the case where a user logs in
+  // as a different user without explicitly logging out first.
+  if (stateData && tokenEndpointResponse.claims) {
+    const newSub = tokenEndpointResponse.claims.sub;
+    const newIss = tokenEndpointResponse.claims.iss;
+    const existingSub = stateData.user?.sub;
+    const existingIss = stateData.user?.iss;
+
+    const subMismatch = newSub !== undefined && existingSub !== undefined && newSub !== existingSub;
+    const issMismatch = newIss !== undefined && existingIss !== undefined && newIss !== existingIss;
+
+    if (subMismatch || issMismatch) {
+      stateData = undefined;
+    }
+  }
+
   if (stateData) {
     const isNewTokenSet = !stateData.tokenSets.some(
       (tokenSet) => tokenSet.audience === audience && tokenSet.scope === tokenEndpointResponse.scope


### PR DESCRIPTION
## Problem
When a user is already logged in and a new login is completed for a different user (without an explicit `logout`), the `SDK` would silently merge the new token response into the existing session. This could result in a session that contains tokens belonging to different users, a subtle but potentially serious identity confusion bug.

## Solution
In `updateStateData`, before merging a new token response into existing state, we now check whether the incoming `iss` or `sub` claims differ from those stored in the current session. If a mismatch is detected, the existing `state` is discarded and a fresh session is created for the new user.

### This covers two cases:

- `sub` mismatch: the same IdP issued a token for a different user.
- `iss` mismatch: the token was issued by a different IdP entirely.
The check is intentionally conservative. It only triggers when both the existing and incoming values are present and non-empty, so sessions without `iss`/`sub` (e.g. legacy sessions or client credentials flows) are unaffected.