### PR TITLE
feat(auth0-auth-js): add actor token support and act claim to Custom Token Exchange

### DIFF
--- a/packages/auth0-api-js/src/api-client.spec.ts
+++ b/packages/auth0-api-js/src/api-client.spec.ts
@@ -962,6 +962,8 @@ test('getAccessTokenForConnection - should return a token set when the exchange 
     clientSecret: 'my-client-secret',
   });
 
+  const newAccessToken = await generateToken(domain, 'user_123', 'https://api.backend.com');
+
   server.use(
     http.post(`https://${domain}/oauth/token`, async ({ request }) => {
       const body = await request.formData();
@@ -977,7 +979,7 @@ test('getAccessTokenForConnection - should return a token set when the exchange 
       ) {
         return HttpResponse.json(
           {
-            access_token: 'new-access-token',
+            access_token: newAccessToken,
             expires_in: 86400,
             scope: 'openid profile email',
             token_type: 'Bearer',
@@ -1000,7 +1002,7 @@ test('getAccessTokenForConnection - should return a token set when the exchange 
   });
 
   expect(tokenSet).toStrictEqual({
-    accessToken: 'new-access-token',
+    accessToken: newAccessToken,
     expiresAt: expect.any(Number),
     scope: 'openid profile email',
     connection: 'my-connection',
@@ -1045,6 +1047,8 @@ test('getTokenByExchangeProfile - should return tokens when exchange succeeds', 
     clientSecret: 'my-client-secret',
   });
 
+  const exchangedAccessToken = await generateToken(domain, 'user_123', 'https://api.backend.com');
+
   server.use(
     http.post(`https://${domain}/oauth/token`, async ({ request }) => {
       const body = await request.formData();
@@ -1059,7 +1063,7 @@ test('getTokenByExchangeProfile - should return tokens when exchange succeeds', 
       ) {
         return HttpResponse.json(
           {
-            access_token: 'exchanged-access-token',
+            access_token: exchangedAccessToken,
             expires_in: 3600,
             scope: 'read:data write:data',
             token_type: 'Bearer',
@@ -1086,7 +1090,7 @@ test('getTokenByExchangeProfile - should return tokens when exchange succeeds', 
   );
 
   expect(result).toMatchObject({
-    accessToken: 'exchanged-access-token',
+    accessToken: exchangedAccessToken,
     expiresAt: expect.any(Number),
     scope: 'read:data write:data',
   });
@@ -1101,12 +1105,13 @@ test('getTokenByExchangeProfile - should include idToken and refreshToken when p
     clientSecret: 'my-client-secret',
   });
   const idToken = await generateToken(domain, 'user_123', 'my-client-id');
+  const exchangedAccessToken = await generateToken(domain, 'user_123', 'https://api.backend.com');
 
   server.use(
     http.post(`https://${domain}/oauth/token`, async () => {
       return HttpResponse.json(
         {
-          access_token: 'exchanged-access-token',
+          access_token: exchangedAccessToken,
           expires_in: 3600,
           token_type: 'Bearer',
           issued_token_type: 'urn:ietf:params:oauth:token-type:access_token',
@@ -1178,11 +1183,13 @@ test('getTokenByExchangeProfile - should propagate issued_token_type from token 
     clientSecret: 'my-client-secret',
   });
 
+  const exchangedAccessToken = await generateToken(domain, 'user_123', 'https://api.backend.com');
+
   server.use(
     http.post(`https://${domain}/oauth/token`, async () => {
       return HttpResponse.json(
         {
-          access_token: 'exchanged-access-token',
+          access_token: exchangedAccessToken,
           expires_in: 3600,
           token_type: 'Bearer',
           issued_token_type: 'urn:ietf:params:oauth:token-type:access_token',
@@ -1212,12 +1219,13 @@ test('getTokenByExchangeProfile - should include organization parameter when pro
     clientSecret: 'my-client-secret',
   });
 
+  const exchangedAccessToken = await generateToken(domain, 'user_123', 'https://api.backend.com');
   let capturedOrganization: string | null = null;
   server.use(
     http.post(`https://${domain}/oauth/token`, async ({ request }) => {
       const body = await request.formData();
       capturedOrganization = body.get('organization') as string;
-      
+
       if (
         body.get('grant_type') === 'urn:ietf:params:oauth:grant-type:token-exchange' &&
         body.get('client_id') === 'my-client-id' &&
@@ -1229,7 +1237,7 @@ test('getTokenByExchangeProfile - should include organization parameter when pro
       ) {
         return HttpResponse.json(
           {
-            access_token: 'exchanged-access-token',
+            access_token: exchangedAccessToken,
             expires_in: 3600,
             scope: 'read:data write:data',
             token_type: 'Bearer',
@@ -1258,7 +1266,7 @@ test('getTokenByExchangeProfile - should include organization parameter when pro
 
   expect(capturedOrganization).toBe('org_abc123');
   expect(result).toMatchObject({
-    accessToken: 'exchanged-access-token',
+    accessToken: exchangedAccessToken,
     expiresAt: expect.any(Number),
     scope: 'read:data write:data',
   });
@@ -1272,12 +1280,13 @@ test('getTokenByExchangeProfile - should work without organization parameter (ba
     clientSecret: 'my-client-secret',
   });
 
+  const exchangedAccessToken = await generateToken(domain, 'user_123', 'https://api.backend.com');
   let capturedOrganization: string | null = null;
   server.use(
     http.post(`https://${domain}/oauth/token`, async ({ request }) => {
       const body = await request.formData();
       capturedOrganization = body.get('organization') as string;
-      
+
       if (
         body.get('grant_type') === 'urn:ietf:params:oauth:grant-type:token-exchange' &&
         body.get('subject_token') === 'my-subject-token' &&
@@ -1285,7 +1294,7 @@ test('getTokenByExchangeProfile - should work without organization parameter (ba
       ) {
         return HttpResponse.json(
           {
-            access_token: 'exchanged-access-token',
+            access_token: exchangedAccessToken,
             expires_in: 3600,
             token_type: 'Bearer',
           },
@@ -1309,7 +1318,7 @@ test('getTokenByExchangeProfile - should work without organization parameter (ba
   );
 
   expect(capturedOrganization).toBeNull();
-  expect(result.accessToken).toBe('exchanged-access-token');
+  expect(result.accessToken).toBe(exchangedAccessToken);
 });
 
 test('getTokenOnBehalfOf - should throw when no clientId configured', async () => {
@@ -1347,6 +1356,7 @@ test('getTokenOnBehalfOf - should exchange an access token using fixed OBO token
     clientSecret: 'my-client-secret',
   });
 
+  const oboAccessToken = await generateToken(domain, 'user_123', 'https://api.backend.com');
   let capturedOrganization: string | null = null;
   server.use(
     http.post(`https://${domain}/oauth/token`, async ({ request }) => {
@@ -1365,7 +1375,7 @@ test('getTokenOnBehalfOf - should exchange an access token using fixed OBO token
       ) {
         return HttpResponse.json(
           {
-            access_token: 'obo-access-token',
+            access_token: oboAccessToken,
             expires_in: 3600,
             scope: 'read:data write:data',
             token_type: 'Bearer',
@@ -1389,7 +1399,7 @@ test('getTokenOnBehalfOf - should exchange an access token using fixed OBO token
 
   expect(capturedOrganization).toBeNull();
   expect(result).toMatchObject({
-    accessToken: 'obo-access-token',
+    accessToken: oboAccessToken,
     expiresAt: expect.any(Number),
     scope: 'read:data write:data',
     issuedTokenType: 'urn:ietf:params:oauth:token-type:access_token',
@@ -1405,12 +1415,13 @@ test('getTokenOnBehalfOf - should not expose idToken or refreshToken', async () 
     clientSecret: 'my-client-secret',
   });
   const idToken = await generateToken(domain, 'user_123', 'my-client-id');
+  const oboAccessToken = await generateToken(domain, 'user_123', 'https://api.backend.com');
 
   server.use(
     http.post(`https://${domain}/oauth/token`, async () => {
       return HttpResponse.json(
         {
-          access_token: 'obo-access-token',
+          access_token: oboAccessToken,
           expires_in: 3600,
           token_type: 'Bearer',
           issued_token_type: 'urn:ietf:params:oauth:token-type:access_token',
@@ -1428,7 +1439,7 @@ test('getTokenOnBehalfOf - should not expose idToken or refreshToken', async () 
 
   expect(result).not.toHaveProperty('idToken');
   expect(result).not.toHaveProperty('refreshToken');
-  expect(result.accessToken).toBe('obo-access-token');
+  expect(result.accessToken).toBe(oboAccessToken);
 });
 
 test('getTokenOnBehalfOf - should handle exchange errors', async () => {

--- a/packages/auth0-auth-js/EXAMPLES.md
+++ b/packages/auth0-auth-js/EXAMPLES.md
@@ -38,6 +38,12 @@
     - [Requesting a Login Challenge](#requesting-a-login-challenge)
     - [Exchanging a Credential for Tokens](#exchanging-a-credential-for-tokens)
     - [Error Handling](#error-handling)
+- [Custom Token Exchange](#custom-token-exchange)
+    - [Basic Exchange](#basic-exchange)
+    - [Delegation Exchange with Actor Token](#delegation-exchange-with-actor-token)
+    - [Reading the act Claim](#reading-the-act-claim)
+    - [M2M Delegation (No ID Token)](#m2m-delegation-no-id-token)
+    - [Error Handling](#error-handling-1)
 
 ## Configuration
 
@@ -1084,6 +1090,103 @@ try {
   if (error instanceof PasskeyGetTokenError) {
     console.error(error.message);
     console.error(error.code);          // 'passkey_get_token_error'
+    console.error(error.cause?.error);  // e.g., 'invalid_grant', 'access_denied'
+  }
+}
+```
+
+## Custom Token Exchange
+
+`exchangeToken` implements [RFC 8693 Token Exchange](https://www.rfc-editor.org/rfc/rfc8693) via an Auth0 Token Exchange Profile. It lets you swap a token issued by an external system (an MCP server, a legacy IdP, a partner service) for Auth0 tokens, preserving the user's identity.
+
+### Basic Exchange
+
+```ts
+import { AuthClient } from '@auth0/auth0-auth-js';
+
+const authClient = new AuthClient({
+  domain: 'your-tenant.auth0.com',
+  clientId: 'YOUR_CLIENT_ID',
+  clientSecret: 'YOUR_CLIENT_SECRET',
+});
+
+const tokens = await authClient.exchangeToken({
+  subjectToken: externalToken,
+  subjectTokenType: 'urn:acme:legacy-token',
+  audience: 'https://api.example.com',
+  scope: 'openid profile read:data',
+});
+
+console.log(tokens.accessToken);
+```
+
+### Delegation Exchange with Actor Token
+
+When an intermediate service acts on behalf of a user, pass the service's own token as `actorToken`. Both `actorToken` and `actorTokenType` must be provided together.
+
+```ts
+const tokens = await authClient.exchangeToken({
+  subjectToken: userToken,
+  subjectTokenType: 'urn:ietf:params:oauth:token-type:access_token',
+  actorToken: serviceAccountToken,
+  actorTokenType: 'urn:ietf:params:oauth:token-type:access_token',
+  audience: 'https://api.example.com',
+});
+```
+
+### Reading the act Claim
+
+When a delegation exchange succeeds, the `act` claim on `TokenResponse` identifies the acting party. It is sourced from the ID token when one is issued, or from the JWT access token in M2M flows where no ID token is returned.
+
+```ts
+const tokens = await authClient.exchangeToken({
+  subjectToken: userToken,
+  subjectTokenType: 'urn:acme:user-token',
+  actorToken: serviceToken,
+  actorTokenType: 'urn:acme:service-token',
+  audience: 'https://api.example.com',
+  scope: 'openid',
+});
+
+if (tokens.act) {
+  console.log(tokens.act.sub);  // Subject of the acting party
+  console.log(tokens.act.iss);  // Optional issuer of the actor token
+}
+```
+
+### M2M Delegation (No ID Token)
+
+In machine-to-machine flows the `openid` scope is not requested, so no ID token is issued. The SDK automatically falls back to reading the `act` claim from the JWT access token. If the access token is opaque, `act` will be `undefined`.
+
+```ts
+const tokens = await authClient.exchangeToken({
+  subjectToken: serviceAToken,
+  subjectTokenType: 'urn:acme:service-token',
+  actorToken: serviceBToken,
+  actorTokenType: 'urn:acme:service-token',
+  audience: 'https://api.example.com',
+  // no 'openid' in scope — no id_token will be returned
+});
+
+// act is populated from the JWT access token if it carries the claim
+console.log(tokens.act?.sub);
+```
+
+### Error Handling
+
+```ts
+import { AuthClient, TokenExchangeError } from '@auth0/auth0-auth-js';
+
+try {
+  const tokens = await authClient.exchangeToken({
+    subjectToken: externalToken,
+    subjectTokenType: 'urn:acme:legacy-token',
+    audience: 'https://api.example.com',
+  });
+} catch (error) {
+  if (error instanceof TokenExchangeError) {
+    console.error(error.message);       // Human-readable error message
+    console.error(error.code);          // 'token_exchange_error'
     console.error(error.cause?.error);  // e.g., 'invalid_grant', 'access_denied'
   }
 }

--- a/packages/auth0-auth-js/src/auth-client.spec.ts
+++ b/packages/auth0-auth-js/src/auth-client.spec.ts
@@ -2911,6 +2911,180 @@ describe('exchangeToken with Token Exchange Profile', () => {
   });
 });
 
+describe('exchangeToken — actor token support', () => {
+  const baseOptions = {
+    subjectToken: 'subject-token-123',
+    subjectTokenType: 'urn:acme:custom-token',
+    audience: 'https://api.example.com',
+  };
+
+  test('should send actor_token and actor_token_type when provided', async () => {
+    const authClient = new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });
+
+    let capturedActorToken: string | null = null;
+    let capturedActorTokenType: string | null = null;
+    server.use(
+      http.post(mockOpenIdConfiguration.token_endpoint, async ({ request }) => {
+        const info = await request.formData();
+        capturedActorToken = info.get('actor_token') as string;
+        capturedActorTokenType = info.get('actor_token_type') as string;
+        return HttpResponse.json({
+          access_token: accessToken,
+          id_token: await generateToken(domain, 'user_cte', '<client_id>', undefined, undefined, undefined, {
+            act: { sub: 'service-account-123' },
+          }),
+          expires_in: 3600,
+          token_type: 'Bearer',
+          scope: 'read:default',
+        });
+      })
+    );
+
+    const result = await authClient.exchangeToken({
+      ...baseOptions,
+      actorToken: 'actor-token-abc',
+      actorTokenType: 'urn:acme:actor-token',
+    });
+
+    expect(capturedActorToken).toBe('actor-token-abc');
+    expect(capturedActorTokenType).toBe('urn:acme:actor-token');
+    expect(result.act).toEqual({ sub: 'service-account-123' });
+  });
+
+  test('should expose act claim from id_token on TokenResponse', async () => {
+    const authClient = new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });
+
+    server.use(
+      http.post(mockOpenIdConfiguration.token_endpoint, async () => {
+        return HttpResponse.json({
+          access_token: accessToken,
+          id_token: await generateToken(domain, 'user_cte', '<client_id>', undefined, undefined, undefined, {
+            act: { sub: 'actor-sub-456', iss: 'https://actor.example.com' },
+          }),
+          expires_in: 3600,
+          token_type: 'Bearer',
+          scope: 'read:default',
+        });
+      })
+    );
+
+    const result = await authClient.exchangeToken(baseOptions);
+
+    expect(result.act).toBeDefined();
+    expect(result.act?.sub).toBe('actor-sub-456');
+    expect(result.act?.iss).toBe('https://actor.example.com');
+  });
+
+  test('should not send actor_token or actor_token_type when omitted', async () => {
+    const authClient = new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });
+
+    let hasActorToken = false;
+    let hasActorTokenType = false;
+    server.use(
+      http.post(mockOpenIdConfiguration.token_endpoint, async ({ request }) => {
+        const info = await request.formData();
+        hasActorToken = info.has('actor_token');
+        hasActorTokenType = info.has('actor_token_type');
+        return HttpResponse.json({
+          access_token: accessToken,
+          id_token: await generateToken(domain, 'user_cte', '<client_id>'),
+          expires_in: 3600,
+          token_type: 'Bearer',
+          scope: 'read:default',
+        });
+      })
+    );
+
+    const result = await authClient.exchangeToken(baseOptions);
+
+    expect(hasActorToken).toBe(false);
+    expect(hasActorTokenType).toBe(false);
+    expect(result.act).toBeUndefined();
+  });
+
+  test('should throw TokenExchangeError when actorToken is provided without actorTokenType', async () => {
+    const authClient = new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });
+
+    await expect(
+      authClient.exchangeToken({ ...baseOptions, actorToken: 'actor-token-abc' })
+    ).rejects.toMatchObject({
+      name: 'TokenExchangeError',
+      code: 'token_exchange_error',
+      message: 'actorTokenType is required when actorToken is provided',
+    });
+  });
+
+  test('should not set act when access token is opaque and no id_token is returned', async () => {
+    const authClient = new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });
+
+    server.use(
+      http.post(mockOpenIdConfiguration.token_endpoint, async () => {
+        return HttpResponse.json({
+          access_token: 'opaque-access-token-string',
+          expires_in: 3600,
+          token_type: 'Bearer',
+          scope: 'read:data',
+        });
+      })
+    );
+
+    const result = await authClient.exchangeToken(baseOptions);
+
+    expect(result.act).toBeUndefined();
+  });
+
+  test('should prefer act from id_token over act from access token when both are present', async () => {
+    const authClient = new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });
+
+    const accessTokenWithAct = await generateToken(domain, 'user_cte', 'https://api.example.com', undefined, undefined, undefined, {
+      act: { sub: 'at-actor' },
+    });
+
+    server.use(
+      http.post(mockOpenIdConfiguration.token_endpoint, async () => {
+        return HttpResponse.json({
+          access_token: accessTokenWithAct,
+          id_token: await generateToken(domain, 'user_cte', '<client_id>', undefined, undefined, undefined, {
+            act: { sub: 'id-token-actor' },
+          }),
+          expires_in: 3600,
+          token_type: 'Bearer',
+          scope: 'read:default',
+        });
+      })
+    );
+
+    const result = await authClient.exchangeToken(baseOptions);
+
+    expect(result.act?.sub).toBe('id-token-actor');
+  });
+
+  test('should expose act claim from access token when no id_token is returned (M2M delegation)', async () => {
+    const authClient = new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });
+
+    const accessTokenWithAct = await generateToken(domain, 'user_cte', 'https://api.example.com', undefined, undefined, undefined, {
+      act: { sub: 'service-account-123' },
+    });
+
+    server.use(
+      http.post(mockOpenIdConfiguration.token_endpoint, async () => {
+        return HttpResponse.json({
+          access_token: accessTokenWithAct,
+          expires_in: 3600,
+          token_type: 'Bearer',
+          scope: 'read:data',
+          // no id_token — M2M flow, openid scope not requested
+        });
+      })
+    );
+
+    const result = await authClient.exchangeToken(baseOptions);
+
+    expect(result.act).toBeDefined();
+    expect(result.act?.sub).toBe('service-account-123');
+  });
+});
+
 describe('getTokenByPasskey (WebAuthn grant)', () => {
   const credential = {
     id: 'cred-id',

--- a/packages/auth0-auth-js/src/auth-client.spec.ts
+++ b/packages/auth0-auth-js/src/auth-client.spec.ts
@@ -2926,10 +2926,6 @@ describe('getTokenByPasskey (WebAuthn grant)', () => {
     clientExtensionResults: {},
   };
 
-  /**
-   * Registers a JSON handler on the token endpoint that captures the request
-   * and returns a valid token response (id_token aud=<client_id>, iss=domain).
-   */
   const mockPasskeyTokenEndpoint = async (overrides?: { idToken?: string }) => {
     const captured: { contentType?: string | null; body?: Record<string, unknown> } = {};
     const idToken = overrides?.idToken ?? (await generateToken(domain, 'user_passkey', '<client_id>'));
@@ -3000,9 +2996,6 @@ describe('getTokenByPasskey (WebAuthn grant)', () => {
   });
 
   test('rejects public clients (no client credentials); cause carries the MissingClientAuth reason', async () => {
-    // The passkey token exchange is confidential-only: it authenticates the
-    // client like any other grant. A client without credentials is rejected as
-    // a PasskeyGetTokenError whose cause surfaces the underlying reason.
     const authClient = new AuthClient({ domain, clientId: '<client_id>' });
 
     try {
@@ -3028,7 +3021,6 @@ describe('getTokenByPasskey (WebAuthn grant)', () => {
   });
 
   test('rejects when the id_token audience does not match the client', async () => {
-    // id_token issued for a different audience → openid-client validation fails.
     const wrongAudienceIdToken = await generateToken(domain, 'user_passkey', '<other_client>');
     await mockPasskeyTokenEndpoint({ idToken: wrongAudienceIdToken });
     const authClient = new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });

--- a/packages/auth0-auth-js/src/auth-client.spec.ts
+++ b/packages/auth0-auth-js/src/auth-client.spec.ts
@@ -3100,6 +3100,10 @@ describe('getTokenByPasskey (WebAuthn grant)', () => {
     clientExtensionResults: {},
   };
 
+  /**
+   * Registers a JSON handler on the token endpoint that captures the request
+   * and returns a valid token response (id_token aud=<client_id>, iss=domain).
+   */
   const mockPasskeyTokenEndpoint = async (overrides?: { idToken?: string }) => {
     const captured: { contentType?: string | null; body?: Record<string, unknown> } = {};
     const idToken = overrides?.idToken ?? (await generateToken(domain, 'user_passkey', '<client_id>'));
@@ -3169,6 +3173,9 @@ describe('getTokenByPasskey (WebAuthn grant)', () => {
     expect('client_secret' in captured.body!).toBe(false);
   });
 
+  // The passkey token exchange is confidential-only: it authenticates the
+  // client like any other grant. A client without credentials is rejected as
+  // a PasskeyGetTokenError whose cause surfaces the underlying reason.
   test('rejects public clients (no client credentials); cause carries the MissingClientAuth reason', async () => {
     const authClient = new AuthClient({ domain, clientId: '<client_id>' });
 
@@ -3194,6 +3201,7 @@ describe('getTokenByPasskey (WebAuthn grant)', () => {
     expect(result.claims?.iss).toBe(`https://${domain}/`);
   });
 
+  // id_token issued for a different audience → openid-client validation fails.
   test('rejects when the id_token audience does not match the client', async () => {
     const wrongAudienceIdToken = await generateToken(domain, 'user_passkey', '<other_client>');
     await mockPasskeyTokenEndpoint({ idToken: wrongAudienceIdToken });

--- a/packages/auth0-auth-js/src/auth-client.spec.ts
+++ b/packages/auth0-auth-js/src/auth-client.spec.ts
@@ -2968,7 +2968,11 @@ describe('exchangeToken — actor token support', () => {
       })
     );
 
-    const result = await authClient.exchangeToken(baseOptions);
+    const result = await authClient.exchangeToken({
+      ...baseOptions,
+      actorToken: 'actor-token-abc',
+      actorTokenType: 'urn:acme:actor-token',
+    });
 
     expect(result.act).toBeDefined();
     expect(result.act?.sub).toBe('actor-sub-456');
@@ -3054,7 +3058,11 @@ describe('exchangeToken — actor token support', () => {
       })
     );
 
-    const result = await authClient.exchangeToken(baseOptions);
+    const result = await authClient.exchangeToken({
+      ...baseOptions,
+      actorToken: 'actor-token-abc',
+      actorTokenType: 'urn:acme:actor-token',
+    });
 
     expect(result.act?.sub).toBe('id-token-actor');
   });
@@ -3078,7 +3086,11 @@ describe('exchangeToken — actor token support', () => {
       })
     );
 
-    const result = await authClient.exchangeToken(baseOptions);
+    const result = await authClient.exchangeToken({
+      ...baseOptions,
+      actorToken: 'actor-token-abc',
+      actorTokenType: 'urn:acme:actor-token',
+    });
 
     expect(result.act).toBeDefined();
     expect(result.act?.sub).toBe('service-account-123');
@@ -3173,10 +3185,10 @@ describe('getTokenByPasskey (WebAuthn grant)', () => {
     expect('client_secret' in captured.body!).toBe(false);
   });
 
-  // The passkey token exchange is confidential-only: it authenticates the
-  // client like any other grant. A client without credentials is rejected as
-  // a PasskeyGetTokenError whose cause surfaces the underlying reason.
   test('rejects public clients (no client credentials); cause carries the MissingClientAuth reason', async () => {
+    // The passkey token exchange is confidential-only: it authenticates the
+    // client like any other grant. A client without credentials is rejected as
+    // a PasskeyGetTokenError whose cause surfaces the underlying reason.
     const authClient = new AuthClient({ domain, clientId: '<client_id>' });
 
     try {
@@ -3201,8 +3213,8 @@ describe('getTokenByPasskey (WebAuthn grant)', () => {
     expect(result.claims?.iss).toBe(`https://${domain}/`);
   });
 
-  // id_token issued for a different audience → openid-client validation fails.
   test('rejects when the id_token audience does not match the client', async () => {
+    // id_token issued for a different audience → openid-client validation fails.
     const wrongAudienceIdToken = await generateToken(domain, 'user_passkey', '<other_client>');
     await mockPasskeyTokenEndpoint({ idToken: wrongAudienceIdToken });
     const authClient = new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -853,9 +853,6 @@ export class AuthClient {
           tokenResponse.act = tokenResponse.claims.act as ActClaim;
         } else {
           try {
-            // The access token is not verified here — the client is not its audience and cannot
-            // validate the signature. The token was received directly from Auth0 over TLS, so
-            // the act claim is trusted in the same way as any other token endpoint response field.
             tokenResponse.act = decodeJwt(tokenEndpointResponse.access_token).act as ActClaim | undefined;
           } catch {
             // opaque access token — act claim not available

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -78,6 +78,8 @@ const MAX_ARRAY_VALUES_PER_KEY = 20;
  *   credentials must be managed through configuration, not request parameters
  * - subject_token, subject_token_type: Core token exchange parameters, overriding creates
  *   ambiguity about which token is being exchanged
+ * - actor_token, actor_token_type: Actor token parameters for delegation exchanges, must use
+ *   explicit typed parameters to ensure correct delegation semantics
  * - requested_token_type: Determines the type of token returned, must be explicit
  * - audience, aud, resource, resources, resource_indicator: Target API parameters must use
  *   explicit API parameters to prevent confusion about precedence and ensure correct routing
@@ -101,6 +103,8 @@ const PARAM_DENYLIST = Object.freeze(
     'subject_token',
     'subject_token_type',
     'requested_token_type',
+    'actor_token',
+    'actor_token_type',
     'audience',
     'aud',
     'resource',
@@ -157,18 +161,6 @@ function toOAuth2Error(e: unknown): OAuth2Error {
     }
   }
   return base;
-}
-
-/**
- * Validates that a token type value is a syntactically valid URI.
- * Semantic validation (reserved namespaces) is enforced by the Auth0 server.
- */
-function validateTokenTypeUri(value: string, paramName: string): void {
-  try {
-    new URL(value);
-  } catch {
-    throw new TokenExchangeError(`${paramName} must be a valid URI`);
-  }
 }
 
 /**
@@ -817,10 +809,9 @@ export class AuthClient {
     const { configuration } = await this.#discover();
 
     validateSubjectToken(options.subjectToken);
-    validateTokenTypeUri(options.subjectTokenType, 'subjectTokenType');
 
-    if (options.actorTokenType !== undefined) {
-      validateTokenTypeUri(options.actorTokenType, 'actorTokenType');
+    if (options.actorToken !== undefined && options.actorTokenType === undefined) {
+      throw new TokenExchangeError('actorTokenType is required when actorToken is provided');
     }
 
     const tokenRequestParams = new URLSearchParams({

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -78,7 +78,6 @@ const MAX_ARRAY_VALUES_PER_KEY = 20;
  * - subject_token, subject_token_type: Core token exchange parameters, overriding creates
  *   ambiguity about which token is being exchanged
  * - requested_token_type: Determines the type of token returned, must be explicit
- * - actor_token, actor_token_type: Delegation parameters that affect authorization context
  * - audience, aud, resource, resources, resource_indicator: Target API parameters must use
  *   explicit API parameters to prevent confusion about precedence and ensure correct routing
  * - scope: Overriding via extras bypasses the explicit scope parameter and creates ambiguity
@@ -101,8 +100,6 @@ const PARAM_DENYLIST = Object.freeze(
     'subject_token',
     'subject_token_type',
     'requested_token_type',
-    'actor_token',
-    'actor_token_type',
     'audience',
     'aud',
     'resource',
@@ -159,6 +156,18 @@ function toOAuth2Error(e: unknown): OAuth2Error {
     }
   }
   return base;
+}
+
+/**
+ * Validates that a token type value is a syntactically valid URI.
+ * Semantic validation (reserved namespaces) is enforced by the Auth0 server.
+ */
+function validateTokenTypeUri(value: string, paramName: string): void {
+  try {
+    new URL(value);
+  } catch {
+    throw new TokenExchangeError(`${paramName} must be a valid URI`);
+  }
 }
 
 /**
@@ -807,6 +816,11 @@ export class AuthClient {
     const { configuration } = await this.#discover();
 
     validateSubjectToken(options.subjectToken);
+    validateTokenTypeUri(options.subjectTokenType, 'subjectTokenType');
+
+    if (options.actorTokenType !== undefined) {
+      validateTokenTypeUri(options.actorTokenType, 'actorTokenType');
+    }
 
     const tokenRequestParams = new URLSearchParams({
       subject_token_type: options.subjectTokenType,
@@ -824,6 +838,12 @@ export class AuthClient {
     }
     if (options.organization) {
       tokenRequestParams.append('organization', options.organization);
+    }
+    if (options.actorToken) {
+      tokenRequestParams.append('actor_token', options.actorToken);
+    }
+    if (options.actorTokenType) {
+      tokenRequestParams.append('actor_token_type', options.actorTokenType);
     }
 
     appendExtraParams(tokenRequestParams, options.extra);

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -1,5 +1,5 @@
 import * as client from 'openid-client';
-import { createRemoteJWKSet, importPKCS8, jwtVerify, customFetch, jwksCache } from 'jose';
+import { createRemoteJWKSet, importPKCS8, jwtVerify, customFetch, jwksCache, decodeJwt } from 'jose';
 import type { JWKSCacheInput } from 'jose';
 import {
   BackchannelAuthenticationError,
@@ -40,6 +40,7 @@ import {
   TokenByRefreshTokenOptions,
   TokenForConnectionOptions,
   TokenResponse,
+  ActClaim,
   VerifyLogoutTokenOptions,
   VerifyLogoutTokenResult,
 } from './types.js';
@@ -855,7 +856,18 @@ export class AuthClient {
         tokenRequestParams
       );
 
-      return TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
+      const tokenResponse = TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
+      const idTokenClaims = tokenEndpointResponse.id_token ? tokenEndpointResponse.claims() : undefined;
+      if (idTokenClaims?.act) {
+        tokenResponse.act = idTokenClaims.act as ActClaim;
+      } else {
+        try {
+          tokenResponse.act = decodeJwt(tokenEndpointResponse.access_token).act as ActClaim | undefined;
+        } catch {
+          // opaque access token — act claim not available
+        }
+      }
+      return tokenResponse;
     } catch (e) {
       throw new TokenExchangeError(
         `Failed to exchange token of type '${options.subjectTokenType}'${options.audience ? ` for audience '${options.audience}'` : ''}.`,

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -848,14 +848,18 @@ export class AuthClient {
       );
 
       const tokenResponse = TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
-      const idTokenClaims = tokenEndpointResponse.id_token ? tokenEndpointResponse.claims() : undefined;
-      if (idTokenClaims?.act) {
-        tokenResponse.act = idTokenClaims.act as ActClaim;
-      } else {
-        try {
-          tokenResponse.act = decodeJwt(tokenEndpointResponse.access_token).act as ActClaim | undefined;
-        } catch {
-          // opaque access token — act claim not available
+      if (options.actorToken) {
+        if (tokenResponse.claims?.act) {
+          tokenResponse.act = tokenResponse.claims.act as ActClaim;
+        } else {
+          try {
+            // The access token is not verified here — the client is not its audience and cannot
+            // validate the signature. The token was received directly from Auth0 over TLS, so
+            // the act claim is trusted in the same way as any other token endpoint response field.
+            tokenResponse.act = decodeJwt(tokenEndpointResponse.access_token).act as ActClaim | undefined;
+          } catch {
+            // opaque access token — act claim not available
+          }
         }
       }
       return tokenResponse;

--- a/packages/auth0-auth-js/src/mfa/mfa-client.spec.ts
+++ b/packages/auth0-auth-js/src/mfa/mfa-client.spec.ts
@@ -495,16 +495,24 @@ describe('MfaClient', () => {
 
   describe('verify', () => {
     let idToken: string;
+    let mfaAccessToken: string;
+    let oobAccessToken: string;
+    let recoveryAccessToken: string;
+    let genericAccessToken: string;
 
     beforeAll(async () => {
       idToken = await generateToken(domain, 'user|123', clientId);
+      mfaAccessToken = await generateToken(domain, 'user|123', clientId);
+      oobAccessToken = await generateToken(domain, 'user|123', clientId);
+      recoveryAccessToken = await generateToken(domain, 'user|123', clientId);
+      genericAccessToken = await generateToken(domain, 'user|123', clientId);
     });
 
     test('should verify OTP and return TokenResponse', async () => {
       server.use(
         http.post(`https://${domain}/oauth/token`, async () =>
           HttpResponse.json({
-            access_token: 'mfa_access_token',
+            access_token: mfaAccessToken,
             id_token: idToken,
             refresh_token: 'mfa_refresh_token',
             token_type: 'Bearer',
@@ -517,7 +525,7 @@ describe('MfaClient', () => {
       const client = new MfaClient({ domain, clientId, getConfiguration: makeGetConfiguration(domain, clientId) });
       const result = await client.verify({ mfaToken, factorType: 'otp', otp: '123456' });
 
-      expect(result.accessToken).toBe('mfa_access_token');
+      expect(result.accessToken).toBe(mfaAccessToken);
       expect(result.idToken).toBe(idToken);
       expect(result.refreshToken).toBe('mfa_refresh_token');
       expect(result.tokenType).toBe('bearer');
@@ -530,7 +538,7 @@ describe('MfaClient', () => {
       server.use(
         http.post(`https://${domain}/oauth/token`, async () =>
           HttpResponse.json({
-            access_token: 'oob_access_token',
+            access_token: oobAccessToken,
             id_token: idToken,
             token_type: 'Bearer',
             expires_in: 86400,
@@ -541,14 +549,14 @@ describe('MfaClient', () => {
       const client = new MfaClient({ domain, clientId, getConfiguration: makeGetConfiguration(domain, clientId) });
       const result = await client.verify({ mfaToken, factorType: 'oob', oobCode: 'oob_123' });
 
-      expect(result.accessToken).toBe('oob_access_token');
+      expect(result.accessToken).toBe(oobAccessToken);
     });
 
     test('should verify recovery-code and set recoveryCode on TokenResponse', async () => {
       server.use(
         http.post(`https://${domain}/oauth/token`, async () =>
           HttpResponse.json({
-            access_token: 'recovery_access_token',
+            access_token: recoveryAccessToken,
             id_token: idToken,
             token_type: 'Bearer',
             expires_in: 86400,
@@ -560,7 +568,7 @@ describe('MfaClient', () => {
       const client = new MfaClient({ domain, clientId, getConfiguration: makeGetConfiguration(domain, clientId) });
       const result = await client.verify({ mfaToken, factorType: 'recovery-code', recoveryCode: 'OLD_CODE' });
 
-      expect(result.accessToken).toBe('recovery_access_token');
+      expect(result.accessToken).toBe(recoveryAccessToken);
       expect(result.recoveryCode).toBe('NEW_RECOVERY_CODE');
     });
 
@@ -571,7 +579,7 @@ describe('MfaClient', () => {
         http.post(`https://${domain}/oauth/token`, async ({ request }) => {
           capturedBody = await request.formData();
           return HttpResponse.json({
-            access_token: 'token',
+            access_token: genericAccessToken,
             token_type: 'Bearer',
             expires_in: 86400,
           });
@@ -592,7 +600,7 @@ describe('MfaClient', () => {
       server.use(
         http.post(`https://${domain}/oauth/token`, async ({ request }) => {
           capturedBody = await request.formData();
-          return HttpResponse.json({ access_token: 'token', token_type: 'Bearer', expires_in: 86400 });
+          return HttpResponse.json({ access_token: genericAccessToken, token_type: 'Bearer', expires_in: 86400 });
         })
       );
 
@@ -610,7 +618,7 @@ describe('MfaClient', () => {
       server.use(
         http.post(`https://${domain}/oauth/token`, async ({ request }) => {
           capturedBody = await request.formData();
-          return HttpResponse.json({ access_token: 'token', token_type: 'Bearer', expires_in: 86400 });
+          return HttpResponse.json({ access_token: genericAccessToken, token_type: 'Bearer', expires_in: 86400 });
         })
       );
 

--- a/packages/auth0-auth-js/src/types.ts
+++ b/packages/auth0-auth-js/src/types.ts
@@ -633,10 +633,12 @@ export class TokenResponse {
   recoveryCode?: string;
 
   /**
-   * The actor claim from the ID token (RFC 8693).
+   * The actor claim from a delegation token exchange (RFC 8693).
    *
-   * Present in delegation exchanges when an `actorToken` was provided. Identifies
-   * the acting party on whose behalf the subject token was exchanged.
+   * Present when an `actorToken` was provided. Sourced from the ID token when
+   * one is issued, or from the JWT access token in M2M flows where no ID token
+   * is returned. Identifies the acting party on whose behalf the subject token
+   * was exchanged.
    *
    * @see {@link https://www.rfc-editor.org/rfc/rfc8693#section-4.1 RFC 8693 Section 4.1}
    */

--- a/packages/auth0-auth-js/src/types.ts
+++ b/packages/auth0-auth-js/src/types.ts
@@ -389,6 +389,32 @@ export interface ExchangeProfileOptions {
   organization?: string;
 
   /**
+   * The actor token to include in the delegation exchange (RFC 8693).
+   *
+   * When provided, identifies the acting party (the intermediate service or agent)
+   * on whose behalf the exchange is being performed. The resulting token will carry
+   * an `act` claim describing the actor.
+   *
+   * Must be used together with `actorTokenType`.
+   *
+   * @see {@link https://www.rfc-editor.org/rfc/rfc8693#section-2.1 RFC 8693 Section 2.1}
+   */
+  actorToken?: string;
+
+  /**
+   * A URI that identifies the type of the actor token (RFC 8693).
+   *
+   * Must be a syntactically valid URI. Reserved namespaces are validated by the
+   * Auth0 platform, not the SDK.
+   *
+   * Must be used together with `actorToken`.
+   *
+   * @example "urn:acme:actor-token"
+   * @example "http://acme.com/service-token"
+   */
+  actorTokenType?: string;
+
+  /**
    * Additional custom parameters accessible in Auth0 Actions via event.request.body.
    *
    * Use for context like device fingerprints, session IDs, or business metadata.
@@ -535,6 +561,23 @@ export interface AuthorizationDetails {
 }
 
 /**
+ * Represents the `act` (actor) claim in a token response (RFC 8693).
+ *
+ * Present when a token was issued via a delegation exchange, identifying the
+ * acting party (e.g., an intermediate service) that performed the exchange on
+ * behalf of the subject.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc8693#section-4.1 RFC 8693 Section 4.1}
+ */
+export interface ActClaim {
+  /**
+   * The subject identifier of the actor.
+   */
+  sub: string;
+  [key: string]: unknown;
+}
+
+/**
  * Represents a successful token response from Auth0.
  *
  * Contains all tokens and metadata returned from Auth0 token endpoints,
@@ -589,6 +632,16 @@ export class TokenResponse {
    */
   recoveryCode?: string;
 
+  /**
+   * The actor claim from the ID token (RFC 8693).
+   *
+   * Present in delegation exchanges when an `actorToken` was provided. Identifies
+   * the acting party on whose behalf the subject token was exchanged.
+   *
+   * @see {@link https://www.rfc-editor.org/rfc/rfc8693#section-4.1 RFC 8693 Section 4.1}
+   */
+  act?: ActClaim;
+
   constructor(
     accessToken: string,
     expiresAt: number,
@@ -632,6 +685,7 @@ export class TokenResponse {
 
     tokenResponse.tokenType = response.token_type;
     tokenResponse.issuedTokenType = (response as typeof response & { issued_token_type?: string }).issued_token_type;
+    tokenResponse.act = claims?.act as ActClaim | undefined;
 
     return tokenResponse;
   }

--- a/packages/auth0-auth-js/src/types.ts
+++ b/packages/auth0-auth-js/src/types.ts
@@ -685,7 +685,6 @@ export class TokenResponse {
 
     tokenResponse.tokenType = response.token_type;
     tokenResponse.issuedTokenType = (response as typeof response & { issued_token_type?: string }).issued_token_type;
-    tokenResponse.act = claims?.act as ActClaim | undefined;
 
     return tokenResponse;
   }


### PR DESCRIPTION
### Description

Extends the Custom Token Exchange (CTE) implementation in `auth0-auth-js` to support RFC 8693 delegation flows via actor tokens.

- Adds `actorToken` and `actorTokenType` optional fields to `ExchangeProfileOptions`, forwarded as `actor_token` and `actor_token_type` in the token request. Both remain in `PARAM_DENYLIST` to prevent injection via `extra` — callers must use the typed fields.
- Adds the `ActClaim` interface `({ sub: string; [key: string]: unknown })` per RFC 8693 Section 4.1. The index signature allows for additional server-provided fields (e.g. chained delegation, `iss`).
- Adds `act?: ActClaim` to `TokenResponse`, populated exclusively inside `#exchangeProfileToken()` (not in the shared `fromTokenEndpointResponse()`). Prefers the `act` claim from the verified ID token; falls back to decoding the JWT access token for M2M flows where no ID token is issued. Wrapped in try/catch to handle opaque access tokens gracefully.
- No client-side URI validation for `subjectTokenType` or `actorTokenType` — invalid URIs are rejected by the Auth0 server, consistent with Swift, Android, and spa-js behaviour.

### Examples

Added a full "Custom Token Exchange" section to `EXAMPLES.md` covering basic exchange, delegation with actor token, reading `act`, M2M fallback behaviour, and error handling.

### Testing

#### Unit Tests

- should send actor_token and actor_token_type when provided: verifies request params and `result.act` are correctly wired
- should expose act claim from id_token on TokenResponse: verifies extra fields (e.g. `iss`) on `act` are accessible
- should not send actor_token or actor_token_type when omitted: verifies no regression on existing exchanges
- should throw TokenExchangeError when actorToken is provided without actorTokenType
- should not set act when access token is opaque and no id_token is returned
- should prefer act from id_token over act from access token when both are present
- should expose act claim from access token when no id_token is returned (M2M delegation)

#### Manual Tests

- Tested end-to-end against a live Auth0 tenant using a locally built version.
- The test covered a delegation exchange where a service actor exchanges a user's token on their behalf using `actorToken` and `actorTokenType` parameters. The following behaviours were verified:

  - The exchange completes successfully and returns a valid access token and ID token
  - The `act` claim is present on the `TokenResponse`, correctly populated from the ID token with the actor identity set by the CTE Action
  - The refresh token is suppressed by Auth0 when an `actor_token` is present in the request, and the SDK handles the absence gracefully

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch