### PR TITLE
feat: expose MFA context on token error `cause` with `isMfaRequiredError` type guard

### DIFF
--- a/packages/auth0-auth-js/EXAMPLES.md
+++ b/packages/auth0-auth-js/EXAMPLES.md
@@ -639,9 +639,51 @@ When the verification is successful, the `sid` and `sub` claims will be returned
 The SDK provides an MFA client to manage multi-factor authentication for your users. The MFA client is accessible via the `mfa` property on the `AuthClient` instance.
 
 > [!IMPORTANT]
-> MFA operations require an MFA token, which is typically obtained from an MFA challenge response during the authentication flow. The MFA token must be passed as part of the parameters object for each method.
+> MFA operations require an MFA token, which is typically obtained from an `MfaRequiredError` thrown during the authentication flow. The MFA token must be passed as part of the parameters object for each method.
 
 [Refer API Docs ](https://auth0.com/docs/api/authentication/muti-factor-authentication/request-mfa-challenge)
+
+### Handling the MFA Required Error
+
+When the server requires multi-factor authentication, methods like `getTokenByPassword`, `getTokenByRefreshToken`, and `exchangeToken` throw an `MfaRequiredError`. This error contains the `mfaToken` needed to proceed with the MFA flow and optionally `mfaRequirements` describing which factors to challenge or enroll.
+
+```ts
+import { AuthClient, MfaRequiredError } from '@auth0/auth0-auth-js';
+
+const authClient = new AuthClient({
+  domain: '<AUTH0_DOMAIN>',
+  clientId: '<AUTH0_CLIENT_ID>',
+  clientSecret: '<AUTH0_CLIENT_SECRET>',
+});
+
+try {
+  const tokens = await authClient.getTokenByPassword({
+    username: 'user@example.com',
+    password: 'password123',
+  });
+} catch (error) {
+  if (error instanceof MfaRequiredError) {
+    // error.mfaToken - pass this to MFA APIs below
+    // error.mfaRequirements - describes required factors:
+    //   { challenge: [{ type: "otp" }] } — user must verify an enrolled factor
+    //   { enroll: [{ type: "otp" }, { type: "phone" }] } — user must enroll a new factor
+
+    if (error.mfaRequirements?.enroll?.length) {
+      // User needs to enroll — see "Enrolling an Authenticator" below
+      const enrollment = await authClient.mfa.enrollAuthenticator({
+        mfaToken: error.mfaToken,
+        authenticatorTypes: ['otp'],
+      });
+    } else {
+      // User has enrolled factors — see "Challenging an Authenticator" below
+      const challenge = await authClient.mfa.challengeAuthenticator({
+        mfaToken: error.mfaToken,
+        challengeType: 'otp',
+      });
+    }
+  }
+}
+```
 
 ### Enrolling an Authenticator
 

--- a/packages/auth0-auth-js/EXAMPLES.md
+++ b/packages/auth0-auth-js/EXAMPLES.md
@@ -639,16 +639,24 @@ When the verification is successful, the `sid` and `sub` claims will be returned
 The SDK provides an MFA client to manage multi-factor authentication for your users. The MFA client is accessible via the `mfa` property on the `AuthClient` instance.
 
 > [!IMPORTANT]
-> MFA operations require an MFA token, which is typically obtained from an `MfaRequiredError` thrown during the authentication flow. The MFA token must be passed as part of the parameters object for each method.
+> MFA operations require an MFA token. This token is available on the error's `cause` when the server returns `mfa_required` during the authentication flow. Use the `isMfaRequiredError` type guard to detect this condition and access the token.
 
 [Refer API Docs ](https://auth0.com/docs/api/authentication/muti-factor-authentication/request-mfa-challenge)
 
-### Handling the MFA Required Error
+### Handling the MFA Required Response
 
-When the server requires multi-factor authentication, methods like `getTokenByPassword`, `getTokenByRefreshToken`, and `exchangeToken` throw an `MfaRequiredError`. This error contains the `mfaToken` needed to proceed with the MFA flow and optionally `mfaRequirements` describing which factors to challenge or enroll.
+When the server requires multi-factor authentication, token request methods (`getTokenByPassword`, `getTokenByRefreshToken`, `exchangeToken`) throw their usual error class (`TokenByPasswordError`, `TokenByRefreshTokenError`, `TokenExchangeError`) with extra MFA context on `cause`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cause.error` | `'mfa_required'` | Indicates MFA is required |
+| `cause.mfa_token` | `string` | Token to pass to MFA APIs |
+| `cause.mfa_requirements` | `{ challenge?: Array<{ type: string }>; enroll?: Array<{ type: string }> }` | Which factors the user must challenge or enroll (optional) |
+
+Use the exported `isMfaRequiredError` type guard to detect and narrow the error:
 
 ```ts
-import { AuthClient, MfaRequiredError } from '@auth0/auth0-auth-js';
+import { AuthClient, isMfaRequiredError } from '@auth0/auth0-auth-js';
 
 const authClient = new AuthClient({
   domain: '<AUTH0_DOMAIN>',
@@ -662,25 +670,43 @@ try {
     password: 'password123',
   });
 } catch (error) {
-  if (error instanceof MfaRequiredError) {
-    // error.mfaToken - pass this to MFA APIs below
-    // error.mfaRequirements - describes required factors:
-    //   { challenge: [{ type: "otp" }] } — user must verify an enrolled factor
-    //   { enroll: [{ type: "otp" }, { type: "phone" }] } — user must enroll a new factor
+  if (isMfaRequiredError(error)) {
+    // TypeScript narrows: error.cause.mfa_token is guaranteed to be a string
+    const { mfa_token, mfa_requirements } = error.cause;
 
-    if (error.mfaRequirements?.enroll?.length) {
-      // User needs to enroll — see "Enrolling an Authenticator" below
+    if (mfa_requirements?.enroll?.length) {
+      // User needs to enroll a new factor — see "Enrolling an Authenticator" below
       const enrollment = await authClient.mfa.enrollAuthenticator({
-        mfaToken: error.mfaToken,
+        mfaToken: mfa_token,
         authenticatorTypes: ['otp'],
       });
     } else {
       // User has enrolled factors — see "Challenging an Authenticator" below
       const challenge = await authClient.mfa.challengeAuthenticator({
-        mfaToken: error.mfaToken,
+        mfaToken: mfa_token,
         challengeType: 'otp',
       });
     }
+  }
+}
+```
+
+The same pattern works for refresh token and token exchange flows:
+
+```ts
+import { isMfaRequiredError } from '@auth0/auth0-auth-js';
+
+try {
+  const tokens = await authClient.getTokenByRefreshToken({
+    refreshToken: 'existing_refresh_token',
+  });
+} catch (error) {
+  if (isMfaRequiredError(error)) {
+    // Step-up MFA required for this audience/scope
+    const challenge = await authClient.mfa.challengeAuthenticator({
+      mfaToken: error.cause.mfa_token,
+      challengeType: 'otp',
+    });
   }
 }
 ```

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -6,7 +6,6 @@ import {
   BuildAuthorizationUrlError,
   BuildLinkUserUrlError,
   BuildUnlinkUserUrlError,
-  MfaRequiredError,
   TokenExchangeError,
   MissingClientAuthError,
   NotSupportedError,
@@ -18,7 +17,6 @@ import {
   TokenByRefreshTokenError,
   TokenForConnectionError,
   VerifyLogoutTokenError,
-  type MfaRequirements,
 } from './errors.js';
 import { stripUndefinedProperties } from './utils.js';
 import { MfaClient } from './mfa/mfa-client.js';
@@ -142,17 +140,18 @@ function validateSubjectToken(token: string): void {
   }
 }
 
-function throwIfMfaRequired(e: unknown): void {
+function toOAuth2Error(e: unknown): OAuth2Error {
   const err = e as { error?: string; error_description?: string; cause?: Record<string, unknown> };
-  if (err.error === 'mfa_required') {
-    const cause: OAuth2Error = {
-      error: err.error,
-      error_description: err.error_description ?? 'Multifactor authentication required',
-    };
-    const mfaToken = err.cause?.mfa_token as string | undefined;
-    const mfaRequirements = err.cause?.mfa_requirements as MfaRequirements | undefined;
-    throw new MfaRequiredError('Multifactor authentication required', cause, mfaToken, mfaRequirements);
+  const base: OAuth2Error = {
+    error: err.error ?? '',
+    error_description: err.error_description ?? '',
+    message: (e as { message?: string }).message,
+  };
+  if (err.error === 'mfa_required' && err.cause) {
+    base.mfa_token = err.cause.mfa_token as string | undefined;
+    base.mfa_requirements = err.cause.mfa_requirements as OAuth2Error['mfa_requirements'];
   }
+  return base;
 }
 
 /**
@@ -710,10 +709,9 @@ export class AuthClient {
 
       return TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
     } catch (e) {
-      throwIfMfaRequired(e);
       throw new TokenExchangeError(
         `Failed to exchange token for connection '${options.connection}'.`,
-        e as OAuth2Error
+        toOAuth2Error(e)
       );
     }
   }
@@ -768,10 +766,9 @@ export class AuthClient {
 
       return TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
     } catch (e) {
-      throwIfMfaRequired(e);
       throw new TokenExchangeError(
         `Failed to exchange token of type '${options.subjectTokenType}'${options.audience ? ` for audience '${options.audience}'` : ''}.`,
-        e as OAuth2Error
+        toOAuth2Error(e)
       );
     }
   }
@@ -915,10 +912,9 @@ export class AuthClient {
 
       return TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
     } catch (e) {
-      throwIfMfaRequired(e);
       throw new TokenByRefreshTokenError(
         'The access token has expired and there was an error while trying to refresh it.',
-        e as OAuth2Error
+        toOAuth2Error(e)
       );
     }
   }
@@ -986,10 +982,9 @@ export class AuthClient {
 
       return TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
     } catch (e) {
-      throwIfMfaRequired(e);
       throw new TokenByPasswordError(
         'There was an error while trying to request a token.',
-        e as OAuth2Error
+        toOAuth2Error(e)
       );
     }
   }

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -6,6 +6,7 @@ import {
   BuildAuthorizationUrlError,
   BuildLinkUserUrlError,
   BuildUnlinkUserUrlError,
+  MfaRequiredError,
   TokenExchangeError,
   MissingClientAuthError,
   NotSupportedError,
@@ -17,6 +18,7 @@ import {
   TokenByRefreshTokenError,
   TokenForConnectionError,
   VerifyLogoutTokenError,
+  type MfaRequirements,
 } from './errors.js';
 import { stripUndefinedProperties } from './utils.js';
 import { MfaClient } from './mfa/mfa-client.js';
@@ -137,6 +139,19 @@ function validateSubjectToken(token: string): void {
   // Very common copy paste mistake (case-insensitive check)
   if (/^bearer\s+/i.test(token)) {
     throw new TokenExchangeError("subject_token must not include the 'Bearer ' prefix");
+  }
+}
+
+function throwIfMfaRequired(e: unknown): void {
+  const err = e as { error?: string; error_description?: string; cause?: Record<string, unknown> };
+  if (err.error === 'mfa_required') {
+    const cause: OAuth2Error = {
+      error: err.error,
+      error_description: err.error_description ?? 'Multifactor authentication required',
+    };
+    const mfaToken = err.cause?.mfa_token as string | undefined;
+    const mfaRequirements = err.cause?.mfa_requirements as MfaRequirements | undefined;
+    throw new MfaRequiredError('Multifactor authentication required', cause, mfaToken, mfaRequirements);
   }
 }
 
@@ -695,6 +710,7 @@ export class AuthClient {
 
       return TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
     } catch (e) {
+      throwIfMfaRequired(e);
       throw new TokenExchangeError(
         `Failed to exchange token for connection '${options.connection}'.`,
         e as OAuth2Error
@@ -752,6 +768,7 @@ export class AuthClient {
 
       return TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
     } catch (e) {
+      throwIfMfaRequired(e);
       throw new TokenExchangeError(
         `Failed to exchange token of type '${options.subjectTokenType}'${options.audience ? ` for audience '${options.audience}'` : ''}.`,
         e as OAuth2Error
@@ -898,6 +915,7 @@ export class AuthClient {
 
       return TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
     } catch (e) {
+      throwIfMfaRequired(e);
       throw new TokenByRefreshTokenError(
         'The access token has expired and there was an error while trying to refresh it.',
         e as OAuth2Error
@@ -968,6 +986,7 @@ export class AuthClient {
 
       return TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
     } catch (e) {
+      throwIfMfaRequired(e);
       throw new TokenByPasswordError(
         'There was an error while trying to request a token.',
         e as OAuth2Error

--- a/packages/auth0-auth-js/src/errors.ts
+++ b/packages/auth0-auth-js/src/errors.ts
@@ -8,6 +8,14 @@ export interface OAuth2Error {
 }
 
 /**
+ * Describes which MFA factors the user must challenge or enroll.
+ */
+export interface MfaRequirements {
+  challenge?: Array<{ type: string }>;
+  enroll?: Array<{ type: string }>;
+}
+
+/**
  * Error codes used for {@link NotSupportedError}
  */
 export enum NotSupportedErrorCode {
@@ -170,6 +178,22 @@ export class BuildUnlinkUserUrlError extends ApiError {
   constructor(cause?: OAuth2Error) {
     super('build_unlink_user_url_error', 'There was an error when trying to build the Unlink User URL.', cause);
     this.name = 'BuildUnlinkUserUrlError';
+  }
+}
+
+/**
+ * Error thrown when the server requires multi-factor authentication to complete the token request.
+ * Contains the MFA token needed to proceed with enrollment or challenge flows.
+ */
+export class MfaRequiredError extends ApiError {
+  public mfaToken?: string;
+  public mfaRequirements?: MfaRequirements;
+
+  constructor(message: string, cause?: OAuth2Error, mfaToken?: string, mfaRequirements?: MfaRequirements) {
+    super('mfa_required', message, cause);
+    this.name = 'MfaRequiredError';
+    this.mfaToken = mfaToken;
+    this.mfaRequirements = mfaRequirements;
   }
 }
 

--- a/packages/auth0-auth-js/src/errors.ts
+++ b/packages/auth0-auth-js/src/errors.ts
@@ -1,18 +1,21 @@
 /**
- * Interface to represent an OAuth2 error.
- */
-export interface OAuth2Error {
-  error: string;
-  error_description: string;
-  message?: string;
-}
-
-/**
  * Describes which MFA factors the user must challenge or enroll.
  */
 export interface MfaRequirements {
   challenge?: Array<{ type: string }>;
   enroll?: Array<{ type: string }>;
+}
+
+/**
+ * Interface to represent an OAuth2 error.
+ * When the error is `mfa_required`, `mfa_token` and `mfa_requirements` will be populated.
+ */
+export interface OAuth2Error {
+  error: string;
+  error_description: string;
+  message?: string;
+  mfa_token?: string;
+  mfa_requirements?: MfaRequirements;
 }
 
 /**
@@ -52,6 +55,8 @@ abstract class ApiError extends Error {
       error: cause.error,
       error_description: cause.error_description,
       message: cause.message,
+      mfa_token: cause.mfa_token,
+      mfa_requirements: cause.mfa_requirements,
     };
   }
 }
@@ -182,19 +187,46 @@ export class BuildUnlinkUserUrlError extends ApiError {
 }
 
 /**
- * Error thrown when the server requires multi-factor authentication to complete the token request.
- * Contains the MFA token needed to proceed with enrollment or challenge flows.
+ * Narrows an error thrown by a token request method to one caused by an `mfa_required` response.
+ *
+ * When the Auth0 server requires multi-factor authentication, token request methods
+ * (`getTokenByPassword`, `getTokenByRefreshToken`, `exchangeToken`) throw their usual error
+ * (e.g. `TokenByPasswordError`) with `cause.error` set to `'mfa_required'`.
+ * The `cause` will also contain:
+ * - `mfa_token` — the token needed to proceed with enrollment or challenge MFA APIs
+ * - `mfa_requirements` — (optional) describes which factors to challenge or enroll
+ *
+ * This type guard checks whether an error was caused by an `mfa_required` response and
+ * narrows the type so that `cause` and `cause.mfa_token` are guaranteed to be defined.
+ *
+ * @param error - The error caught from a token request method
+ * @returns `true` if the error was caused by an `mfa_required` server response
+ *
+ * @example
+ * ```typescript
+ * import { AuthClient, isMfaRequiredError } from '@auth0/auth0-auth-js';
+ *
+ * try {
+ *   await authClient.getTokenByPassword({ username, password });
+ * } catch (error) {
+ *   if (isMfaRequiredError(error)) {
+ *     // error.cause.mfa_token is guaranteed to be defined here
+ *     const challenge = await authClient.mfa.challengeAuthenticator({
+ *       mfaToken: error.cause.mfa_token,
+ *       challengeType: 'otp',
+ *     });
+ *   }
+ * }
+ * ```
  */
-export class MfaRequiredError extends ApiError {
-  public mfaToken?: string;
-  public mfaRequirements?: MfaRequirements;
-
-  constructor(message: string, cause?: OAuth2Error, mfaToken?: string, mfaRequirements?: MfaRequirements) {
-    super('mfa_required', message, cause);
-    this.name = 'MfaRequiredError';
-    this.mfaToken = mfaToken;
-    this.mfaRequirements = mfaRequirements;
-  }
+export function isMfaRequiredError(
+  error: unknown
+): error is { cause: OAuth2Error & { error: 'mfa_required'; mfa_token: string } } & Error {
+  return (
+    error instanceof Error &&
+    (error as { cause?: OAuth2Error }).cause?.error === 'mfa_required' &&
+    typeof (error as { cause?: OAuth2Error }).cause?.mfa_token === 'string'
+  );
 }
 
 /**


### PR DESCRIPTION
 ## Summary         
 - Extends `OAuth2Error` interface with optional `mfa_token` and `mfa_requirements` fields                                                                              
  - Adds `MfaRequirements` interface describing which factors the user must challenge or enroll
  - Adds `isMfaRequiredError(error)` type guard that narrows any caught error to one with `cause.mfa_token` (string) and `cause.mfa_requirements` guaranteed present     
  - Propagates MFA fields from the server response body into the `cause` of existing error classes via a `toOAuth2Error` helper                                          
  - Updates EXAMPLES.md with documentation and usage examples                                                                                                            
                                                                                                                                                                         
  ## Motivation                                                                                                                                                          
                                                                                                                                                                         
  When the Auth0 server requires MFA, it returns a 403 with `error: "mfa_required"`, `mfa_token`, and optionally `mfa_requirements`. Previously these fields were        
  discarded when the response was wrapped into `TokenByPasswordError`, `TokenByRefreshTokenError`, etc.                                                                
                                                                                                                                                                         
  This change is **non-breaking**:                                                                                                                                       
  - Existing `instanceof TokenByPasswordError` catches still work identically                                                                                          
  - `cause` gains two new optional fields (`mfa_token`, `mfa_requirements`) that are `undefined` for non-MFA errors                                                      
  - The `isMfaRequiredError` type guard is additive — consumers opt-in to the new behavior                                                                               
                                                                                                                                                                         
  ## How it works                                                                                                                                                        
                                                                                                                                                                         
  Server returns 403:                                                                                                                                                    
  { error: "mfa_required", error_description: "...", mfa_token: "Fe26...", mfa_requirements: {...} }                                                                   
                                                                                                                                                                         
  openid-client throws ResponseBodyError with full response body in .cause                                                                                               
                                                                                                                                                                         
  auth-client.ts catch block calls toOAuth2Error(e):                                                                                                                     
    → detects mfa_required, extracts mfa_token and mfa_requirements from response body                                                                                 
    → returns OAuth2Error with all fields populated                                                                                                                      
                                                                                                                                                                         
  Existing error class (e.g. TokenByPasswordError) is thrown with enriched cause                                                                                         
                                                                                                                                                                         
  Consumer catches error and uses isMfaRequiredError(error) to detect + narrow                                                                                           
                                                                                                                                                                       
  ## Examples                                                                                                                                                            
                                                                       
  ### Basic: detect MFA and start challenge                                                                                                                              
                                                                       
  ```typescript                                                                                                                                                          
  import { AuthClient, isMfaRequiredError } from '@auth0/auth0-auth-js';
                                                                                                                                                                         
  const authClient = new AuthClient({ domain, clientId, clientSecret });                                                                                                 
                                                                                                                                                                         
  try {                                                                                                                                                                  
    await authClient.getTokenByPassword({ username: 'user@example.com', password: 'p4ssw0rd' });                                                                       
  } catch (error) {                                                                                                                                                      
    if (isMfaRequiredError(error)) {                                                                                                                                     
      // error.cause.mfa_token is narrowed to `string`                                                                                                                   
      const challenge = await authClient.mfa.challengeAuthenticator({                                                                                                    
        mfaToken: error.cause.mfa_token,                                                                                                                                 
        challengeType: 'otp',                                                                                                                                            
      });                                                                                                                                                                
    }                                                                                                                                                                    
  }                                                                                                                                                                      
                                                                                                                                                                       
  Refresh token step-up MFA                                                                                                                                              
                                                                       
  import { isMfaRequiredError } from '@auth0/auth0-auth-js';                                                                                                             
                                                                                                                                                                         
  try {                                                                                                                                                                
    await authClient.getTokenByRefreshToken({ refreshToken: 'rt_...' });                                                                                                 
  } catch (error) {                                                                                                                                                      
    if (isMfaRequiredError(error)) {                                                                                                                                     
      const challenge = await authClient.mfa.challengeAuthenticator({                                                                                                    
        mfaToken: error.cause.mfa_token,                                                                                                                                 
        challengeType: 'otp',                                                                                                                                            
      });                                                                                                                                                                
    }                                                                                                                                                                    
  }                                                                                                                                                                    
                                                                                                                                                                         
  Enrollment vs. challenge branching                                                                                                                                     
                                                                                                                                                                       
  import { isMfaRequiredError } from '@auth0/auth0-auth-js';                                                                                                             
                                                                                                                                                                         
  try {                                                                                                                                                                
    await authClient.getTokenByPassword({ username, password });                                                                                                         
  } catch (error) {                                                                                                                                                      
    if (isMfaRequiredError(error)) {                                                                                                                                     
      const { mfa_token, mfa_requirements } = error.cause;                                                                                                               
                                                                                                                                                                         
      if (mfa_requirements?.enroll?.length) {                                                                                                                            
        // User must enroll a new factor                                                                                                                                 
        const enrollment = await authClient.mfa.enrollAuthenticator({                                                                                                    
          mfaToken: mfa_token,                                                                                                                                           
          authenticatorTypes: ['otp'],                                                                                                                                   
        });                                                                                                                                                              
        // Show QR code via enrollment.barcodeUri                                                                                                                        
      } else if (mfa_requirements?.challenge?.length) {                                                                                                                  
        // User has factors enrolled, initiate challenge                                                                                                                 
        await authClient.mfa.challengeAuthenticator({                                                                                                                    
          mfaToken: mfa_token,                                                                                                                                           
          challengeType: mfa_requirements.challenge[0].type as 'otp' | 'oob',                                                                                            
        });                                                                                                                                                              
      }                                                                                                                                                                  
    }                                                                                                                                                                    
  }                                                                                                                                                                    
                                                                                                                                                                         
  Existing error handling still works (no breaking change)                                                                                                               
                                                                                                                                                                       
  import { TokenByPasswordError } from '@auth0/auth0-auth-js';                                                                                                           
                                                                                                                                                                         
  try {                                                                                                                                                                
    await authClient.getTokenByPassword({ username, password });                                                                                                         
  } catch (error) {                                                                                                                                                      
    if (error instanceof TokenByPasswordError) {                                                                                                                         
      // This still catches mfa_required errors — nothing changes for existing consumers                                                                                 
      console.log(error.cause?.error); // 'mfa_required' | 'invalid_grant' | ...                                                                                         
    }                                                                                                                                                                    
  }  
```