### PR TITLE
chore: git ignore package-lock.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage
 .DS_Store
 #temporary
 docs
+package-lock.json


### PR DESCRIPTION
### Changes
- Adding `package-lock.json` file to `.gitignore`
