### PR TITLE
feat(auth0-auth-js): add passkeys API support

### DIFF
--- a/packages/auth0-auth-js/EXAMPLES.md
+++ b/packages/auth0-auth-js/EXAMPLES.md
@@ -779,7 +779,7 @@ const challenge = await authClient.passkey.register({
 | `familyName` | Optional | `string` | User's family (last) name. |
 | `nickname` | Optional | `string` | User's nickname. |
 | `picture` | Optional | `string` | URL to the user's profile picture. |
-| `userMetadata` | Optional | `Record<string, unknown>` | Arbitrary metadata stored in the user's `user_metadata` field. |
+| `userMetadata` | Optional | `Record<string, string>` | Arbitrary metadata stored in the user's `user_metadata` field. |
 | `realm` | Optional | `string` | Database connection name. If not provided, the tenant's default database connection is used. |
 | `organization` | Optional | `string` | Organization ID or name. Scopes the user to the specified organization context. |
 

--- a/packages/auth0-auth-js/EXAMPLES.md
+++ b/packages/auth0-auth-js/EXAMPLES.md
@@ -33,6 +33,11 @@
     - [Listing Authenticators](#listing-authenticators)
     - [Challenging an Authenticator](#challenging-an-authenticator)
     - [Deleting an Authenticator](#deleting-an-authenticator)
+- [Using Passkeys](#using-passkeys)
+    - [Requesting a Signup Challenge](#requesting-a-signup-challenge)
+    - [Requesting a Login Challenge](#requesting-a-login-challenge)
+    - [Exchanging a Credential for Tokens](#exchanging-a-credential-for-tokens)
+    - [Error Handling](#error-handling)
 
 ## Configuration
 
@@ -725,4 +730,239 @@ const mfaToken = '<mfa_token>';
 const authenticatorId = 'totp|dev_abc123';
 
 await authClient.mfa.deleteAuthenticator({ authenticatorId, mfaToken });
+```
+
+## Using Passkeys
+
+The SDK provides a passkey client for native WebAuthn-based authentication. The passkey client is accessible via the `passkey` property on the `AuthClient` instance.
+
+> [!IMPORTANT]
+> Passkeys require the following prerequisites:
+> - A [custom domain](https://auth0.com/docs/customize/custom-domains) configured on your Auth0 tenant (e.g., `auth.example.com`, not `example.auth0.com`). The custom domain serves as the WebAuthn Relying Party (RP) ID.
+> - A database connection with the `passkey` authentication method enabled.
+> - Your application must be served over HTTPS on a domain that matches or is a subdomain of the configured RP ID.
+
+The SDK is platform-agnostic — it does not call WebAuthn browser APIs directly. Your application is responsible for calling `navigator.credentials.create()` or `navigator.credentials.get()` and serializing the credential response before passing it to the SDK.
+
+Learn more: [Passkeys](https://auth0.com/docs/authenticate/database-connections/passkeys) | [Native Passkeys API](https://auth0.com/docs/authenticate/database-connections/passkeys/native-passkeys-api)
+
+### Requesting a Signup Challenge
+
+To register a new passkey for a user, request a signup challenge. The response contains WebAuthn public key creation options that should be passed to `navigator.credentials.create()`:
+
+```ts
+import { AuthClient } from '@auth0/auth0-auth-js';
+
+const authClient = new AuthClient({
+  domain: '<AUTH0_CUSTOM_DOMAIN>',
+  clientId: '<AUTH0_CLIENT_ID>',
+});
+
+const challenge = await authClient.passkey.signupChallenge({
+  email: 'user@example.com',
+  name: 'Jane Doe',
+});
+
+// challenge.authSession — session identifier needed for the token exchange step
+// challenge.authnParamsPublicKey — pass to navigator.credentials.create({ publicKey: ... })
+```
+
+#### Parameters
+
+| Parameter | Required | Type | Description |
+|-----------|----------|------|-------------|
+| `email` | Optional | `string` | User's email address. Include if `email` is configured as an identifier in your database connection's [user attributes](https://auth0.com/docs/authenticate/database-connections/passkeys). |
+| `username` | Optional | `string` | User's username. Include if `username` is configured as an identifier in your database connection's user attributes. |
+| `phoneNumber` | Optional | `string` | User's phone number. Include if `phone` is configured as an identifier in your database connection's user attributes. |
+| `name` | Optional | `string` | User's full display name. |
+| `realm` | Optional | `string` | Database connection name. If not provided, the tenant's default database connection is used. |
+
+> [!NOTE]
+> Which identifiers (`email`, `username`, `phoneNumber`) you should provide depends on what's enabled in your Auth0 tenant's database connection attributes. Provide the identifiers that match your connection's configuration.
+
+You can include additional user profile fields when [Flexible Identifiers](https://auth0.com/docs/authenticate/database-connections/passkeys) is enabled on your database connection:
+
+```ts
+const challenge = await authClient.passkey.signupChallenge({
+  email: 'user@example.com',
+  name: 'Jane Doe',
+  phoneNumber: '+1234567890',
+  username: 'janedoe',
+});
+```
+
+To specify a database connection:
+
+```ts
+const challenge = await authClient.passkey.signupChallenge({
+  email: 'user@example.com',
+  realm: 'Username-Password-Authentication',
+});
+```
+
+### Requesting a Login Challenge
+
+To authenticate with an existing passkey, request a login challenge. The response contains WebAuthn public key request options that should be passed to `navigator.credentials.get()`:
+
+```ts
+const challenge = await authClient.passkey.loginChallenge();
+
+// challenge.authSession — session identifier needed for the token exchange step
+// challenge.authnParamsPublicKey — pass to navigator.credentials.get({ publicKey: ... })
+```
+
+#### Parameters
+
+| Parameter | Required | Type | Description |
+|-----------|----------|------|-------------|
+| `realm` | Optional | `string` | Database connection name. If not provided, the tenant's default database connection is used. |
+
+To specify a database connection:
+
+```ts
+const challenge = await authClient.passkey.loginChallenge({
+  realm: 'Username-Password-Authentication',
+});
+```
+
+### Exchanging a Credential for Tokens
+
+After the user completes the WebAuthn ceremony (either signup or login), exchange the credential response for Auth0 tokens.
+
+The WebAuthn API returns binary `ArrayBuffer` fields. These must be converted to base64url-encoded strings before passing to this method. Here is a helper function you can use:
+
+```ts
+function bufferToBase64url(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+```
+
+For a **signup** (registration) ceremony, the credential response includes `attestationObject`:
+
+```ts
+const credential = await navigator.credentials.create({
+  publicKey: challenge.authnParamsPublicKey,
+});
+
+const tokens = await authClient.passkey.signinWithPasskey({
+  authSession: challenge.authSession,
+  credential: {
+    id: credential.id,
+    rawId: bufferToBase64url(credential.rawId),
+    type: credential.type,
+    authenticatorAttachment: credential.authenticatorAttachment,
+    response: {
+      clientDataJSON: bufferToBase64url(credential.response.clientDataJSON),
+      attestationObject: bufferToBase64url(credential.response.attestationObject),
+    },
+  },
+});
+```
+
+For a **login** (authentication) ceremony, the credential response includes `authenticatorData`, `signature`, and `userHandle`:
+
+```ts
+const credential = await navigator.credentials.get({
+  publicKey: challenge.authnParamsPublicKey,
+});
+
+const tokens = await authClient.passkey.signinWithPasskey({
+  authSession: challenge.authSession,
+  credential: {
+    id: credential.id,
+    rawId: bufferToBase64url(credential.rawId),
+    type: credential.type,
+    authenticatorAttachment: credential.authenticatorAttachment,
+    response: {
+      clientDataJSON: bufferToBase64url(credential.response.clientDataJSON),
+      authenticatorData: bufferToBase64url(credential.response.authenticatorData),
+      signature: bufferToBase64url(credential.response.signature),
+      userHandle: bufferToBase64url(credential.response.userHandle),
+    },
+  },
+});
+```
+
+#### Parameters
+
+| Parameter | Required | Type | Description |
+|-----------|----------|------|-------------|
+| `authSession` | Required | `string` | The session identifier returned from `signupChallenge()` or `loginChallenge()`. |
+| `credential` | Required | `PasskeyCredentialResponse` | The serialized WebAuthn credential. For signup: include `attestationObject`. For login: include `authenticatorData`, `signature`, and `userHandle`. |
+| `realm` | Optional | `string` | Database connection name. If not provided, the tenant's default database connection is used. |
+| `scope` | Optional | `string` | OAuth scopes to request (e.g., `'openid profile email'`). |
+| `audience` | Optional | `string` | API identifier for the access token. Without this, an opaque token is returned instead of a JWT. |
+
+You can specify audience and scope to control the access token:
+
+```ts
+const tokens = await authClient.passkey.signinWithPasskey({
+  authSession: challenge.authSession,
+  credential: serializedCredential,
+  audience: 'https://api.example.com',
+  scope: 'openid profile email',
+});
+```
+
+To specify a database connection:
+
+```ts
+const tokens = await authClient.passkey.signinWithPasskey({
+  authSession: challenge.authSession,
+  credential: serializedCredential,
+  realm: 'Username-Password-Authentication',
+});
+```
+
+### Error Handling
+
+All passkey methods throw typed errors that can be caught and handled individually:
+
+```ts
+import {
+  AuthClient,
+  PasskeySignupChallengeError,
+  PasskeyLoginChallengeError,
+  PasskeySigninError,
+} from '@auth0/auth0-auth-js';
+
+try {
+  const challenge = await authClient.passkey.signupChallenge({
+    email: 'user@example.com',
+  });
+} catch (error) {
+  if (error instanceof PasskeySignupChallengeError) {
+    console.error(error.message);       // Human-readable error message
+    console.error(error.code);          // 'passkey_signup_challenge_error'
+    console.error(error.cause?.error);  // API error code (e.g., 'invalid_request')
+    console.error(error.cause?.error_description); // API error detail
+  }
+}
+
+try {
+  const challenge = await authClient.passkey.loginChallenge();
+} catch (error) {
+  if (error instanceof PasskeyLoginChallengeError) {
+    console.error(error.message);
+    console.error(error.code);          // 'passkey_login_challenge_error'
+  }
+}
+
+try {
+  const tokens = await authClient.passkey.signinWithPasskey({
+    authSession: challenge.authSession,
+    credential: serializedCredential,
+  });
+} catch (error) {
+  if (error instanceof PasskeySigninError) {
+    console.error(error.message);
+    console.error(error.code);          // 'passkey_signin_error'
+    console.error(error.cause?.error);  // e.g., 'invalid_grant', 'access_denied'
+  }
+}
 ```

--- a/packages/auth0-auth-js/EXAMPLES.md
+++ b/packages/auth0-auth-js/EXAMPLES.md
@@ -758,7 +758,7 @@ const authClient = new AuthClient({
   clientId: '<AUTH0_CLIENT_ID>',
 });
 
-const challenge = await authClient.passkey.signupChallenge({
+const challenge = await authClient.passkey.register({
   email: 'user@example.com',
   name: 'Jane Doe',
 });
@@ -783,7 +783,7 @@ const challenge = await authClient.passkey.signupChallenge({
 You can include additional user profile fields when [Flexible Identifiers](https://auth0.com/docs/authenticate/database-connections/passkeys) is enabled on your database connection:
 
 ```ts
-const challenge = await authClient.passkey.signupChallenge({
+const challenge = await authClient.passkey.register({
   email: 'user@example.com',
   name: 'Jane Doe',
   phoneNumber: '+1234567890',
@@ -794,7 +794,7 @@ const challenge = await authClient.passkey.signupChallenge({
 To specify a database connection:
 
 ```ts
-const challenge = await authClient.passkey.signupChallenge({
+const challenge = await authClient.passkey.register({
   email: 'user@example.com',
   realm: 'Username-Password-Authentication',
 });
@@ -805,7 +805,7 @@ const challenge = await authClient.passkey.signupChallenge({
 To authenticate with an existing passkey, request a login challenge. The response contains WebAuthn public key request options that should be passed to `navigator.credentials.get()`:
 
 ```ts
-const challenge = await authClient.passkey.loginChallenge();
+const challenge = await authClient.passkey.challenge();
 
 // challenge.authSession — session identifier needed for the token exchange step
 // challenge.authnParamsPublicKey — pass to navigator.credentials.get({ publicKey: ... })
@@ -820,7 +820,7 @@ const challenge = await authClient.passkey.loginChallenge();
 To specify a database connection:
 
 ```ts
-const challenge = await authClient.passkey.loginChallenge({
+const challenge = await authClient.passkey.challenge({
   realm: 'Username-Password-Authentication',
 });
 ```
@@ -849,7 +849,7 @@ const credential = await navigator.credentials.create({
   publicKey: challenge.authnParamsPublicKey,
 });
 
-const tokens = await authClient.passkey.signinWithPasskey({
+const tokens = await authClient.passkey.getTokenByPasskey({
   authSession: challenge.authSession,
   credential: {
     id: credential.id,
@@ -871,7 +871,7 @@ const credential = await navigator.credentials.get({
   publicKey: challenge.authnParamsPublicKey,
 });
 
-const tokens = await authClient.passkey.signinWithPasskey({
+const tokens = await authClient.passkey.getTokenByPasskey({
   authSession: challenge.authSession,
   credential: {
     id: credential.id,
@@ -892,7 +892,7 @@ const tokens = await authClient.passkey.signinWithPasskey({
 
 | Parameter | Required | Type | Description |
 |-----------|----------|------|-------------|
-| `authSession` | Required | `string` | The session identifier returned from `signupChallenge()` or `loginChallenge()`. |
+| `authSession` | Required | `string` | The session identifier returned from `register()` or `challenge()`. |
 | `credential` | Required | `PasskeyCredentialResponse` | The serialized WebAuthn credential. For signup: include `attestationObject`. For login: include `authenticatorData`, `signature`, and `userHandle`. |
 | `realm` | Optional | `string` | Database connection name. If not provided, the tenant's default database connection is used. |
 | `scope` | Optional | `string` | OAuth scopes to request (e.g., `'openid profile email'`). |
@@ -901,7 +901,7 @@ const tokens = await authClient.passkey.signinWithPasskey({
 You can specify audience and scope to control the access token:
 
 ```ts
-const tokens = await authClient.passkey.signinWithPasskey({
+const tokens = await authClient.passkey.getTokenByPasskey({
   authSession: challenge.authSession,
   credential: serializedCredential,
   audience: 'https://api.example.com',
@@ -912,7 +912,7 @@ const tokens = await authClient.passkey.signinWithPasskey({
 To specify a database connection:
 
 ```ts
-const tokens = await authClient.passkey.signinWithPasskey({
+const tokens = await authClient.passkey.getTokenByPasskey({
   authSession: challenge.authSession,
   credential: serializedCredential,
   realm: 'Username-Password-Authentication',
@@ -926,42 +926,42 @@ All passkey methods throw typed errors that can be caught and handled individual
 ```ts
 import {
   AuthClient,
-  PasskeySignupChallengeError,
-  PasskeyLoginChallengeError,
-  PasskeySigninError,
+  PasskeyRegisterError,
+  PasskeyChallengeError,
+  PasskeyGetTokenError,
 } from '@auth0/auth0-auth-js';
 
 try {
-  const challenge = await authClient.passkey.signupChallenge({
+  const challenge = await authClient.passkey.register({
     email: 'user@example.com',
   });
 } catch (error) {
-  if (error instanceof PasskeySignupChallengeError) {
+  if (error instanceof PasskeyRegisterError) {
     console.error(error.message);       // Human-readable error message
-    console.error(error.code);          // 'passkey_signup_challenge_error'
+    console.error(error.code);          // 'passkey_register_error'
     console.error(error.cause?.error);  // API error code (e.g., 'invalid_request')
     console.error(error.cause?.error_description); // API error detail
   }
 }
 
 try {
-  const challenge = await authClient.passkey.loginChallenge();
+  const challenge = await authClient.passkey.challenge();
 } catch (error) {
-  if (error instanceof PasskeyLoginChallengeError) {
+  if (error instanceof PasskeyChallengeError) {
     console.error(error.message);
-    console.error(error.code);          // 'passkey_login_challenge_error'
+    console.error(error.code);          // 'passkey_challenge_error'
   }
 }
 
 try {
-  const tokens = await authClient.passkey.signinWithPasskey({
+  const tokens = await authClient.passkey.getTokenByPasskey({
     authSession: challenge.authSession,
     credential: serializedCredential,
   });
 } catch (error) {
-  if (error instanceof PasskeySigninError) {
+  if (error instanceof PasskeyGetTokenError) {
     console.error(error.message);
-    console.error(error.code);          // 'passkey_signin_error'
+    console.error(error.code);          // 'passkey_get_token_error'
     console.error(error.cause?.error);  // e.g., 'invalid_grant', 'access_denied'
   }
 }

--- a/packages/auth0-auth-js/EXAMPLES.md
+++ b/packages/auth0-auth-js/EXAMPLES.md
@@ -775,7 +775,13 @@ const challenge = await authClient.passkey.register({
 | `username` | Optional | `string` | User's username. Include if `username` is configured as an identifier in your database connection's user attributes. |
 | `phoneNumber` | Optional | `string` | User's phone number. Include if `phone` is configured as an identifier in your database connection's user attributes. |
 | `name` | Optional | `string` | User's full display name. |
+| `givenName` | Optional | `string` | User's given (first) name. |
+| `familyName` | Optional | `string` | User's family (last) name. |
+| `nickname` | Optional | `string` | User's nickname. |
+| `picture` | Optional | `string` | URL to the user's profile picture. |
+| `userMetadata` | Optional | `Record<string, unknown>` | Arbitrary metadata stored in the user's `user_metadata` field. |
 | `realm` | Optional | `string` | Database connection name. If not provided, the tenant's default database connection is used. |
+| `organization` | Optional | `string` | Organization ID or name. Scopes the user to the specified organization context. |
 
 > [!NOTE]
 > Which identifiers (`email`, `username`, `phoneNumber`) you should provide depends on what's enabled in your Auth0 tenant's database connection attributes. Provide the identifiers that match your connection's configuration.
@@ -786,8 +792,11 @@ You can include additional user profile fields when [Flexible Identifiers](https
 const challenge = await authClient.passkey.register({
   email: 'user@example.com',
   name: 'Jane Doe',
+  givenName: 'Jane',
+  familyName: 'Doe',
   phoneNumber: '+1234567890',
   username: 'janedoe',
+  userMetadata: { preferred_language: 'en' },
 });
 ```
 
@@ -797,6 +806,15 @@ To specify a database connection:
 const challenge = await authClient.passkey.register({
   email: 'user@example.com',
   realm: 'Username-Password-Authentication',
+});
+```
+
+To register within an organization context:
+
+```ts
+const challenge = await authClient.passkey.register({
+  email: 'user@example.com',
+  organization: 'org_abc123',
 });
 ```
 
@@ -816,12 +834,21 @@ const challenge = await authClient.passkey.challenge();
 | Parameter | Required | Type | Description |
 |-----------|----------|------|-------------|
 | `realm` | Optional | `string` | Database connection name. If not provided, the tenant's default database connection is used. |
+| `organization` | Optional | `string` | Organization ID or name. Scopes the authentication to the specified organization context. |
 
 To specify a database connection:
 
 ```ts
 const challenge = await authClient.passkey.challenge({
   realm: 'Username-Password-Authentication',
+});
+```
+
+To authenticate within an organization context:
+
+```ts
+const challenge = await authClient.passkey.challenge({
+  organization: 'org_abc123',
 });
 ```
 
@@ -897,6 +924,7 @@ const tokens = await authClient.passkey.getTokenByPasskey({
 | `realm` | Optional | `string` | Database connection name. If not provided, the tenant's default database connection is used. |
 | `scope` | Optional | `string` | OAuth scopes to request (e.g., `'openid profile email'`). |
 | `audience` | Optional | `string` | API identifier for the access token. Without this, an opaque token is returned instead of a JWT. |
+| `organization` | Optional | `string` | Organization ID or name. Scopes tokens to the specified organization context. |
 
 You can specify audience and scope to control the access token:
 
@@ -916,6 +944,16 @@ const tokens = await authClient.passkey.getTokenByPasskey({
   authSession: challenge.authSession,
   credential: serializedCredential,
   realm: 'Username-Password-Authentication',
+});
+```
+
+To exchange within an organization context:
+
+```ts
+const tokens = await authClient.passkey.getTokenByPasskey({
+  authSession: challenge.authSession,
+  credential: serializedCredential,
+  organization: 'org_abc123',
 });
 ```
 

--- a/packages/auth0-auth-js/README.md
+++ b/packages/auth0-auth-js/README.md
@@ -264,7 +264,7 @@ For detailed MFA examples including SMS enrollment, OOB challenges, and more, se
 The SDK provides native support for passkey-based authentication using the WebAuthn protocol. You can register new passkeys, authenticate with existing passkeys, and exchange passkey credentials for tokens — all without redirect-based flows.
 
 ```ts
-import { AuthClient, PasskeySigninError } from '@auth0/auth0-auth-js';
+import { AuthClient, PasskeyGetTokenError } from '@auth0/auth0-auth-js';
 
 const authClient = new AuthClient({
   domain: '<AUTH0_CUSTOM_DOMAIN>',
@@ -272,18 +272,18 @@ const authClient = new AuthClient({
 });
 
 // 1. Register a new passkey (signup)
-const signupChallenge = await authClient.passkey.signupChallenge({
+const signupChallenge = await authClient.passkey.register({
   email: 'user@example.com',
   name: 'Jane Doe',
 });
 // Pass signupChallenge.authnParamsPublicKey to navigator.credentials.create()
 
 // 2. Authenticate with an existing passkey (login)
-const loginChallenge = await authClient.passkey.loginChallenge();
+const loginChallenge = await authClient.passkey.challenge();
 // Pass loginChallenge.authnParamsPublicKey to navigator.credentials.get()
 
 // 3. Exchange the serialized credential response for tokens
-const tokens = await authClient.passkey.signinWithPasskey({
+const tokens = await authClient.passkey.getTokenByPasskey({
   authSession: signupChallenge.authSession,
   credential: serializedCredential,
   audience: 'https://api.example.com',

--- a/packages/auth0-auth-js/README.md
+++ b/packages/auth0-auth-js/README.md
@@ -259,7 +259,49 @@ await authClient.mfa.deleteAuthenticator({
 
 For detailed MFA examples including SMS enrollment, OOB challenges, and more, see the [MFA section in EXAMPLES.md](https://github.com/auth0/auth0-auth-js/blob/main/packages/auth0-auth-js/EXAMPLES.md#using-multi-factor-authentication-mfa).
 
-### 8. More Examples
+### 8. Passkeys
+
+The SDK provides native support for passkey-based authentication using the WebAuthn protocol. You can register new passkeys, authenticate with existing passkeys, and exchange passkey credentials for tokens — all without redirect-based flows.
+
+```ts
+import { AuthClient, PasskeySigninError } from '@auth0/auth0-auth-js';
+
+const authClient = new AuthClient({
+  domain: '<AUTH0_CUSTOM_DOMAIN>',
+  clientId: '<AUTH0_CLIENT_ID>',
+});
+
+// 1. Register a new passkey (signup)
+const signupChallenge = await authClient.passkey.signupChallenge({
+  email: 'user@example.com',
+  name: 'Jane Doe',
+});
+// Pass signupChallenge.authnParamsPublicKey to navigator.credentials.create()
+
+// 2. Authenticate with an existing passkey (login)
+const loginChallenge = await authClient.passkey.loginChallenge();
+// Pass loginChallenge.authnParamsPublicKey to navigator.credentials.get()
+
+// 3. Exchange the serialized credential response for tokens
+const tokens = await authClient.passkey.signinWithPasskey({
+  authSession: signupChallenge.authSession,
+  credential: serializedCredential,
+  audience: 'https://api.example.com',
+  scope: 'openid profile email',
+});
+```
+
+> [!IMPORTANT]
+> Passkeys require the following prerequisites:
+> - A [custom domain](https://auth0.com/docs/customize/custom-domains) configured on your Auth0 tenant (e.g., `auth.example.com`, not `example.auth0.com`). The custom domain serves as the WebAuthn Relying Party (RP) ID, which must match or be a registrable domain suffix of your application's origin.
+> - A database connection with the `passkey` authentication method enabled.
+> - Your application must be served over HTTPS on a domain that aligns with the configured RP ID.
+
+For detailed passkey examples including credential serialization, all parameter options, and error handling, see the [Passkeys section in EXAMPLES.md](https://github.com/auth0/auth0-auth-js/blob/main/packages/auth0-auth-js/EXAMPLES.md#using-passkeys).
+
+Learn more: [Passkeys](https://auth0.com/docs/authenticate/database-connections/passkeys) | [Native Passkeys API](https://auth0.com/docs/authenticate/database-connections/passkeys/native-passkeys-api)
+
+### 9. More Examples
 
 A full overview of examples can be found in [EXAMPLES.md](https://github.com/auth0/auth0-auth-js/blob/main/packages/auth0-auth-js/EXAMPLES.md).
 

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -20,6 +20,7 @@ import {
 } from './errors.js';
 import { stripUndefinedProperties } from './utils.js';
 import { MfaClient } from './mfa/mfa-client.js';
+import { PasskeyClient } from './passkey/passkey-client.js';
 import { createTelemetryFetch, getTelemetryConfig } from './telemetry.js';
 import {
   AuthClientOptions,
@@ -225,6 +226,7 @@ export class AuthClient {
   readonly #inFlightDiscovery: Map<string, Promise<DiscoveryCacheEntry>>;
   readonly #jwksCache: JWKSCacheInput;
   public mfa: MfaClient;
+  public passkey: PasskeyClient;
 
   constructor(options: AuthClientOptions) {
     this.#options = options;
@@ -252,6 +254,17 @@ export class AuthClient {
       domain: this.#options.domain,
       clientId: this.#options.clientId,
       customFetch: this.#customFetch,
+    });
+
+    this.passkey = new PasskeyClient({
+      domain: this.#options.domain,
+      clientId: this.#options.clientId,
+      customFetch: this.#customFetch,
+      grantRequest: async (grantType, params) => {
+        const { configuration } = await this.#discover();
+        const tokenEndpointResponse = await client.genericGrantRequest(configuration, grantType, params);
+        return TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
+      },
     });
   }
 

--- a/packages/auth0-auth-js/src/index.ts
+++ b/packages/auth0-auth-js/src/index.ts
@@ -2,3 +2,4 @@ export { AuthClient } from './auth-client.js';
 export * from './errors.js';
 export * from './types.js';
 export * from './mfa/index.js';
+export * from './passkey/index.js';

--- a/packages/auth0-auth-js/src/passkey/errors.ts
+++ b/packages/auth0-auth-js/src/passkey/errors.ts
@@ -1,0 +1,59 @@
+/**
+ * Interface to represent a Passkey API error response.
+ */
+export interface PasskeyApiErrorResponse {
+  error: string;
+  error_description: string;
+  message?: string;
+}
+
+/**
+ * Base class for Passkey-related errors.
+ */
+abstract class PasskeyError extends Error {
+  public cause?: PasskeyApiErrorResponse;
+  public code: string;
+
+  constructor(code: string, message: string, cause?: PasskeyApiErrorResponse) {
+    super(message);
+
+    this.code = code;
+    this.cause = cause && {
+      error: cause.error,
+      error_description: cause.error_description,
+      message: cause.message,
+    };
+  }
+}
+
+/**
+ * Error thrown when requesting a passkey signup challenge fails.
+ */
+export class PasskeySignupChallengeError extends PasskeyError {
+  constructor(message: string, cause?: PasskeyApiErrorResponse) {
+    super('passkey_signup_challenge_error', message, cause);
+    this.name = 'PasskeySignupChallengeError';
+  }
+}
+
+/**
+ * Error thrown when requesting a passkey login challenge fails.
+ */
+export class PasskeyLoginChallengeError extends PasskeyError {
+  constructor(message: string, cause?: PasskeyApiErrorResponse) {
+    super('passkey_login_challenge_error', message, cause);
+    this.name = 'PasskeyLoginChallengeError';
+  }
+}
+
+/**
+ * Error thrown when exchanging a passkey credential for tokens fails.
+ * Accepts both PasskeyApiErrorResponse and OAuth2Error (same shape) as the cause,
+ * since this error is thrown from AuthClient's token exchange.
+ */
+export class PasskeySigninError extends PasskeyError {
+  constructor(message: string, cause?: PasskeyApiErrorResponse) {
+    super('passkey_signin_error', message, cause);
+    this.name = 'PasskeySigninError';
+  }
+}

--- a/packages/auth0-auth-js/src/passkey/errors.ts
+++ b/packages/auth0-auth-js/src/passkey/errors.ts
@@ -27,33 +27,31 @@ abstract class PasskeyError extends Error {
 }
 
 /**
- * Error thrown when requesting a passkey signup challenge fails.
+ * Error thrown when requesting a passkey register challenge fails.
  */
-export class PasskeySignupChallengeError extends PasskeyError {
+export class PasskeyRegisterError extends PasskeyError {
   constructor(message: string, cause?: PasskeyApiErrorResponse) {
-    super('passkey_signup_challenge_error', message, cause);
-    this.name = 'PasskeySignupChallengeError';
+    super('passkey_register_error', message, cause);
+    this.name = 'PasskeyRegisterError';
   }
 }
 
 /**
  * Error thrown when requesting a passkey login challenge fails.
  */
-export class PasskeyLoginChallengeError extends PasskeyError {
+export class PasskeyChallengeError extends PasskeyError {
   constructor(message: string, cause?: PasskeyApiErrorResponse) {
-    super('passkey_login_challenge_error', message, cause);
-    this.name = 'PasskeyLoginChallengeError';
+    super('passkey_challenge_error', message, cause);
+    this.name = 'PasskeyChallengeError';
   }
 }
 
 /**
  * Error thrown when exchanging a passkey credential for tokens fails.
- * Accepts both PasskeyApiErrorResponse and OAuth2Error (same shape) as the cause,
- * since this error is thrown from AuthClient's token exchange.
  */
-export class PasskeySigninError extends PasskeyError {
+export class PasskeyGetTokenError extends PasskeyError {
   constructor(message: string, cause?: PasskeyApiErrorResponse) {
-    super('passkey_signin_error', message, cause);
-    this.name = 'PasskeySigninError';
+    super('passkey_get_token_error', message, cause);
+    this.name = 'PasskeyGetTokenError';
   }
 }

--- a/packages/auth0-auth-js/src/passkey/errors.ts
+++ b/packages/auth0-auth-js/src/passkey/errors.ts
@@ -10,7 +10,7 @@ export interface PasskeyApiErrorResponse {
 /**
  * Base class for Passkey-related errors.
  */
-abstract class PasskeyError extends Error {
+export abstract class PasskeyError extends Error {
   public cause?: PasskeyApiErrorResponse;
   public code: string;
 

--- a/packages/auth0-auth-js/src/passkey/index.ts
+++ b/packages/auth0-auth-js/src/passkey/index.ts
@@ -1,0 +1,12 @@
+export { PasskeyClient } from './passkey-client.js';
+export * from './errors.js';
+export type {
+  PasskeySignupChallengeOptions,
+  PasskeySignupChallengeResponse,
+  PasskeyLoginChallengeOptions,
+  PasskeyLoginChallengeResponse,
+  PasskeyCredentialResponse,
+  SigninWithPasskeyOptions,
+  PasskeyCreationOptions,
+  PasskeyRequestOptions,
+} from './types.js';

--- a/packages/auth0-auth-js/src/passkey/index.ts
+++ b/packages/auth0-auth-js/src/passkey/index.ts
@@ -6,7 +6,7 @@ export type {
   PasskeyLoginChallengeOptions,
   PasskeyLoginChallengeResponse,
   PasskeyCredentialResponse,
-  SigninWithPasskeyOptions,
+  GetTokenByPasskeyOptions,
   PasskeyCreationOptions,
   PasskeyRequestOptions,
 } from './types.js';

--- a/packages/auth0-auth-js/src/passkey/passkey-client.spec.ts
+++ b/packages/auth0-auth-js/src/passkey/passkey-client.spec.ts
@@ -3,9 +3,9 @@ import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
 import { PasskeyClient } from './passkey-client.js';
 import {
-  PasskeySignupChallengeError,
-  PasskeyLoginChallengeError,
-  PasskeySigninError,
+  PasskeyRegisterError,
+  PasskeyChallengeError,
+  PasskeyGetTokenError,
 } from './errors.js';
 import type { GrantRequestFn } from './types.js';
 import { TokenResponse } from '../types.js';
@@ -180,7 +180,7 @@ describe('PasskeyClient', () => {
       );
 
       const client = createClient();
-      await client.loginChallenge();
+      await client.challenge();
 
       expect(capturedUrl).toBe(`https://${domain}/passkey/challenge`);
     });
@@ -193,36 +193,36 @@ describe('PasskeyClient', () => {
       };
 
       const client = createClient({ customFetch });
-      await client.loginChallenge();
+      await client.challenge();
 
       expect(fetchCalled).toBe(true);
     });
 
     test('falls back to the global fetch when no custom fetch is provided', async () => {
       const client = createClient();
-      const result = await client.loginChallenge();
+      const result = await client.challenge();
       expect(result.authSession).toBe('eyJ_login_session');
     });
   });
 
-  // ─── signupChallenge ───────────────────────────────────────────────
+  // ─── register ─────────────────────────────────────────────────────
 
-  describe('signupChallenge', () => {
+  describe('register', () => {
     test('accepts email as a valid user identifier', async () => {
       const client = createClient();
-      const result = await client.signupChallenge({ email: 'user@example.com' });
+      const result = await client.register({ email: 'user@example.com' });
       expect(result.authSession).toBeDefined();
     });
 
     test('accepts username as a valid user identifier', async () => {
       const client = createClient();
-      const result = await client.signupChallenge({ username: 'janedoe' });
+      const result = await client.register({ username: 'janedoe' });
       expect(result.authSession).toBeDefined();
     });
 
     test('accepts phoneNumber as a valid user identifier', async () => {
       const client = createClient();
-      const result = await client.signupChallenge({ phoneNumber: '+1234567890' });
+      const result = await client.register({ phoneNumber: '+1234567890' });
       expect(result.authSession).toBeDefined();
     });
 
@@ -236,7 +236,7 @@ describe('PasskeyClient', () => {
       );
 
       const client = createClient();
-      await client.signupChallenge({ email: 'user@example.com' });
+      await client.register({ email: 'user@example.com' });
 
       expect(capturedUrl).toBe(`https://${domain}/passkey/register`);
     });
@@ -251,7 +251,7 @@ describe('PasskeyClient', () => {
       );
 
       const client = createClient();
-      await client.signupChallenge({ email: 'user@example.com' });
+      await client.register({ email: 'user@example.com' });
 
       expect(capturedContentType).toBe('application/json');
     });
@@ -266,7 +266,7 @@ describe('PasskeyClient', () => {
       );
 
       const client = createClient();
-      await client.signupChallenge({ email: 'user@example.com' });
+      await client.register({ email: 'user@example.com' });
 
       expect(capturedBody.client_id).toBe(clientId);
       expect(capturedBody.user_profile).toEqual({ email: 'user@example.com' });
@@ -282,7 +282,7 @@ describe('PasskeyClient', () => {
       );
 
       const client = createClient();
-      await client.signupChallenge({
+      await client.register({
         email: 'user@example.com',
         name: 'Jane Doe',
         phoneNumber: '+1234567890',
@@ -307,7 +307,7 @@ describe('PasskeyClient', () => {
       );
 
       const client = createClient();
-      await client.signupChallenge({ email: 'user@example.com' });
+      await client.register({ email: 'user@example.com' });
 
       const profile = capturedBody.user_profile as Record<string, unknown>;
       expect(profile.email).toBe('user@example.com');
@@ -326,7 +326,7 @@ describe('PasskeyClient', () => {
       );
 
       const client = createClient();
-      await client.signupChallenge({
+      await client.register({
         email: 'user@example.com',
         realm: 'Username-Password-Authentication',
       });
@@ -344,14 +344,14 @@ describe('PasskeyClient', () => {
       );
 
       const client = createClient();
-      await client.signupChallenge({ email: 'user@example.com' });
+      await client.register({ email: 'user@example.com' });
 
       expect(capturedBody).not.toHaveProperty('realm');
     });
 
     test('returns transformed response with camelCase authSession and authnParamsPublicKey', async () => {
       const client = createClient();
-      const result = await client.signupChallenge({ email: 'user@example.com' });
+      const result = await client.register({ email: 'user@example.com' });
 
       expect(result.authSession).toBe('eyJ_signup_session');
       expect(result.authnParamsPublicKey).toEqual({
@@ -376,7 +376,7 @@ describe('PasskeyClient', () => {
       );
 
       const client = createClient();
-      const result = await client.signupChallenge({ email: 'user@example.com' });
+      const result = await client.register({ email: 'user@example.com' });
 
       expect(result.authSession).toBe('eyJ_minimal_session');
       expect(result.authnParamsPublicKey.authenticatorSelection).toBeUndefined();
@@ -384,7 +384,7 @@ describe('PasskeyClient', () => {
       expect(result.authnParamsPublicKey.challenge).toBe('bWluaW1hbC1jaGFsbGVuZ2U');
     });
 
-    test('throws PasskeySignupChallengeError when the API returns HTTP 400', async () => {
+    test('throws PasskeyRegisterError when the API returns HTTP 400', async () => {
       server.use(
         http.post(`https://${domain}/passkey/register`, () => {
           return HttpResponse.json(
@@ -395,10 +395,10 @@ describe('PasskeyClient', () => {
       );
 
       const client = createClient();
-      await expect(client.signupChallenge({ email: 'user@example.com' })).rejects.toThrow(PasskeySignupChallengeError);
+      await expect(client.register({ email: 'user@example.com' })).rejects.toThrow(PasskeyRegisterError);
     });
 
-    test('throws PasskeySignupChallengeError when passkeys are not enabled (HTTP 403)', async () => {
+    test('throws PasskeyRegisterError when passkeys are not enabled (HTTP 403)', async () => {
       server.use(
         http.post(`https://${domain}/passkey/register`, () => {
           return HttpResponse.json(
@@ -409,10 +409,10 @@ describe('PasskeyClient', () => {
       );
 
       const client = createClient();
-      await expect(client.signupChallenge({ email: 'user@example.com' })).rejects.toThrow(PasskeySignupChallengeError);
+      await expect(client.register({ email: 'user@example.com' })).rejects.toThrow(PasskeyRegisterError);
     });
 
-    test('throws PasskeySignupChallengeError when the user already exists (HTTP 409)', async () => {
+    test('throws PasskeyRegisterError when the user already exists (HTTP 409)', async () => {
       server.use(
         http.post(`https://${domain}/passkey/register`, () => {
           return HttpResponse.json(
@@ -425,11 +425,11 @@ describe('PasskeyClient', () => {
       const client = createClient();
 
       try {
-        await client.signupChallenge({ email: 'existing@example.com' });
+        await client.register({ email: 'existing@example.com' });
         expect.fail('Should have thrown');
       } catch (e) {
-        const error = e as PasskeySignupChallengeError;
-        expect(error).toBeInstanceOf(PasskeySignupChallengeError);
+        const error = e as PasskeyRegisterError;
+        expect(error).toBeInstanceOf(PasskeyRegisterError);
         expect(error.message).toBe('User already exists');
         expect(error.cause?.error).toBe('user_exists');
       }
@@ -448,10 +448,10 @@ describe('PasskeyClient', () => {
       const client = createClient();
 
       try {
-        await client.signupChallenge({ email: 'user@example.com' });
+        await client.register({ email: 'user@example.com' });
         expect.fail('Should have thrown');
       } catch (e) {
-        const error = e as PasskeySignupChallengeError;
+        const error = e as PasskeyRegisterError;
         expect(error.message).toBe('Custom error message from API');
       }
     });
@@ -469,10 +469,10 @@ describe('PasskeyClient', () => {
       const client = createClient();
 
       try {
-        await client.signupChallenge({ email: 'user@example.com' });
+        await client.register({ email: 'user@example.com' });
         expect.fail('Should have thrown');
       } catch (e) {
-        const error = e as PasskeySignupChallengeError;
+        const error = e as PasskeyRegisterError;
         expect(error.message).toBe('Failed to request signup challenge');
       }
     });
@@ -490,12 +490,12 @@ describe('PasskeyClient', () => {
       const client = createClient();
 
       try {
-        await client.signupChallenge({ email: 'user@example.com' });
+        await client.register({ email: 'user@example.com' });
         expect.fail('Should have thrown');
       } catch (e) {
-        const error = e as PasskeySignupChallengeError;
-        expect(error.code).toBe('passkey_signup_challenge_error');
-        expect(error.name).toBe('PasskeySignupChallengeError');
+        const error = e as PasskeyRegisterError;
+        expect(error.code).toBe('passkey_register_error');
+        expect(error.name).toBe('PasskeyRegisterError');
         expect(error.cause).toEqual({
           error: 'invalid_request',
           error_description: 'Email is required',
@@ -518,11 +518,11 @@ describe('PasskeyClient', () => {
       const client = createClient();
 
       try {
-        await client.signupChallenge({ email: 'user@example.com' });
+        await client.register({ email: 'user@example.com' });
         expect.fail('Should have thrown');
       } catch (e) {
-        const error = e as PasskeySignupChallengeError;
-        expect(error).toBeInstanceOf(PasskeySignupChallengeError);
+        const error = e as PasskeyRegisterError;
+        expect(error).toBeInstanceOf(PasskeyRegisterError);
         expect(error.cause?.error).toBe('unknown_error');
         expect(error.cause?.error_description).toContain('500');
       }
@@ -538,16 +538,16 @@ describe('PasskeyClient', () => {
       );
 
       const client = createClient();
-      await client.signupChallenge({ email: 'user@example.com', name: '' });
+      await client.register({ email: 'user@example.com', name: '' });
 
       const profile = capturedBody.user_profile as Record<string, unknown>;
       expect(profile).not.toHaveProperty('name');
     });
   });
 
-  // ─── loginChallenge ────────────────────────────────────────────────
+  // ─── challenge ────────────────────────────────────────────────────
 
-  describe('loginChallenge', () => {
+  describe('challenge', () => {
     test('sends a POST request to /passkey/challenge', async () => {
       let capturedUrl = '';
       server.use(
@@ -558,7 +558,7 @@ describe('PasskeyClient', () => {
       );
 
       const client = createClient();
-      await client.loginChallenge();
+      await client.challenge();
 
       expect(capturedUrl).toBe(`https://${domain}/passkey/challenge`);
     });
@@ -573,7 +573,7 @@ describe('PasskeyClient', () => {
       );
 
       const client = createClient();
-      await client.loginChallenge();
+      await client.challenge();
 
       expect(capturedContentType).toBe('application/json');
     });
@@ -588,14 +588,14 @@ describe('PasskeyClient', () => {
       );
 
       const client = createClient();
-      await client.loginChallenge();
+      await client.challenge();
 
       expect(capturedBody.client_id).toBe(clientId);
     });
 
     test('works without any options (options parameter is undefined)', async () => {
       const client = createClient();
-      const result = await client.loginChallenge();
+      const result = await client.challenge();
 
       expect(result.authSession).toBe('eyJ_login_session');
       expect(result.authnParamsPublicKey.rpId).toBe('example.auth0.com');
@@ -603,7 +603,7 @@ describe('PasskeyClient', () => {
 
     test('works with an empty options object', async () => {
       const client = createClient();
-      const result = await client.loginChallenge({});
+      const result = await client.challenge({});
 
       expect(result.authSession).toBe('eyJ_login_session');
     });
@@ -618,7 +618,7 @@ describe('PasskeyClient', () => {
       );
 
       const client = createClient();
-      await client.loginChallenge({ realm: 'Username-Password-Authentication' });
+      await client.challenge({ realm: 'Username-Password-Authentication' });
 
       expect(capturedBody.realm).toBe('Username-Password-Authentication');
     });
@@ -633,14 +633,14 @@ describe('PasskeyClient', () => {
       );
 
       const client = createClient();
-      await client.loginChallenge();
+      await client.challenge();
 
       expect(capturedBody).not.toHaveProperty('realm');
     });
 
     test('returns transformed response with camelCase authSession and authnParamsPublicKey', async () => {
       const client = createClient();
-      const result = await client.loginChallenge();
+      const result = await client.challenge();
 
       expect(result.authSession).toBe('eyJ_login_session');
       expect(result.authnParamsPublicKey).toEqual({
@@ -659,7 +659,7 @@ describe('PasskeyClient', () => {
       );
 
       const client = createClient();
-      const result = await client.loginChallenge();
+      const result = await client.challenge();
 
       expect(result.authSession).toBe('eyJ_login_minimal');
       expect(result.authnParamsPublicKey.challenge).toBe('bWluaW1hbC1sb2dpbg');
@@ -668,7 +668,7 @@ describe('PasskeyClient', () => {
       expect(result.authnParamsPublicKey.userVerification).toBeUndefined();
     });
 
-    test('throws PasskeyLoginChallengeError when passkeys are not enabled (HTTP 403)', async () => {
+    test('throws PasskeyChallengeError when passkeys are not enabled (HTTP 403)', async () => {
       server.use(
         http.post(`https://${domain}/passkey/challenge`, () => {
           return HttpResponse.json(
@@ -679,10 +679,10 @@ describe('PasskeyClient', () => {
       );
 
       const client = createClient();
-      await expect(client.loginChallenge()).rejects.toThrow(PasskeyLoginChallengeError);
+      await expect(client.challenge()).rejects.toThrow(PasskeyChallengeError);
     });
 
-    test('throws PasskeyLoginChallengeError when client is unauthorized (HTTP 401)', async () => {
+    test('throws PasskeyChallengeError when client is unauthorized (HTTP 401)', async () => {
       server.use(
         http.post(`https://${domain}/passkey/challenge`, () => {
           return HttpResponse.json(
@@ -693,7 +693,7 @@ describe('PasskeyClient', () => {
       );
 
       const client = createClient();
-      await expect(client.loginChallenge()).rejects.toThrow(PasskeyLoginChallengeError);
+      await expect(client.challenge()).rejects.toThrow(PasskeyChallengeError);
     });
 
     test('uses error_description from the API response as the error message', async () => {
@@ -709,10 +709,10 @@ describe('PasskeyClient', () => {
       const client = createClient();
 
       try {
-        await client.loginChallenge();
+        await client.challenge();
         expect.fail('Should have thrown');
       } catch (e) {
-        const error = e as PasskeyLoginChallengeError;
+        const error = e as PasskeyChallengeError;
         expect(error.message).toBe('Connection not configured');
       }
     });
@@ -730,10 +730,10 @@ describe('PasskeyClient', () => {
       const client = createClient();
 
       try {
-        await client.loginChallenge();
+        await client.challenge();
         expect.fail('Should have thrown');
       } catch (e) {
-        const error = e as PasskeyLoginChallengeError;
+        const error = e as PasskeyChallengeError;
         expect(error.message).toBe('Failed to request login challenge');
       }
     });
@@ -751,12 +751,12 @@ describe('PasskeyClient', () => {
       const client = createClient();
 
       try {
-        await client.loginChallenge();
+        await client.challenge();
         expect.fail('Should have thrown');
       } catch (e) {
-        const error = e as PasskeyLoginChallengeError;
-        expect(error.code).toBe('passkey_login_challenge_error');
-        expect(error.name).toBe('PasskeyLoginChallengeError');
+        const error = e as PasskeyChallengeError;
+        expect(error.code).toBe('passkey_challenge_error');
+        expect(error.name).toBe('PasskeyChallengeError');
         expect(error.cause).toEqual({
           error: 'forbidden',
           error_description: 'Not enabled',
@@ -779,25 +779,25 @@ describe('PasskeyClient', () => {
       const client = createClient();
 
       try {
-        await client.loginChallenge();
+        await client.challenge();
         expect.fail('Should have thrown');
       } catch (e) {
-        const error = e as PasskeyLoginChallengeError;
-        expect(error).toBeInstanceOf(PasskeyLoginChallengeError);
+        const error = e as PasskeyChallengeError;
+        expect(error).toBeInstanceOf(PasskeyChallengeError);
         expect(error.cause?.error).toBe('unknown_error');
         expect(error.cause?.error_description).toContain('502');
       }
     });
   });
 
-  // ─── signinWithPasskey ─────────────────────────────────────────────
+  // ─── getTokenByPasskey ────────────────────────────────────────────
 
-  describe('signinWithPasskey', () => {
+  describe('getTokenByPasskey', () => {
     test('calls the grantRequest delegate with the webauthn grant type', async () => {
       const grantRequest = vi.fn(createMockGrantRequest());
       const client = createClient({ grantRequest });
 
-      await client.signinWithPasskey({
+      await client.getTokenByPasskey({
         authSession: 'eyJ_session',
         credential: mockCredentialCreation,
       });
@@ -811,7 +811,7 @@ describe('PasskeyClient', () => {
       const grantRequest = vi.fn(createMockGrantRequest());
       const client = createClient({ grantRequest });
 
-      await client.signinWithPasskey({
+      await client.getTokenByPasskey({
         authSession: 'eyJ_session',
         credential: mockCredentialCreation,
       });
@@ -825,7 +825,7 @@ describe('PasskeyClient', () => {
       const grantRequest = vi.fn(createMockGrantRequest());
       const client = createClient({ grantRequest });
 
-      await client.signinWithPasskey({
+      await client.getTokenByPasskey({
         authSession: 'eyJ_session',
         credential: mockCredentialCreation,
         realm: 'Username-Password-Authentication',
@@ -843,7 +843,7 @@ describe('PasskeyClient', () => {
       const grantRequest = vi.fn(createMockGrantRequest());
       const client = createClient({ grantRequest });
 
-      await client.signinWithPasskey({
+      await client.getTokenByPasskey({
         authSession: 'eyJ_session',
         credential: mockCredentialCreation,
       });
@@ -856,7 +856,7 @@ describe('PasskeyClient', () => {
 
     test('returns the TokenResponse from the grantRequest delegate', async () => {
       const client = createClient();
-      const result = await client.signinWithPasskey({
+      const result = await client.getTokenByPasskey({
         authSession: 'eyJ_session',
         credential: mockCredentialCreation,
       });
@@ -871,7 +871,7 @@ describe('PasskeyClient', () => {
       const grantRequest = vi.fn(createMockGrantRequest());
       const client = createClient({ grantRequest });
 
-      await client.signinWithPasskey({
+      await client.getTokenByPasskey({
         authSession: 'eyJ_session',
         credential: mockCredentialAssertion,
       });
@@ -895,7 +895,7 @@ describe('PasskeyClient', () => {
         },
       };
 
-      await client.signinWithPasskey({
+      await client.getTokenByPasskey({
         authSession: 'session',
         credential: minimalCredential,
       });
@@ -904,26 +904,26 @@ describe('PasskeyClient', () => {
       expect(params.get('authn_response')).toBe(JSON.stringify(minimalCredential));
     });
 
-    test('throws PasskeySigninError when the grantRequest delegate rejects', async () => {
+    test('throws PasskeyGetTokenError when the grantRequest delegate rejects', async () => {
       const grantRequest = vi.fn().mockRejectedValue(new Error('token exchange failed'));
       const client = createClient({ grantRequest });
 
       await expect(
-        client.signinWithPasskey({ authSession: 'invalid', credential: mockCredentialCreation })
-      ).rejects.toThrow(PasskeySigninError);
+        client.getTokenByPasskey({ authSession: 'invalid', credential: mockCredentialCreation })
+      ).rejects.toThrow(PasskeyGetTokenError);
     });
 
-    test('sets the error code to passkey_signin_error', async () => {
+    test('sets the error code to passkey_get_token_error', async () => {
       const grantRequest = vi.fn().mockRejectedValue(new Error('expired'));
       const client = createClient({ grantRequest });
 
       try {
-        await client.signinWithPasskey({ authSession: 'expired', credential: mockCredentialCreation });
+        await client.getTokenByPasskey({ authSession: 'expired', credential: mockCredentialCreation });
         expect.fail('Should have thrown');
       } catch (e) {
-        const error = e as PasskeySigninError;
-        expect(error.code).toBe('passkey_signin_error');
-        expect(error.name).toBe('PasskeySigninError');
+        const error = e as PasskeyGetTokenError;
+        expect(error.code).toBe('passkey_get_token_error');
+        expect(error.name).toBe('PasskeyGetTokenError');
       }
     });
 
@@ -932,10 +932,10 @@ describe('PasskeyClient', () => {
       const client = createClient({ grantRequest });
 
       try {
-        await client.signinWithPasskey({ authSession: 'session', credential: mockCredentialCreation });
+        await client.getTokenByPasskey({ authSession: 'session', credential: mockCredentialCreation });
         expect.fail('Should have thrown');
       } catch (e) {
-        const error = e as PasskeySigninError;
+        const error = e as PasskeyGetTokenError;
         expect(error.message).toBe('Failed to exchange passkey credential for tokens.');
       }
     });
@@ -950,11 +950,11 @@ describe('PasskeyClient', () => {
       const client = createClient({ grantRequest });
 
       try {
-        await client.signinWithPasskey({ authSession: 'expired', credential: mockCredentialCreation });
+        await client.getTokenByPasskey({ authSession: 'expired', credential: mockCredentialCreation });
         expect.fail('Should have thrown');
       } catch (e) {
-        const error = e as PasskeySigninError;
-        expect(error).toBeInstanceOf(PasskeySigninError);
+        const error = e as PasskeyGetTokenError;
+        expect(error).toBeInstanceOf(PasskeyGetTokenError);
         expect(error.cause?.error).toBe('invalid_grant');
         expect(error.cause?.error_description).toBe('Authentication session expired');
       }
@@ -965,11 +965,11 @@ describe('PasskeyClient', () => {
       const client = createClient({ grantRequest });
 
       try {
-        await client.signinWithPasskey({ authSession: 'session', credential: mockCredentialCreation });
+        await client.getTokenByPasskey({ authSession: 'session', credential: mockCredentialCreation });
         expect.fail('Should have thrown');
       } catch (e) {
-        const error = e as PasskeySigninError;
-        expect(error).toBeInstanceOf(PasskeySigninError);
+        const error = e as PasskeyGetTokenError;
+        expect(error).toBeInstanceOf(PasskeyGetTokenError);
         expect(error.cause).toBeUndefined();
       }
     });
@@ -979,11 +979,11 @@ describe('PasskeyClient', () => {
       const client = createClient({ grantRequest });
 
       try {
-        await client.signinWithPasskey({ authSession: 'session', credential: mockCredentialCreation });
+        await client.getTokenByPasskey({ authSession: 'session', credential: mockCredentialCreation });
         expect.fail('Should have thrown');
       } catch (e) {
-        const error = e as PasskeySigninError;
-        expect(error).toBeInstanceOf(PasskeySigninError);
+        const error = e as PasskeyGetTokenError;
+        expect(error).toBeInstanceOf(PasskeyGetTokenError);
         expect(error.cause).toBeUndefined();
       }
     });
@@ -992,7 +992,7 @@ describe('PasskeyClient', () => {
   // ─── customFetch ───────────────────────────────────────────────────
 
   describe('customFetch', () => {
-    test('uses custom fetch for signupChallenge requests', async () => {
+    test('uses custom fetch for register requests', async () => {
       let fetchCalled = false;
       const customFetch: typeof fetch = async (...args) => {
         fetchCalled = true;
@@ -1000,12 +1000,12 @@ describe('PasskeyClient', () => {
       };
 
       const client = createClient({ customFetch });
-      await client.signupChallenge({ email: 'user@example.com' });
+      await client.register({ email: 'user@example.com' });
 
       expect(fetchCalled).toBe(true);
     });
 
-    test('uses custom fetch for loginChallenge requests', async () => {
+    test('uses custom fetch for challenge requests', async () => {
       let fetchCalled = false;
       const customFetch: typeof fetch = async (...args) => {
         fetchCalled = true;
@@ -1013,7 +1013,7 @@ describe('PasskeyClient', () => {
       };
 
       const client = createClient({ customFetch });
-      await client.loginChallenge();
+      await client.challenge();
 
       expect(fetchCalled).toBe(true);
     });
@@ -1026,7 +1026,7 @@ describe('PasskeyClient', () => {
       };
 
       const client = createClient({ customFetch });
-      await client.loginChallenge({ realm: 'my-connection' });
+      await client.challenge({ realm: 'my-connection' });
 
       expect(capturedArgs).not.toBeNull();
       expect(capturedArgs![0]).toBe(`https://${domain}/passkey/challenge`);
@@ -1042,7 +1042,7 @@ describe('PasskeyClient', () => {
   // ─── Error class behavior ─────────────────────────────────────────
 
   describe('error classes', () => {
-    test('PasskeySignupChallengeError extends Error', async () => {
+    test('PasskeyRegisterError extends Error', async () => {
       server.use(
         http.post(`https://${domain}/passkey/register`, () => {
           return HttpResponse.json(
@@ -1055,15 +1055,15 @@ describe('PasskeyClient', () => {
       const client = createClient();
 
       try {
-        await client.signupChallenge({ email: 'user@example.com' });
+        await client.register({ email: 'user@example.com' });
         expect.fail('Should have thrown');
       } catch (e) {
         expect(e).toBeInstanceOf(Error);
-        expect(e).toBeInstanceOf(PasskeySignupChallengeError);
+        expect(e).toBeInstanceOf(PasskeyRegisterError);
       }
     });
 
-    test('PasskeyLoginChallengeError extends Error', async () => {
+    test('PasskeyChallengeError extends Error', async () => {
       server.use(
         http.post(`https://${domain}/passkey/challenge`, () => {
           return HttpResponse.json(
@@ -1076,24 +1076,24 @@ describe('PasskeyClient', () => {
       const client = createClient();
 
       try {
-        await client.loginChallenge();
+        await client.challenge();
         expect.fail('Should have thrown');
       } catch (e) {
         expect(e).toBeInstanceOf(Error);
-        expect(e).toBeInstanceOf(PasskeyLoginChallengeError);
+        expect(e).toBeInstanceOf(PasskeyChallengeError);
       }
     });
 
-    test('PasskeySigninError extends Error', async () => {
+    test('PasskeyGetTokenError extends Error', async () => {
       const grantRequest = vi.fn().mockRejectedValue(new Error('fail'));
       const client = createClient({ grantRequest });
 
       try {
-        await client.signinWithPasskey({ authSession: 'session', credential: mockCredentialCreation });
+        await client.getTokenByPasskey({ authSession: 'session', credential: mockCredentialCreation });
         expect.fail('Should have thrown');
       } catch (e) {
         expect(e).toBeInstanceOf(Error);
-        expect(e).toBeInstanceOf(PasskeySigninError);
+        expect(e).toBeInstanceOf(PasskeyGetTokenError);
       }
     });
 
@@ -1115,10 +1115,10 @@ describe('PasskeyClient', () => {
       const client = createClient();
 
       try {
-        await client.signupChallenge({ email: 'user@example.com' });
+        await client.register({ email: 'user@example.com' });
         expect.fail('Should have thrown');
       } catch (e) {
-        const error = e as PasskeySignupChallengeError;
+        const error = e as PasskeyRegisterError;
         expect(error.cause).toEqual({
           error: 'invalid_request',
           error_description: 'Bad request',

--- a/packages/auth0-auth-js/src/passkey/passkey-client.spec.ts
+++ b/packages/auth0-auth-js/src/passkey/passkey-client.spec.ts
@@ -349,6 +349,51 @@ describe('PasskeyClient', () => {
       expect(capturedBody).not.toHaveProperty('realm');
     });
 
+    test('includes organization in the request body when provided', async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`https://${domain}/passkey/register`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(mockSignupChallengeResponse);
+        })
+      );
+
+      const client = createClient();
+      await client.register({
+        email: 'user@example.com',
+        organization: 'org_abc123',
+      });
+
+      expect(capturedBody.organization).toBe('org_abc123');
+    });
+
+    test('includes extended user profile fields in user_profile when provided', async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`https://${domain}/passkey/register`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(mockSignupChallengeResponse);
+        })
+      );
+
+      const client = createClient();
+      await client.register({
+        email: 'user@example.com',
+        givenName: 'Jane',
+        familyName: 'Doe',
+        nickname: 'janey',
+        picture: 'https://example.com/photo.jpg',
+        userMetadata: { preferred_language: 'en' },
+      });
+
+      const profile = capturedBody.user_profile as Record<string, unknown>;
+      expect(profile.given_name).toBe('Jane');
+      expect(profile.family_name).toBe('Doe');
+      expect(profile.nickname).toBe('janey');
+      expect(profile.picture).toBe('https://example.com/photo.jpg');
+      expect(profile.user_metadata).toEqual({ preferred_language: 'en' });
+    });
+
     test('returns transformed response with camelCase authSession and authnParamsPublicKey', async () => {
       const client = createClient();
       const result = await client.register({ email: 'user@example.com' });
@@ -638,6 +683,36 @@ describe('PasskeyClient', () => {
       expect(capturedBody).not.toHaveProperty('realm');
     });
 
+    test('includes organization in the request body when provided', async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`https://${domain}/passkey/challenge`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(mockLoginChallengeResponse);
+        })
+      );
+
+      const client = createClient();
+      await client.challenge({ organization: 'org_abc123' });
+
+      expect(capturedBody.organization).toBe('org_abc123');
+    });
+
+    test('does not include organization when not provided', async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`https://${domain}/passkey/challenge`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(mockLoginChallengeResponse);
+        })
+      );
+
+      const client = createClient();
+      await client.challenge();
+
+      expect(capturedBody).not.toHaveProperty('organization');
+    });
+
     test('returns transformed response with camelCase authSession and authnParamsPublicKey', async () => {
       const client = createClient();
       const result = await client.challenge();
@@ -839,7 +914,21 @@ describe('PasskeyClient', () => {
       expect(params.get('audience')).toBe('https://api.example.com');
     });
 
-    test('does not include realm, scope, or audience when not provided', async () => {
+    test('includes organization param when provided', async () => {
+      const grantRequest = vi.fn(createMockGrantRequest());
+      const client = createClient({ grantRequest });
+
+      await client.getTokenByPasskey({
+        authSession: 'eyJ_session',
+        credential: mockCredentialCreation,
+        organization: 'org_abc123',
+      });
+
+      const [, params] = grantRequest.mock.calls[0]!;
+      expect(params.get('organization')).toBe('org_abc123');
+    });
+
+    test('does not include realm, scope, audience, or organization when not provided', async () => {
       const grantRequest = vi.fn(createMockGrantRequest());
       const client = createClient({ grantRequest });
 
@@ -852,6 +941,7 @@ describe('PasskeyClient', () => {
       expect(params.has('realm')).toBe(false);
       expect(params.has('scope')).toBe(false);
       expect(params.has('audience')).toBe(false);
+      expect(params.has('organization')).toBe(false);
     });
 
     test('returns the TokenResponse from the grantRequest delegate', async () => {
@@ -927,7 +1017,7 @@ describe('PasskeyClient', () => {
       }
     });
 
-    test('uses a descriptive fallback message for the error', async () => {
+    test('preserves the original error message for non-OAuth errors (e.g. network failures)', async () => {
       const grantRequest = vi.fn().mockRejectedValue(new Error('network error'));
       const client = createClient({ grantRequest });
 
@@ -936,7 +1026,22 @@ describe('PasskeyClient', () => {
         expect.fail('Should have thrown');
       } catch (e) {
         const error = e as PasskeyGetTokenError;
+        expect(error.message).toBe('network error');
+        expect(error.cause).toBeUndefined();
+      }
+    });
+
+    test('uses a fallback message when the thrown value is not an Error instance', async () => {
+      const grantRequest = vi.fn().mockRejectedValue('string rejection');
+      const client = createClient({ grantRequest });
+
+      try {
+        await client.getTokenByPasskey({ authSession: 'session', credential: mockCredentialCreation });
+        expect.fail('Should have thrown');
+      } catch (e) {
+        const error = e as PasskeyGetTokenError;
         expect(error.message).toBe('Failed to exchange passkey credential for tokens.');
+        expect(error.cause).toBeUndefined();
       }
     });
 
@@ -955,6 +1060,7 @@ describe('PasskeyClient', () => {
       } catch (e) {
         const error = e as PasskeyGetTokenError;
         expect(error).toBeInstanceOf(PasskeyGetTokenError);
+        expect(error.message).toBe('Authentication session expired');
         expect(error.cause?.error).toBe('invalid_grant');
         expect(error.cause?.error_description).toBe('Authentication session expired');
       }

--- a/packages/auth0-auth-js/src/passkey/passkey-client.spec.ts
+++ b/packages/auth0-auth-js/src/passkey/passkey-client.spec.ts
@@ -1018,7 +1018,7 @@ describe('PasskeyClient', () => {
       }
     });
 
-    test('preserves the original error message for non-OAuth errors (e.g. network failures)', async () => {
+    test('uses fallback message for non-OAuth errors (e.g. network failures)', async () => {
       const grantRequest = vi.fn().mockRejectedValue(new Error('network error'));
       const client = createClient({ grantRequest });
 
@@ -1027,22 +1027,8 @@ describe('PasskeyClient', () => {
         expect.fail('Should have thrown');
       } catch (e) {
         const error = e as PasskeyGetTokenError;
-        expect(error.message).toBe('network error');
-        expect(error.cause).toBeUndefined();
-      }
-    });
-
-    test('uses a fallback message when the thrown value is not an Error instance', async () => {
-      const grantRequest = vi.fn().mockRejectedValue('string rejection');
-      const client = createClient({ grantRequest });
-
-      try {
-        await client.getTokenByPasskey({ authSession: 'session', credential: mockCredentialCreation });
-        expect.fail('Should have thrown');
-      } catch (e) {
-        const error = e as PasskeyGetTokenError;
+        expect(error).toBeInstanceOf(PasskeyGetTokenError);
         expect(error.message).toBe('Failed to exchange passkey credential for tokens.');
-        expect(error.cause).toBeUndefined();
       }
     });
 
@@ -1064,34 +1050,6 @@ describe('PasskeyClient', () => {
         expect(error.message).toBe('Authentication session expired');
         expect(error.cause?.error).toBe('invalid_grant');
         expect(error.cause?.error_description).toBe('Authentication session expired');
-      }
-    });
-
-    test('sets cause to undefined when the thrown error does not have OAuth2Error shape', async () => {
-      const grantRequest = vi.fn().mockRejectedValue(new Error('network timeout'));
-      const client = createClient({ grantRequest });
-
-      try {
-        await client.getTokenByPasskey({ authSession: 'session', credential: mockCredentialCreation });
-        expect.fail('Should have thrown');
-      } catch (e) {
-        const error = e as PasskeyGetTokenError;
-        expect(error).toBeInstanceOf(PasskeyGetTokenError);
-        expect(error.cause).toBeUndefined();
-      }
-    });
-
-    test('sets cause to undefined when the thrown value is null', async () => {
-      const grantRequest = vi.fn().mockRejectedValue(null);
-      const client = createClient({ grantRequest });
-
-      try {
-        await client.getTokenByPasskey({ authSession: 'session', credential: mockCredentialCreation });
-        expect.fail('Should have thrown');
-      } catch (e) {
-        const error = e as PasskeyGetTokenError;
-        expect(error).toBeInstanceOf(PasskeyGetTokenError);
-        expect(error.cause).toBeUndefined();
       }
     });
   });

--- a/packages/auth0-auth-js/src/passkey/passkey-client.spec.ts
+++ b/packages/auth0-auth-js/src/passkey/passkey-client.spec.ts
@@ -1,0 +1,1131 @@
+import { expect, test, describe, beforeAll, afterAll, afterEach, vi } from 'vitest';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import { PasskeyClient } from './passkey-client.js';
+import {
+  PasskeySignupChallengeError,
+  PasskeyLoginChallengeError,
+  PasskeySigninError,
+} from './errors.js';
+import type { GrantRequestFn } from './types.js';
+import { TokenResponse } from '../types.js';
+
+const domain = 'auth0.local';
+const clientId = 'test-client-id';
+
+function createMockTokenResponse(): TokenResponse {
+  const response = new TokenResponse(
+    'eyJ_access_token',
+    Math.floor(Date.now() / 1000) + 86400,
+    'eyJ_id_token',
+    'eyJ_refresh_token'
+  );
+  response.tokenType = 'Bearer';
+  return response;
+}
+
+function createMockGrantRequest(): GrantRequestFn {
+  return async () => createMockTokenResponse();
+}
+
+function createClient(overrides?: { customFetch?: typeof fetch; grantRequest?: GrantRequestFn }) {
+  return new PasskeyClient({
+    domain,
+    clientId,
+    grantRequest: overrides?.grantRequest ?? createMockGrantRequest(),
+    ...(overrides?.customFetch && { customFetch: overrides.customFetch }),
+  });
+}
+
+const mockSignupChallengeResponse = {
+  auth_session: 'eyJ_signup_session',
+  authn_params_public_key: {
+    challenge: 'dGVzdC1jaGFsbGVuZ2U',
+    rp: {
+      id: 'example.auth0.com',
+      name: 'My App',
+    },
+    user: {
+      id: 'dXNlcl8xMjM',
+      name: 'user@example.com',
+      displayName: 'Jane Doe',
+    },
+    pubKeyCredParams: [
+      { type: 'public-key', alg: -8 },
+      { type: 'public-key', alg: -7 },
+      { type: 'public-key', alg: -257 },
+    ],
+    authenticatorSelection: {
+      residentKey: 'required',
+      userVerification: 'preferred',
+    },
+    timeout: 60000,
+  },
+};
+
+const mockSignupChallengeResponseMinimal = {
+  auth_session: 'eyJ_minimal_session',
+  authn_params_public_key: {
+    challenge: 'bWluaW1hbC1jaGFsbGVuZ2U',
+    rp: {
+      id: 'example.auth0.com',
+      name: 'My App',
+    },
+    user: {
+      id: 'dXNlcl8xMjM',
+      name: 'user@example.com',
+      displayName: 'user@example.com',
+    },
+    pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+  },
+};
+
+const mockLoginChallengeResponse = {
+  auth_session: 'eyJ_login_session',
+  authn_params_public_key: {
+    challenge: 'dGVzdC1sb2dpbi1jaGFsbGVuZ2U',
+    rpId: 'example.auth0.com',
+    timeout: 60000,
+    userVerification: 'preferred',
+  },
+};
+
+const mockLoginChallengeResponseMinimal = {
+  auth_session: 'eyJ_login_minimal',
+  authn_params_public_key: {
+    challenge: 'bWluaW1hbC1sb2dpbg',
+    rpId: 'example.auth0.com',
+  },
+};
+
+const mockCredentialCreation = {
+  id: 'credential-id-123',
+  rawId: 'Y3JlZGVudGlhbC1pZC0xMjM',
+  type: 'public-key',
+  authenticatorAttachment: 'platform',
+  response: {
+    clientDataJSON: 'eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIn0',
+    attestationObject: 'o2NmbXRkbm9uZQ',
+  },
+  clientExtensionResults: {},
+};
+
+const mockCredentialAssertion = {
+  id: 'credential-id-456',
+  rawId: 'Y3JlZGVudGlhbC1pZC00NTY',
+  type: 'public-key',
+  authenticatorAttachment: 'platform',
+  response: {
+    clientDataJSON: 'eyJ0eXBlIjoid2ViYXV0aG4uZ2V0In0',
+    authenticatorData: 'dKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvA',
+    signature: 'MEUCIQC-signature-base64url',
+    userHandle: 'dXNlcl8xMjM',
+  },
+  clientExtensionResults: {},
+};
+
+const restHandlers = [
+  http.post(`https://${domain}/passkey/register`, async ({ request }) => {
+    const body = (await request.json()) as { client_id: string };
+
+    if (body.client_id !== clientId) {
+      return HttpResponse.json(
+        { error: 'invalid_client', error_description: 'Invalid client ID' },
+        { status: 401 }
+      );
+    }
+
+    return HttpResponse.json(mockSignupChallengeResponse);
+  }),
+
+  http.post(`https://${domain}/passkey/challenge`, async ({ request }) => {
+    const body = (await request.json()) as { client_id: string };
+
+    if (body.client_id !== clientId) {
+      return HttpResponse.json(
+        { error: 'invalid_client', error_description: 'Invalid client ID' },
+        { status: 401 }
+      );
+    }
+
+    return HttpResponse.json(mockLoginChallengeResponse);
+  }),
+];
+
+const server = setupServer(...restHandlers);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterAll(() => server.close());
+afterEach(() => {
+  server.resetHandlers();
+  vi.clearAllMocks();
+});
+
+describe('PasskeyClient', () => {
+  // ─── Constructor ───────────────────────────────────────────────────
+
+  describe('constructor', () => {
+    test('creates an instance with required options', () => {
+      const client = createClient();
+      expect(client).toBeInstanceOf(PasskeyClient);
+    });
+
+    test('constructs the base URL using https and the provided domain', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.post(`https://${domain}/passkey/challenge`, ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json(mockLoginChallengeResponse);
+        })
+      );
+
+      const client = createClient();
+      await client.loginChallenge();
+
+      expect(capturedUrl).toBe(`https://${domain}/passkey/challenge`);
+    });
+
+    test('uses the provided custom fetch implementation for HTTP requests', async () => {
+      let fetchCalled = false;
+      const customFetch: typeof fetch = async (...args) => {
+        fetchCalled = true;
+        return fetch(...args);
+      };
+
+      const client = createClient({ customFetch });
+      await client.loginChallenge();
+
+      expect(fetchCalled).toBe(true);
+    });
+
+    test('falls back to the global fetch when no custom fetch is provided', async () => {
+      const client = createClient();
+      const result = await client.loginChallenge();
+      expect(result.authSession).toBe('eyJ_login_session');
+    });
+  });
+
+  // ─── signupChallenge ───────────────────────────────────────────────
+
+  describe('signupChallenge', () => {
+    test('accepts email as a valid user identifier', async () => {
+      const client = createClient();
+      const result = await client.signupChallenge({ email: 'user@example.com' });
+      expect(result.authSession).toBeDefined();
+    });
+
+    test('accepts username as a valid user identifier', async () => {
+      const client = createClient();
+      const result = await client.signupChallenge({ username: 'janedoe' });
+      expect(result.authSession).toBeDefined();
+    });
+
+    test('accepts phoneNumber as a valid user identifier', async () => {
+      const client = createClient();
+      const result = await client.signupChallenge({ phoneNumber: '+1234567890' });
+      expect(result.authSession).toBeDefined();
+    });
+
+    test('sends a POST request to /passkey/register', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.post(`https://${domain}/passkey/register`, ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json(mockSignupChallengeResponse);
+        })
+      );
+
+      const client = createClient();
+      await client.signupChallenge({ email: 'user@example.com' });
+
+      expect(capturedUrl).toBe(`https://${domain}/passkey/register`);
+    });
+
+    test('sends the Content-Type: application/json header', async () => {
+      let capturedContentType = '';
+      server.use(
+        http.post(`https://${domain}/passkey/register`, ({ request }) => {
+          capturedContentType = request.headers.get('Content-Type') || '';
+          return HttpResponse.json(mockSignupChallengeResponse);
+        })
+      );
+
+      const client = createClient();
+      await client.signupChallenge({ email: 'user@example.com' });
+
+      expect(capturedContentType).toBe('application/json');
+    });
+
+    test('sends client_id and email wrapped in user_profile in the request body', async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`https://${domain}/passkey/register`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(mockSignupChallengeResponse);
+        })
+      );
+
+      const client = createClient();
+      await client.signupChallenge({ email: 'user@example.com' });
+
+      expect(capturedBody.client_id).toBe(clientId);
+      expect(capturedBody.user_profile).toEqual({ email: 'user@example.com' });
+    });
+
+    test('includes all provided user_profile fields (email, name, phoneNumber, username)', async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`https://${domain}/passkey/register`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(mockSignupChallengeResponse);
+        })
+      );
+
+      const client = createClient();
+      await client.signupChallenge({
+        email: 'user@example.com',
+        name: 'Jane Doe',
+        phoneNumber: '+1234567890',
+        username: 'janedoe',
+      });
+
+      expect(capturedBody.user_profile).toEqual({
+        email: 'user@example.com',
+        name: 'Jane Doe',
+        phone_number: '+1234567890',
+        username: 'janedoe',
+      });
+    });
+
+    test('omits optional user_profile fields that are not provided', async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`https://${domain}/passkey/register`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(mockSignupChallengeResponse);
+        })
+      );
+
+      const client = createClient();
+      await client.signupChallenge({ email: 'user@example.com' });
+
+      const profile = capturedBody.user_profile as Record<string, unknown>;
+      expect(profile.email).toBe('user@example.com');
+      expect(profile).not.toHaveProperty('name');
+      expect(profile).not.toHaveProperty('phone_number');
+      expect(profile).not.toHaveProperty('username');
+    });
+
+    test('includes realm in the request body when provided', async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`https://${domain}/passkey/register`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(mockSignupChallengeResponse);
+        })
+      );
+
+      const client = createClient();
+      await client.signupChallenge({
+        email: 'user@example.com',
+        realm: 'Username-Password-Authentication',
+      });
+
+      expect(capturedBody.realm).toBe('Username-Password-Authentication');
+    });
+
+    test('does not include realm in the request body when not provided', async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`https://${domain}/passkey/register`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(mockSignupChallengeResponse);
+        })
+      );
+
+      const client = createClient();
+      await client.signupChallenge({ email: 'user@example.com' });
+
+      expect(capturedBody).not.toHaveProperty('realm');
+    });
+
+    test('returns transformed response with camelCase authSession and authnParamsPublicKey', async () => {
+      const client = createClient();
+      const result = await client.signupChallenge({ email: 'user@example.com' });
+
+      expect(result.authSession).toBe('eyJ_signup_session');
+      expect(result.authnParamsPublicKey).toEqual({
+        challenge: 'dGVzdC1jaGFsbGVuZ2U',
+        rp: { id: 'example.auth0.com', name: 'My App' },
+        user: { id: 'dXNlcl8xMjM', name: 'user@example.com', displayName: 'Jane Doe' },
+        pubKeyCredParams: [
+          { type: 'public-key', alg: -8 },
+          { type: 'public-key', alg: -7 },
+          { type: 'public-key', alg: -257 },
+        ],
+        authenticatorSelection: { residentKey: 'required', userVerification: 'preferred' },
+        timeout: 60000,
+      });
+    });
+
+    test('handles API response that omits optional fields (authenticatorSelection, timeout)', async () => {
+      server.use(
+        http.post(`https://${domain}/passkey/register`, () => {
+          return HttpResponse.json(mockSignupChallengeResponseMinimal);
+        })
+      );
+
+      const client = createClient();
+      const result = await client.signupChallenge({ email: 'user@example.com' });
+
+      expect(result.authSession).toBe('eyJ_minimal_session');
+      expect(result.authnParamsPublicKey.authenticatorSelection).toBeUndefined();
+      expect(result.authnParamsPublicKey.timeout).toBeUndefined();
+      expect(result.authnParamsPublicKey.challenge).toBe('bWluaW1hbC1jaGFsbGVuZ2U');
+    });
+
+    test('throws PasskeySignupChallengeError when the API returns HTTP 400', async () => {
+      server.use(
+        http.post(`https://${domain}/passkey/register`, () => {
+          return HttpResponse.json(
+            { error: 'invalid_request', error_description: 'Email is required' },
+            { status: 400 }
+          );
+        })
+      );
+
+      const client = createClient();
+      await expect(client.signupChallenge({ email: 'user@example.com' })).rejects.toThrow(PasskeySignupChallengeError);
+    });
+
+    test('throws PasskeySignupChallengeError when passkeys are not enabled (HTTP 403)', async () => {
+      server.use(
+        http.post(`https://${domain}/passkey/register`, () => {
+          return HttpResponse.json(
+            { error: 'forbidden', error_description: 'Passkeys not enabled for connection' },
+            { status: 403 }
+          );
+        })
+      );
+
+      const client = createClient();
+      await expect(client.signupChallenge({ email: 'user@example.com' })).rejects.toThrow(PasskeySignupChallengeError);
+    });
+
+    test('throws PasskeySignupChallengeError when the user already exists (HTTP 409)', async () => {
+      server.use(
+        http.post(`https://${domain}/passkey/register`, () => {
+          return HttpResponse.json(
+            { error: 'user_exists', error_description: 'User already exists' },
+            { status: 409 }
+          );
+        })
+      );
+
+      const client = createClient();
+
+      try {
+        await client.signupChallenge({ email: 'existing@example.com' });
+        expect.fail('Should have thrown');
+      } catch (e) {
+        const error = e as PasskeySignupChallengeError;
+        expect(error).toBeInstanceOf(PasskeySignupChallengeError);
+        expect(error.message).toBe('User already exists');
+        expect(error.cause?.error).toBe('user_exists');
+      }
+    });
+
+    test('uses error_description from the API response as the error message', async () => {
+      server.use(
+        http.post(`https://${domain}/passkey/register`, () => {
+          return HttpResponse.json(
+            { error: 'invalid_request', error_description: 'Custom error message from API' },
+            { status: 400 }
+          );
+        })
+      );
+
+      const client = createClient();
+
+      try {
+        await client.signupChallenge({ email: 'user@example.com' });
+        expect.fail('Should have thrown');
+      } catch (e) {
+        const error = e as PasskeySignupChallengeError;
+        expect(error.message).toBe('Custom error message from API');
+      }
+    });
+
+    test('uses a fallback message when error_description is empty', async () => {
+      server.use(
+        http.post(`https://${domain}/passkey/register`, () => {
+          return HttpResponse.json(
+            { error: 'server_error', error_description: '' },
+            { status: 500 }
+          );
+        })
+      );
+
+      const client = createClient();
+
+      try {
+        await client.signupChallenge({ email: 'user@example.com' });
+        expect.fail('Should have thrown');
+      } catch (e) {
+        const error = e as PasskeySignupChallengeError;
+        expect(error.message).toBe('Failed to request signup challenge');
+      }
+    });
+
+    test('includes the full API error details (error, error_description, message) in the cause', async () => {
+      server.use(
+        http.post(`https://${domain}/passkey/register`, () => {
+          return HttpResponse.json(
+            { error: 'invalid_request', error_description: 'Email is required', message: 'Validation failed' },
+            { status: 400 }
+          );
+        })
+      );
+
+      const client = createClient();
+
+      try {
+        await client.signupChallenge({ email: 'user@example.com' });
+        expect.fail('Should have thrown');
+      } catch (e) {
+        const error = e as PasskeySignupChallengeError;
+        expect(error.code).toBe('passkey_signup_challenge_error');
+        expect(error.name).toBe('PasskeySignupChallengeError');
+        expect(error.cause).toEqual({
+          error: 'invalid_request',
+          error_description: 'Email is required',
+          message: 'Validation failed',
+        });
+      }
+    });
+
+    test('handles non-JSON error response by constructing a fallback error object', async () => {
+      server.use(
+        http.post(`https://${domain}/passkey/register`, () => {
+          return new HttpResponse('Internal Server Error', {
+            status: 500,
+            statusText: 'Internal Server Error',
+            headers: { 'Content-Type': 'text/plain' },
+          });
+        })
+      );
+
+      const client = createClient();
+
+      try {
+        await client.signupChallenge({ email: 'user@example.com' });
+        expect.fail('Should have thrown');
+      } catch (e) {
+        const error = e as PasskeySignupChallengeError;
+        expect(error).toBeInstanceOf(PasskeySignupChallengeError);
+        expect(error.cause?.error).toBe('unknown_error');
+        expect(error.cause?.error_description).toContain('500');
+      }
+    });
+
+    test('does not include name in user_profile when it is an empty string', async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`https://${domain}/passkey/register`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(mockSignupChallengeResponse);
+        })
+      );
+
+      const client = createClient();
+      await client.signupChallenge({ email: 'user@example.com', name: '' });
+
+      const profile = capturedBody.user_profile as Record<string, unknown>;
+      expect(profile).not.toHaveProperty('name');
+    });
+  });
+
+  // ─── loginChallenge ────────────────────────────────────────────────
+
+  describe('loginChallenge', () => {
+    test('sends a POST request to /passkey/challenge', async () => {
+      let capturedUrl = '';
+      server.use(
+        http.post(`https://${domain}/passkey/challenge`, ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json(mockLoginChallengeResponse);
+        })
+      );
+
+      const client = createClient();
+      await client.loginChallenge();
+
+      expect(capturedUrl).toBe(`https://${domain}/passkey/challenge`);
+    });
+
+    test('sends the Content-Type: application/json header', async () => {
+      let capturedContentType = '';
+      server.use(
+        http.post(`https://${domain}/passkey/challenge`, ({ request }) => {
+          capturedContentType = request.headers.get('Content-Type') || '';
+          return HttpResponse.json(mockLoginChallengeResponse);
+        })
+      );
+
+      const client = createClient();
+      await client.loginChallenge();
+
+      expect(capturedContentType).toBe('application/json');
+    });
+
+    test('sends client_id in the request body', async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`https://${domain}/passkey/challenge`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(mockLoginChallengeResponse);
+        })
+      );
+
+      const client = createClient();
+      await client.loginChallenge();
+
+      expect(capturedBody.client_id).toBe(clientId);
+    });
+
+    test('works without any options (options parameter is undefined)', async () => {
+      const client = createClient();
+      const result = await client.loginChallenge();
+
+      expect(result.authSession).toBe('eyJ_login_session');
+      expect(result.authnParamsPublicKey.rpId).toBe('example.auth0.com');
+    });
+
+    test('works with an empty options object', async () => {
+      const client = createClient();
+      const result = await client.loginChallenge({});
+
+      expect(result.authSession).toBe('eyJ_login_session');
+    });
+
+    test('includes realm in the request body when provided', async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`https://${domain}/passkey/challenge`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(mockLoginChallengeResponse);
+        })
+      );
+
+      const client = createClient();
+      await client.loginChallenge({ realm: 'Username-Password-Authentication' });
+
+      expect(capturedBody.realm).toBe('Username-Password-Authentication');
+    });
+
+    test('does not include realm when not provided', async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`https://${domain}/passkey/challenge`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(mockLoginChallengeResponse);
+        })
+      );
+
+      const client = createClient();
+      await client.loginChallenge();
+
+      expect(capturedBody).not.toHaveProperty('realm');
+    });
+
+    test('returns transformed response with camelCase authSession and authnParamsPublicKey', async () => {
+      const client = createClient();
+      const result = await client.loginChallenge();
+
+      expect(result.authSession).toBe('eyJ_login_session');
+      expect(result.authnParamsPublicKey).toEqual({
+        challenge: 'dGVzdC1sb2dpbi1jaGFsbGVuZ2U',
+        rpId: 'example.auth0.com',
+        timeout: 60000,
+        userVerification: 'preferred',
+      });
+    });
+
+    test('handles API response that omits optional fields (timeout, userVerification)', async () => {
+      server.use(
+        http.post(`https://${domain}/passkey/challenge`, () => {
+          return HttpResponse.json(mockLoginChallengeResponseMinimal);
+        })
+      );
+
+      const client = createClient();
+      const result = await client.loginChallenge();
+
+      expect(result.authSession).toBe('eyJ_login_minimal');
+      expect(result.authnParamsPublicKey.challenge).toBe('bWluaW1hbC1sb2dpbg');
+      expect(result.authnParamsPublicKey.rpId).toBe('example.auth0.com');
+      expect(result.authnParamsPublicKey.timeout).toBeUndefined();
+      expect(result.authnParamsPublicKey.userVerification).toBeUndefined();
+    });
+
+    test('throws PasskeyLoginChallengeError when passkeys are not enabled (HTTP 403)', async () => {
+      server.use(
+        http.post(`https://${domain}/passkey/challenge`, () => {
+          return HttpResponse.json(
+            { error: 'forbidden', error_description: 'Passkeys not enabled for this tenant' },
+            { status: 403 }
+          );
+        })
+      );
+
+      const client = createClient();
+      await expect(client.loginChallenge()).rejects.toThrow(PasskeyLoginChallengeError);
+    });
+
+    test('throws PasskeyLoginChallengeError when client is unauthorized (HTTP 401)', async () => {
+      server.use(
+        http.post(`https://${domain}/passkey/challenge`, () => {
+          return HttpResponse.json(
+            { error: 'invalid_client', error_description: 'Unknown client' },
+            { status: 401 }
+          );
+        })
+      );
+
+      const client = createClient();
+      await expect(client.loginChallenge()).rejects.toThrow(PasskeyLoginChallengeError);
+    });
+
+    test('uses error_description from the API response as the error message', async () => {
+      server.use(
+        http.post(`https://${domain}/passkey/challenge`, () => {
+          return HttpResponse.json(
+            { error: 'forbidden', error_description: 'Connection not configured' },
+            { status: 403 }
+          );
+        })
+      );
+
+      const client = createClient();
+
+      try {
+        await client.loginChallenge();
+        expect.fail('Should have thrown');
+      } catch (e) {
+        const error = e as PasskeyLoginChallengeError;
+        expect(error.message).toBe('Connection not configured');
+      }
+    });
+
+    test('uses a fallback message when error_description is empty', async () => {
+      server.use(
+        http.post(`https://${domain}/passkey/challenge`, () => {
+          return HttpResponse.json(
+            { error: 'server_error', error_description: '' },
+            { status: 500 }
+          );
+        })
+      );
+
+      const client = createClient();
+
+      try {
+        await client.loginChallenge();
+        expect.fail('Should have thrown');
+      } catch (e) {
+        const error = e as PasskeyLoginChallengeError;
+        expect(error.message).toBe('Failed to request login challenge');
+      }
+    });
+
+    test('includes the full API error details (error, error_description, message) in the cause', async () => {
+      server.use(
+        http.post(`https://${domain}/passkey/challenge`, () => {
+          return HttpResponse.json(
+            { error: 'forbidden', error_description: 'Not enabled', message: 'Check config' },
+            { status: 403 }
+          );
+        })
+      );
+
+      const client = createClient();
+
+      try {
+        await client.loginChallenge();
+        expect.fail('Should have thrown');
+      } catch (e) {
+        const error = e as PasskeyLoginChallengeError;
+        expect(error.code).toBe('passkey_login_challenge_error');
+        expect(error.name).toBe('PasskeyLoginChallengeError');
+        expect(error.cause).toEqual({
+          error: 'forbidden',
+          error_description: 'Not enabled',
+          message: 'Check config',
+        });
+      }
+    });
+
+    test('handles non-JSON error response by constructing a fallback error object', async () => {
+      server.use(
+        http.post(`https://${domain}/passkey/challenge`, () => {
+          return new HttpResponse('Bad Gateway', {
+            status: 502,
+            statusText: 'Bad Gateway',
+            headers: { 'Content-Type': 'text/plain' },
+          });
+        })
+      );
+
+      const client = createClient();
+
+      try {
+        await client.loginChallenge();
+        expect.fail('Should have thrown');
+      } catch (e) {
+        const error = e as PasskeyLoginChallengeError;
+        expect(error).toBeInstanceOf(PasskeyLoginChallengeError);
+        expect(error.cause?.error).toBe('unknown_error');
+        expect(error.cause?.error_description).toContain('502');
+      }
+    });
+  });
+
+  // ─── signinWithPasskey ─────────────────────────────────────────────
+
+  describe('signinWithPasskey', () => {
+    test('calls the grantRequest delegate with the webauthn grant type', async () => {
+      const grantRequest = vi.fn(createMockGrantRequest());
+      const client = createClient({ grantRequest });
+
+      await client.signinWithPasskey({
+        authSession: 'eyJ_session',
+        credential: mockCredentialCreation,
+      });
+
+      expect(grantRequest).toHaveBeenCalledTimes(1);
+      const [grantType] = grantRequest.mock.calls[0]!;
+      expect(grantType).toBe('urn:okta:params:oauth:grant-type:webauthn');
+    });
+
+    test('passes auth_session and JSON-serialized credential as form params', async () => {
+      const grantRequest = vi.fn(createMockGrantRequest());
+      const client = createClient({ grantRequest });
+
+      await client.signinWithPasskey({
+        authSession: 'eyJ_session',
+        credential: mockCredentialCreation,
+      });
+
+      const [, params] = grantRequest.mock.calls[0]!;
+      expect(params.get('auth_session')).toBe('eyJ_session');
+      expect(params.get('authn_response')).toBe(JSON.stringify(mockCredentialCreation));
+    });
+
+    test('includes realm, scope, and audience params when provided', async () => {
+      const grantRequest = vi.fn(createMockGrantRequest());
+      const client = createClient({ grantRequest });
+
+      await client.signinWithPasskey({
+        authSession: 'eyJ_session',
+        credential: mockCredentialCreation,
+        realm: 'Username-Password-Authentication',
+        scope: 'openid profile email',
+        audience: 'https://api.example.com',
+      });
+
+      const [, params] = grantRequest.mock.calls[0]!;
+      expect(params.get('realm')).toBe('Username-Password-Authentication');
+      expect(params.get('scope')).toBe('openid profile email');
+      expect(params.get('audience')).toBe('https://api.example.com');
+    });
+
+    test('does not include realm, scope, or audience when not provided', async () => {
+      const grantRequest = vi.fn(createMockGrantRequest());
+      const client = createClient({ grantRequest });
+
+      await client.signinWithPasskey({
+        authSession: 'eyJ_session',
+        credential: mockCredentialCreation,
+      });
+
+      const [, params] = grantRequest.mock.calls[0]!;
+      expect(params.has('realm')).toBe(false);
+      expect(params.has('scope')).toBe(false);
+      expect(params.has('audience')).toBe(false);
+    });
+
+    test('returns the TokenResponse from the grantRequest delegate', async () => {
+      const client = createClient();
+      const result = await client.signinWithPasskey({
+        authSession: 'eyJ_session',
+        credential: mockCredentialCreation,
+      });
+
+      expect(result.accessToken).toBe('eyJ_access_token');
+      expect(result.idToken).toBe('eyJ_id_token');
+      expect(result.refreshToken).toBe('eyJ_refresh_token');
+      expect(result.tokenType).toBe('Bearer');
+    });
+
+    test('works with an assertion credential (login flow with authenticatorData and signature)', async () => {
+      const grantRequest = vi.fn(createMockGrantRequest());
+      const client = createClient({ grantRequest });
+
+      await client.signinWithPasskey({
+        authSession: 'eyJ_session',
+        credential: mockCredentialAssertion,
+      });
+
+      const [, params] = grantRequest.mock.calls[0]!;
+      expect(params.get('authn_response')).toBe(JSON.stringify(mockCredentialAssertion));
+    });
+
+    test('works with a minimal credential that only has required response fields', async () => {
+      const grantRequest = vi.fn(createMockGrantRequest());
+      const client = createClient({ grantRequest });
+
+      const minimalCredential = {
+        id: 'cred-id',
+        rawId: 'base64url-raw-id',
+        type: 'public-key',
+        response: {
+          clientDataJSON: 'base64url-client-data',
+          authenticatorData: 'base64url-auth-data',
+          signature: 'base64url-signature',
+        },
+      };
+
+      await client.signinWithPasskey({
+        authSession: 'session',
+        credential: minimalCredential,
+      });
+
+      const [, params] = grantRequest.mock.calls[0]!;
+      expect(params.get('authn_response')).toBe(JSON.stringify(minimalCredential));
+    });
+
+    test('throws PasskeySigninError when the grantRequest delegate rejects', async () => {
+      const grantRequest = vi.fn().mockRejectedValue(new Error('token exchange failed'));
+      const client = createClient({ grantRequest });
+
+      await expect(
+        client.signinWithPasskey({ authSession: 'invalid', credential: mockCredentialCreation })
+      ).rejects.toThrow(PasskeySigninError);
+    });
+
+    test('sets the error code to passkey_signin_error', async () => {
+      const grantRequest = vi.fn().mockRejectedValue(new Error('expired'));
+      const client = createClient({ grantRequest });
+
+      try {
+        await client.signinWithPasskey({ authSession: 'expired', credential: mockCredentialCreation });
+        expect.fail('Should have thrown');
+      } catch (e) {
+        const error = e as PasskeySigninError;
+        expect(error.code).toBe('passkey_signin_error');
+        expect(error.name).toBe('PasskeySigninError');
+      }
+    });
+
+    test('uses a descriptive fallback message for the error', async () => {
+      const grantRequest = vi.fn().mockRejectedValue(new Error('network error'));
+      const client = createClient({ grantRequest });
+
+      try {
+        await client.signinWithPasskey({ authSession: 'session', credential: mockCredentialCreation });
+        expect.fail('Should have thrown');
+      } catch (e) {
+        const error = e as PasskeySigninError;
+        expect(error.message).toBe('Failed to exchange passkey credential for tokens.');
+      }
+    });
+
+    test('preserves OAuth2Error details (error, error_description) in the error cause', async () => {
+      const oauth2Error = {
+        error: 'invalid_grant',
+        error_description: 'Authentication session expired',
+        message: 'The auth_session has expired',
+      };
+      const grantRequest = vi.fn().mockRejectedValue(oauth2Error);
+      const client = createClient({ grantRequest });
+
+      try {
+        await client.signinWithPasskey({ authSession: 'expired', credential: mockCredentialCreation });
+        expect.fail('Should have thrown');
+      } catch (e) {
+        const error = e as PasskeySigninError;
+        expect(error).toBeInstanceOf(PasskeySigninError);
+        expect(error.cause?.error).toBe('invalid_grant');
+        expect(error.cause?.error_description).toBe('Authentication session expired');
+      }
+    });
+
+    test('sets cause to undefined when the thrown error does not have OAuth2Error shape', async () => {
+      const grantRequest = vi.fn().mockRejectedValue(new Error('network timeout'));
+      const client = createClient({ grantRequest });
+
+      try {
+        await client.signinWithPasskey({ authSession: 'session', credential: mockCredentialCreation });
+        expect.fail('Should have thrown');
+      } catch (e) {
+        const error = e as PasskeySigninError;
+        expect(error).toBeInstanceOf(PasskeySigninError);
+        expect(error.cause).toBeUndefined();
+      }
+    });
+
+    test('sets cause to undefined when the thrown value is null', async () => {
+      const grantRequest = vi.fn().mockRejectedValue(null);
+      const client = createClient({ grantRequest });
+
+      try {
+        await client.signinWithPasskey({ authSession: 'session', credential: mockCredentialCreation });
+        expect.fail('Should have thrown');
+      } catch (e) {
+        const error = e as PasskeySigninError;
+        expect(error).toBeInstanceOf(PasskeySigninError);
+        expect(error.cause).toBeUndefined();
+      }
+    });
+  });
+
+  // ─── customFetch ───────────────────────────────────────────────────
+
+  describe('customFetch', () => {
+    test('uses custom fetch for signupChallenge requests', async () => {
+      let fetchCalled = false;
+      const customFetch: typeof fetch = async (...args) => {
+        fetchCalled = true;
+        return fetch(...args);
+      };
+
+      const client = createClient({ customFetch });
+      await client.signupChallenge({ email: 'user@example.com' });
+
+      expect(fetchCalled).toBe(true);
+    });
+
+    test('uses custom fetch for loginChallenge requests', async () => {
+      let fetchCalled = false;
+      const customFetch: typeof fetch = async (...args) => {
+        fetchCalled = true;
+        return fetch(...args);
+      };
+
+      const client = createClient({ customFetch });
+      await client.loginChallenge();
+
+      expect(fetchCalled).toBe(true);
+    });
+
+    test('passes the correct URL, method, headers, and body to custom fetch', async () => {
+      let capturedArgs: [RequestInfo | URL, RequestInit | undefined] | null = null;
+      const customFetch: typeof fetch = async (input, init) => {
+        capturedArgs = [input, init];
+        return fetch(input, init);
+      };
+
+      const client = createClient({ customFetch });
+      await client.loginChallenge({ realm: 'my-connection' });
+
+      expect(capturedArgs).not.toBeNull();
+      expect(capturedArgs![0]).toBe(`https://${domain}/passkey/challenge`);
+      expect(capturedArgs![1]?.method).toBe('POST');
+      expect(capturedArgs![1]?.headers).toEqual({ 'Content-Type': 'application/json' });
+
+      const body = JSON.parse(capturedArgs![1]?.body as string);
+      expect(body.client_id).toBe(clientId);
+      expect(body.realm).toBe('my-connection');
+    });
+  });
+
+  // ─── Error class behavior ─────────────────────────────────────────
+
+  describe('error classes', () => {
+    test('PasskeySignupChallengeError extends Error', async () => {
+      server.use(
+        http.post(`https://${domain}/passkey/register`, () => {
+          return HttpResponse.json(
+            { error: 'test', error_description: 'test error' },
+            { status: 400 }
+          );
+        })
+      );
+
+      const client = createClient();
+
+      try {
+        await client.signupChallenge({ email: 'user@example.com' });
+        expect.fail('Should have thrown');
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e).toBeInstanceOf(PasskeySignupChallengeError);
+      }
+    });
+
+    test('PasskeyLoginChallengeError extends Error', async () => {
+      server.use(
+        http.post(`https://${domain}/passkey/challenge`, () => {
+          return HttpResponse.json(
+            { error: 'test', error_description: 'test error' },
+            { status: 400 }
+          );
+        })
+      );
+
+      const client = createClient();
+
+      try {
+        await client.loginChallenge();
+        expect.fail('Should have thrown');
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e).toBeInstanceOf(PasskeyLoginChallengeError);
+      }
+    });
+
+    test('PasskeySigninError extends Error', async () => {
+      const grantRequest = vi.fn().mockRejectedValue(new Error('fail'));
+      const client = createClient({ grantRequest });
+
+      try {
+        await client.signinWithPasskey({ authSession: 'session', credential: mockCredentialCreation });
+        expect.fail('Should have thrown');
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e).toBeInstanceOf(PasskeySigninError);
+      }
+    });
+
+    test('error cause only includes known fields from the API response (no extra fields)', async () => {
+      server.use(
+        http.post(`https://${domain}/passkey/register`, () => {
+          return HttpResponse.json(
+            {
+              error: 'invalid_request',
+              error_description: 'Bad request',
+              message: 'Detailed message',
+              extra_field: 'should not appear',
+            },
+            { status: 400 }
+          );
+        })
+      );
+
+      const client = createClient();
+
+      try {
+        await client.signupChallenge({ email: 'user@example.com' });
+        expect.fail('Should have thrown');
+      } catch (e) {
+        const error = e as PasskeySignupChallengeError;
+        expect(error.cause).toEqual({
+          error: 'invalid_request',
+          error_description: 'Bad request',
+          message: 'Detailed message',
+        });
+        expect(error.cause).not.toHaveProperty('extra_field');
+      }
+    });
+  });
+});

--- a/packages/auth0-auth-js/src/passkey/passkey-client.spec.ts
+++ b/packages/auth0-auth-js/src/passkey/passkey-client.spec.ts
@@ -391,7 +391,8 @@ describe('PasskeyClient', () => {
       expect(profile.family_name).toBe('Doe');
       expect(profile.nickname).toBe('janey');
       expect(profile.picture).toBe('https://example.com/photo.jpg');
-      expect(profile.user_metadata).toEqual({ preferred_language: 'en' });
+      expect(profile).not.toHaveProperty('user_metadata');
+      expect(capturedBody.user_metadata).toEqual({ preferred_language: 'en' });
     });
 
     test('returns transformed response with camelCase authSession and authnParamsPublicKey', async () => {

--- a/packages/auth0-auth-js/src/passkey/passkey-client.ts
+++ b/packages/auth0-auth-js/src/passkey/passkey-client.ts
@@ -6,14 +6,14 @@ import type {
   PasskeyLoginChallengeOptions,
   PasskeyLoginChallengeResponse,
   PasskeyLoginChallengeApiResponse,
-  SigninWithPasskeyOptions,
+  GetTokenByPasskeyOptions,
   GrantRequestFn,
 } from './types.js';
 import type { TokenResponse } from '../types.js';
 import {
-  PasskeySignupChallengeError,
-  PasskeyLoginChallengeError,
-  PasskeySigninError,
+  PasskeyRegisterError,
+  PasskeyChallengeError,
+  PasskeyGetTokenError,
   type PasskeyApiErrorResponse,
 } from './errors.js';
 import {
@@ -59,18 +59,18 @@ export class PasskeyClient {
    *
    * @param options - User profile data and optional realm
    * @returns Promise resolving to the signup challenge with auth session and public key creation options
-   * @throws {PasskeySignupChallengeError} When the challenge request fails
+   * @throws {PasskeyRegisterError} When the challenge request fails
    *
    * @example
    * ```typescript
-   * const challenge = await authClient.passkey.signupChallenge({
+   * const challenge = await authClient.passkey.register({
    *   email: 'user@example.com',
    *   name: 'Jane Doe',
    *   realm: 'Username-Password-Authentication'
    * });
    * ```
    */
-  async signupChallenge(options: PasskeySignupChallengeOptions): Promise<PasskeySignupChallengeResponse> {
+  async register(options: PasskeySignupChallengeOptions): Promise<PasskeySignupChallengeResponse> {
     const url = `${this.#baseUrl}/passkey/register`;
 
     const body: Record<string, unknown> = {
@@ -93,7 +93,7 @@ export class PasskeyClient {
 
     if (!response.ok) {
       const error = await this.#parseErrorResponse(response);
-      throw new PasskeySignupChallengeError(error.error_description || 'Failed to request signup challenge', error);
+      throw new PasskeyRegisterError(error.error_description || 'Failed to request signup challenge', error);
     }
 
     const apiResponse = (await response.json()) as PasskeySignupChallengeApiResponse;
@@ -109,16 +109,16 @@ export class PasskeyClient {
    *
    * @param options - Optional realm configuration
    * @returns Promise resolving to the login challenge with auth session and public key request options
-   * @throws {PasskeyLoginChallengeError} When the challenge request fails
+   * @throws {PasskeyChallengeError} When the challenge request fails
    *
    * @example
    * ```typescript
-   * const challenge = await authClient.passkey.loginChallenge({
+   * const challenge = await authClient.passkey.challenge({
    *   realm: 'Username-Password-Authentication'
    * });
    * ```
    */
-  async loginChallenge(options?: PasskeyLoginChallengeOptions): Promise<PasskeyLoginChallengeResponse> {
+  async challenge(options?: PasskeyLoginChallengeOptions): Promise<PasskeyLoginChallengeResponse> {
     const url = `${this.#baseUrl}/passkey/challenge`;
 
     const body: Record<string, unknown> = {
@@ -135,7 +135,7 @@ export class PasskeyClient {
 
     if (!response.ok) {
       const error = await this.#parseErrorResponse(response);
-      throw new PasskeyLoginChallengeError(error.error_description || 'Failed to request login challenge', error);
+      throw new PasskeyChallengeError(error.error_description || 'Failed to request login challenge', error);
     }
 
     const apiResponse = (await response.json()) as PasskeyLoginChallengeApiResponse;
@@ -148,18 +148,18 @@ export class PasskeyClient {
    * This method should be called after obtaining a credential response from the
    * platform's WebAuthn API (via `navigator.credentials.create()` for signup or
    * `navigator.credentials.get()` for login), using the challenge obtained from
-   * `signupChallenge()` or `loginChallenge()`.
+   * `register()` or `challenge()`.
    *
    * @param options - The auth session and serialized credential response
    * @returns Promise resolving to a TokenResponse with access token, ID token, and optional refresh token
-   * @throws {PasskeySigninError} When the token exchange fails
+   * @throws {PasskeyGetTokenError} When the token exchange fails
    *
    * @example
    * ```typescript
-   * const challenge = await authClient.passkey.loginChallenge();
+   * const challenge = await authClient.passkey.challenge();
    * // Pass challenge.authnParamsPublicKey to navigator.credentials.get()
    * // Then serialize the credential response and exchange for tokens:
-   * const tokens = await authClient.passkey.signinWithPasskey({
+   * const tokens = await authClient.passkey.getTokenByPasskey({
    *   authSession: challenge.authSession,
    *   credential: serializedCredential,
    *   scope: 'openid profile email',
@@ -167,7 +167,7 @@ export class PasskeyClient {
    * });
    * ```
    */
-  async signinWithPasskey(options: SigninWithPasskeyOptions): Promise<TokenResponse> {
+  async getTokenByPasskey(options: GetTokenByPasskeyOptions): Promise<TokenResponse> {
     const params = new URLSearchParams({
       auth_session: options.authSession,
       authn_response: JSON.stringify(options.credential),
@@ -183,7 +183,7 @@ export class PasskeyClient {
       const cause = (e && typeof e === 'object' && 'error' in e && 'error_description' in e)
         ? e as PasskeyApiErrorResponse
         : undefined;
-      throw new PasskeySigninError('Failed to exchange passkey credential for tokens.', cause);
+      throw new PasskeyGetTokenError('Failed to exchange passkey credential for tokens.', cause);
     }
   }
 }

--- a/packages/auth0-auth-js/src/passkey/passkey-client.ts
+++ b/packages/auth0-auth-js/src/passkey/passkey-client.ts
@@ -73,17 +73,25 @@ export class PasskeyClient {
   async register(options: PasskeySignupChallengeOptions): Promise<PasskeySignupChallengeResponse> {
     const url = `${this.#baseUrl}/passkey/register`;
 
+    const userProfile: Record<string, unknown> = {
+      ...(options.email && { email: options.email }),
+      ...(options.name && { name: options.name }),
+      ...(options.phoneNumber && { phone_number: options.phoneNumber }),
+      ...(options.username && { username: options.username }),
+      ...(options.givenName && { given_name: options.givenName }),
+      ...(options.familyName && { family_name: options.familyName }),
+      ...(options.nickname && { nickname: options.nickname }),
+      ...(options.picture && { picture: options.picture }),
+      ...(options.userMetadata && { user_metadata: options.userMetadata }),
+    };
+
     const body: Record<string, unknown> = {
       client_id: this.#clientId,
-      user_profile: {
-        ...(options.email && { email: options.email }),
-        ...(options.name && { name: options.name }),
-        ...(options.phoneNumber && { phone_number: options.phoneNumber }),
-        ...(options.username && { username: options.username }),
-      },
+      user_profile: userProfile,
     };
 
     if (options.realm) body.realm = options.realm;
+    if (options.organization) body.organization = options.organization;
 
     const response = await this.#customFetch(url, {
       method: 'POST',
@@ -126,6 +134,7 @@ export class PasskeyClient {
     };
 
     if (options?.realm) body.realm = options.realm;
+    if (options?.organization) body.organization = options.organization;
 
     const response = await this.#customFetch(url, {
       method: 'POST',
@@ -176,14 +185,19 @@ export class PasskeyClient {
     if (options.realm) params.append('realm', options.realm);
     if (options.scope) params.append('scope', options.scope);
     if (options.audience) params.append('audience', options.audience);
+    if (options.organization) params.append('organization', options.organization);
 
     try {
       return await this.#grantRequest(PASSKEY_GRANT_TYPE, params);
     } catch (e) {
-      const cause = (e && typeof e === 'object' && 'error' in e && 'error_description' in e)
-        ? e as PasskeyApiErrorResponse
-        : undefined;
-      throw new PasskeyGetTokenError('Failed to exchange passkey credential for tokens.', cause);
+      if (e && typeof e === 'object' && 'error' in e && 'error_description' in e) {
+        throw new PasskeyGetTokenError(
+          (e as PasskeyApiErrorResponse).error_description || 'Failed to exchange passkey credential for tokens.',
+          e as PasskeyApiErrorResponse,
+        );
+      }
+      const message = e instanceof Error ? e.message : 'Failed to exchange passkey credential for tokens.';
+      throw new PasskeyGetTokenError(message);
     }
   }
 }

--- a/packages/auth0-auth-js/src/passkey/passkey-client.ts
+++ b/packages/auth0-auth-js/src/passkey/passkey-client.ts
@@ -1,0 +1,189 @@
+import type {
+  PasskeyClientOptions,
+  PasskeySignupChallengeOptions,
+  PasskeySignupChallengeResponse,
+  PasskeySignupChallengeApiResponse,
+  PasskeyLoginChallengeOptions,
+  PasskeyLoginChallengeResponse,
+  PasskeyLoginChallengeApiResponse,
+  SigninWithPasskeyOptions,
+  GrantRequestFn,
+} from './types.js';
+import type { TokenResponse } from '../types.js';
+import {
+  PasskeySignupChallengeError,
+  PasskeyLoginChallengeError,
+  PasskeySigninError,
+  type PasskeyApiErrorResponse,
+} from './errors.js';
+import {
+  transformSignupChallengeResponse,
+  transformLoginChallengeResponse,
+} from './utils.js';
+
+const PASSKEY_GRANT_TYPE = 'urn:okta:params:oauth:grant-type:webauthn';
+
+export class PasskeyClient {
+  #baseUrl: string;
+  #clientId: string;
+  #customFetch: typeof fetch;
+  #grantRequest: GrantRequestFn;
+
+  /**
+   * @internal
+   */
+  constructor(options: PasskeyClientOptions) {
+    this.#baseUrl = `https://${options.domain}`;
+    this.#clientId = options.clientId;
+    this.#customFetch = options.customFetch ?? ((...args) => fetch(...args));
+    this.#grantRequest = options.grantRequest;
+  }
+
+  async #parseErrorResponse(response: Response): Promise<PasskeyApiErrorResponse> {
+    try {
+      return (await response.json()) as PasskeyApiErrorResponse;
+    } catch {
+      return {
+        error: 'unknown_error',
+        error_description: `HTTP ${response.status} ${response.statusText}`,
+      };
+    }
+  }
+
+  /**
+   * Requests a passkey signup challenge for a new user.
+   *
+   * Returns the WebAuthn public key creation options that should be passed to
+   * the platform's credential manager (e.g., `navigator.credentials.create()`)
+   * to register a new passkey.
+   *
+   * @param options - User profile data and optional realm
+   * @returns Promise resolving to the signup challenge with auth session and public key creation options
+   * @throws {PasskeySignupChallengeError} When the challenge request fails
+   *
+   * @example
+   * ```typescript
+   * const challenge = await authClient.passkey.signupChallenge({
+   *   email: 'user@example.com',
+   *   name: 'Jane Doe',
+   *   realm: 'Username-Password-Authentication'
+   * });
+   * ```
+   */
+  async signupChallenge(options: PasskeySignupChallengeOptions): Promise<PasskeySignupChallengeResponse> {
+    const url = `${this.#baseUrl}/passkey/register`;
+
+    const body: Record<string, unknown> = {
+      client_id: this.#clientId,
+      user_profile: {
+        ...(options.email && { email: options.email }),
+        ...(options.name && { name: options.name }),
+        ...(options.phoneNumber && { phone_number: options.phoneNumber }),
+        ...(options.username && { username: options.username }),
+      },
+    };
+
+    if (options.realm) body.realm = options.realm;
+
+    const response = await this.#customFetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const error = await this.#parseErrorResponse(response);
+      throw new PasskeySignupChallengeError(error.error_description || 'Failed to request signup challenge', error);
+    }
+
+    const apiResponse = (await response.json()) as PasskeySignupChallengeApiResponse;
+    return transformSignupChallengeResponse(apiResponse);
+  }
+
+  /**
+   * Requests a passkey login challenge for an existing user.
+   *
+   * Returns the WebAuthn public key request options that should be passed to
+   * the platform's credential manager (e.g., `navigator.credentials.get()`)
+   * to retrieve an existing passkey.
+   *
+   * @param options - Optional realm configuration
+   * @returns Promise resolving to the login challenge with auth session and public key request options
+   * @throws {PasskeyLoginChallengeError} When the challenge request fails
+   *
+   * @example
+   * ```typescript
+   * const challenge = await authClient.passkey.loginChallenge({
+   *   realm: 'Username-Password-Authentication'
+   * });
+   * ```
+   */
+  async loginChallenge(options?: PasskeyLoginChallengeOptions): Promise<PasskeyLoginChallengeResponse> {
+    const url = `${this.#baseUrl}/passkey/challenge`;
+
+    const body: Record<string, unknown> = {
+      client_id: this.#clientId,
+    };
+
+    if (options?.realm) body.realm = options.realm;
+
+    const response = await this.#customFetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const error = await this.#parseErrorResponse(response);
+      throw new PasskeyLoginChallengeError(error.error_description || 'Failed to request login challenge', error);
+    }
+
+    const apiResponse = (await response.json()) as PasskeyLoginChallengeApiResponse;
+    return transformLoginChallengeResponse(apiResponse);
+  }
+
+  /**
+   * Exchanges a passkey credential for tokens using the WebAuthn grant type.
+   *
+   * This method should be called after obtaining a credential response from the
+   * platform's WebAuthn API (via `navigator.credentials.create()` for signup or
+   * `navigator.credentials.get()` for login), using the challenge obtained from
+   * `signupChallenge()` or `loginChallenge()`.
+   *
+   * @param options - The auth session and serialized credential response
+   * @returns Promise resolving to a TokenResponse with access token, ID token, and optional refresh token
+   * @throws {PasskeySigninError} When the token exchange fails
+   *
+   * @example
+   * ```typescript
+   * const challenge = await authClient.passkey.loginChallenge();
+   * // Pass challenge.authnParamsPublicKey to navigator.credentials.get()
+   * // Then serialize the credential response and exchange for tokens:
+   * const tokens = await authClient.passkey.signinWithPasskey({
+   *   authSession: challenge.authSession,
+   *   credential: serializedCredential,
+   *   scope: 'openid profile email',
+   *   audience: 'https://api.example.com',
+   * });
+   * ```
+   */
+  async signinWithPasskey(options: SigninWithPasskeyOptions): Promise<TokenResponse> {
+    const params = new URLSearchParams({
+      auth_session: options.authSession,
+      authn_response: JSON.stringify(options.credential),
+    });
+
+    if (options.realm) params.append('realm', options.realm);
+    if (options.scope) params.append('scope', options.scope);
+    if (options.audience) params.append('audience', options.audience);
+
+    try {
+      return await this.#grantRequest(PASSKEY_GRANT_TYPE, params);
+    } catch (e) {
+      const cause = (e && typeof e === 'object' && 'error' in e && 'error_description' in e)
+        ? e as PasskeyApiErrorResponse
+        : undefined;
+      throw new PasskeySigninError('Failed to exchange passkey credential for tokens.', cause);
+    }
+  }
+}

--- a/packages/auth0-auth-js/src/passkey/passkey-client.ts
+++ b/packages/auth0-auth-js/src/passkey/passkey-client.ts
@@ -190,14 +190,10 @@ export class PasskeyClient {
     try {
       return await this.#grantRequest(PASSKEY_GRANT_TYPE, params);
     } catch (e) {
-      if (e && typeof e === 'object' && 'error' in e && 'error_description' in e) {
-        throw new PasskeyGetTokenError(
-          (e as PasskeyApiErrorResponse).error_description || 'Failed to exchange passkey credential for tokens.',
-          e as PasskeyApiErrorResponse,
-        );
-      }
-      const message = e instanceof Error ? e.message : 'Failed to exchange passkey credential for tokens.';
-      throw new PasskeyGetTokenError(message);
+      throw new PasskeyGetTokenError(
+        (e as PasskeyApiErrorResponse).error_description || 'Failed to exchange passkey credential for tokens.',
+        e as PasskeyApiErrorResponse,
+      );
     }
   }
 }

--- a/packages/auth0-auth-js/src/passkey/passkey-client.ts
+++ b/packages/auth0-auth-js/src/passkey/passkey-client.ts
@@ -82,7 +82,6 @@ export class PasskeyClient {
       ...(options.familyName && { family_name: options.familyName }),
       ...(options.nickname && { nickname: options.nickname }),
       ...(options.picture && { picture: options.picture }),
-      ...(options.userMetadata && { user_metadata: options.userMetadata }),
     };
 
     const body: Record<string, unknown> = {
@@ -92,6 +91,7 @@ export class PasskeyClient {
 
     if (options.realm) body.realm = options.realm;
     if (options.organization) body.organization = options.organization;
+    if (options.userMetadata) body.user_metadata = options.userMetadata;
 
     const response = await this.#customFetch(url, {
       method: 'POST',

--- a/packages/auth0-auth-js/src/passkey/types.ts
+++ b/packages/auth0-auth-js/src/passkey/types.ts
@@ -105,7 +105,7 @@ interface PasskeySignupChallengeBaseOptions {
   /** URL to the user's profile picture */
   picture?: string;
   /** Arbitrary user metadata (stored in `user_metadata` on the Auth0 user) */
-  userMetadata?: Record<string, unknown>;
+  userMetadata?: Record<string, string>;
   /** Database connection name (sent as `realm` to the API) */
   realm?: string;
   /** Organization ID or name to associate the user with */

--- a/packages/auth0-auth-js/src/passkey/types.ts
+++ b/packages/auth0-auth-js/src/passkey/types.ts
@@ -60,11 +60,6 @@ export interface PasskeyRequestOptions {
   rpId: string;
   timeout?: number;
   userVerification?: string;
-  allowCredentials?: Array<{
-    id: string;
-    type: string;
-    transports?: string[];
-  }>;
 }
 
 /**
@@ -200,10 +195,5 @@ export interface PasskeyLoginChallengeApiResponse {
     rpId: string;
     timeout?: number;
     userVerification?: string;
-    allowCredentials?: Array<{
-      id: string;
-      type: string;
-      transports?: string[];
-    }>;
   };
 }

--- a/packages/auth0-auth-js/src/passkey/types.ts
+++ b/packages/auth0-auth-js/src/passkey/types.ts
@@ -60,6 +60,11 @@ export interface PasskeyRequestOptions {
   rpId: string;
   timeout?: number;
   userVerification?: string;
+  allowCredentials?: Array<{
+    id: string;
+    type: string;
+    transports?: string[];
+  }>;
 }
 
 /**
@@ -179,5 +184,10 @@ export interface PasskeyLoginChallengeApiResponse {
     rpId: string;
     timeout?: number;
     userVerification?: string;
+    allowCredentials?: Array<{
+      id: string;
+      type: string;
+      transports?: string[];
+    }>;
   };
 }

--- a/packages/auth0-auth-js/src/passkey/types.ts
+++ b/packages/auth0-auth-js/src/passkey/types.ts
@@ -1,0 +1,183 @@
+import type { TokenResponse } from '../types.js';
+
+/**
+ * Function signature for performing an OAuth grant request and returning a typed TokenResponse.
+ * Injected by AuthClient to allow PasskeyClient to exchange credentials for tokens
+ * via the token endpoint with proper client authentication and DPoP support.
+ * @internal
+ */
+export type GrantRequestFn = (grantType: string, params: URLSearchParams) => Promise<TokenResponse>;
+
+/**
+ * Configuration options for the Passkey client.
+ */
+export interface PasskeyClientOptions {
+  /**
+   * The Auth0 domain to use for passkey operations.
+   * @example 'example.auth0.com' (without https://)
+   */
+  domain: string;
+  /**
+   * The client ID of the application.
+   */
+  clientId: string;
+  /**
+   * Optional, custom Fetch implementation to use.
+   */
+  customFetch?: typeof fetch;
+  /**
+   * Delegate function for performing OAuth grant requests via the token endpoint.
+   * Provided by AuthClient to enable proper client authentication and DPoP support.
+   * @internal
+   */
+  grantRequest: GrantRequestFn;
+}
+
+// ---------------------------------------------------------------------------
+// Shared WebAuthn types
+// ---------------------------------------------------------------------------
+
+/**
+ * Public key credential creation options returned by signup challenges.
+ */
+export interface PasskeyCreationOptions {
+  challenge: string;
+  rp: { id: string; name: string };
+  user: { id: string; name: string; displayName: string };
+  pubKeyCredParams: Array<{ type: string; alg: number }>;
+  authenticatorSelection?: {
+    residentKey?: string;
+    userVerification?: string;
+  };
+  timeout?: number;
+}
+
+/**
+ * Public key credential request options returned by login challenges.
+ */
+export interface PasskeyRequestOptions {
+  challenge: string;
+  rpId: string;
+  timeout?: number;
+  userVerification?: string;
+}
+
+/**
+ * Serialized credential response from the platform WebAuthn API.
+ * All binary fields (rawId, clientDataJSON, etc.) must be base64url-encoded strings.
+ */
+export interface PasskeyCredentialResponse {
+  id: string;
+  rawId: string;
+  type: string;
+  authenticatorAttachment?: string;
+  response: {
+    clientDataJSON: string;
+    attestationObject?: string;
+    authenticatorData?: string;
+    signature?: string;
+    userHandle?: string;
+  };
+  clientExtensionResults?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Authentication (Login & Signup) types
+// ---------------------------------------------------------------------------
+
+/**
+ * Base fields shared by all signup challenge option variants.
+ */
+interface PasskeySignupChallengeBaseOptions {
+  /** Display name for the user (optional) */
+  name?: string;
+  /** Database connection name (sent as `realm` to the API) */
+  realm?: string;
+}
+
+/**
+ * Options for requesting a passkey signup challenge.
+ *
+ * At least one user identifier (`email`, `username`, or `phoneNumber`) must be provided.
+ * Which identifiers are accepted depends on what is configured on your database connection.
+ */
+export type PasskeySignupChallengeOptions = PasskeySignupChallengeBaseOptions & (
+  | { /** Email address — include if email is configured as an identifier */ email: string; phoneNumber?: string; username?: string }
+  | { /** Phone number — if Flexible Identifiers is enabled */ phoneNumber: string; email?: string; username?: string }
+  | { /** Username — if Flexible Identifiers is enabled */ username: string; email?: string; phoneNumber?: string }
+);
+
+/**
+ * Response from a passkey signup challenge request.
+ */
+export interface PasskeySignupChallengeResponse {
+  authSession: string;
+  authnParamsPublicKey: PasskeyCreationOptions;
+}
+
+/**
+ * Options for requesting a passkey login challenge.
+ */
+export interface PasskeyLoginChallengeOptions {
+  /** Database connection name (sent as `realm` to the API) */
+  realm?: string;
+}
+
+/**
+ * Response from a passkey login challenge request.
+ */
+export interface PasskeyLoginChallengeResponse {
+  authSession: string;
+  authnParamsPublicKey: PasskeyRequestOptions;
+}
+
+/**
+ * Options for exchanging a passkey credential response for tokens.
+ */
+export interface SigninWithPasskeyOptions {
+  /** Auth session ID returned from a signup or login challenge */
+  authSession: string;
+  /** Serialized credential response from the platform WebAuthn API */
+  credential: PasskeyCredentialResponse;
+  /** Database connection name (sent as `realm` to the API) */
+  realm?: string;
+  /** Requested OAuth scopes (e.g. 'openid profile email') */
+  scope?: string;
+  /** Target API audience */
+  audience?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Internal API response types (match Auth0 API response shape)
+// ---------------------------------------------------------------------------
+
+/**
+ * @internal
+ */
+export interface PasskeySignupChallengeApiResponse {
+  auth_session: string;
+  authn_params_public_key: {
+    challenge: string;
+    rp: { id: string; name: string };
+    user: { id: string; name: string; displayName: string };
+    pubKeyCredParams: Array<{ type: string; alg: number }>;
+    authenticatorSelection?: {
+      residentKey?: string;
+      userVerification?: string;
+    };
+    timeout?: number;
+  };
+}
+
+/**
+ * @internal
+ */
+export interface PasskeyLoginChallengeApiResponse {
+  auth_session: string;
+  authn_params_public_key: {
+    challenge: string;
+    rpId: string;
+    timeout?: number;
+    userVerification?: string;
+  };
+}

--- a/packages/auth0-auth-js/src/passkey/types.ts
+++ b/packages/auth0-auth-js/src/passkey/types.ts
@@ -96,8 +96,20 @@ export interface PasskeyCredentialResponse {
 interface PasskeySignupChallengeBaseOptions {
   /** Display name for the user (optional) */
   name?: string;
+  /** Given name / first name */
+  givenName?: string;
+  /** Family name / last name */
+  familyName?: string;
+  /** Nickname */
+  nickname?: string;
+  /** URL to the user's profile picture */
+  picture?: string;
+  /** Arbitrary user metadata (stored in `user_metadata` on the Auth0 user) */
+  userMetadata?: Record<string, unknown>;
   /** Database connection name (sent as `realm` to the API) */
   realm?: string;
+  /** Organization ID or name to associate the user with */
+  organization?: string;
 }
 
 /**
@@ -126,6 +138,8 @@ export interface PasskeySignupChallengeResponse {
 export interface PasskeyLoginChallengeOptions {
   /** Database connection name (sent as `realm` to the API) */
   realm?: string;
+  /** Organization ID or name (scopes tokens to the organization context) */
+  organization?: string;
 }
 
 /**
@@ -150,6 +164,8 @@ export interface GetTokenByPasskeyOptions {
   scope?: string;
   /** Target API audience */
   audience?: string;
+  /** Organization ID or name (scopes tokens to the organization context) */
+  organization?: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/auth0-auth-js/src/passkey/types.ts
+++ b/packages/auth0-auth-js/src/passkey/types.ts
@@ -134,7 +134,7 @@ export interface PasskeyLoginChallengeResponse {
 /**
  * Options for exchanging a passkey credential response for tokens.
  */
-export interface SigninWithPasskeyOptions {
+export interface GetTokenByPasskeyOptions {
   /** Auth session ID returned from a signup or login challenge */
   authSession: string;
   /** Serialized credential response from the platform WebAuthn API */

--- a/packages/auth0-auth-js/src/passkey/utils.ts
+++ b/packages/auth0-auth-js/src/passkey/utils.ts
@@ -1,0 +1,44 @@
+import type {
+  PasskeySignupChallengeResponse,
+  PasskeySignupChallengeApiResponse,
+  PasskeyLoginChallengeResponse,
+  PasskeyLoginChallengeApiResponse,
+} from './types.js';
+
+/**
+ * Transforms API signup challenge response to SDK format.
+ * @internal
+ */
+export function transformSignupChallengeResponse(
+  api: PasskeySignupChallengeApiResponse
+): PasskeySignupChallengeResponse {
+  return {
+    authSession: api.auth_session,
+    authnParamsPublicKey: {
+      challenge: api.authn_params_public_key.challenge,
+      rp: api.authn_params_public_key.rp,
+      user: api.authn_params_public_key.user,
+      pubKeyCredParams: api.authn_params_public_key.pubKeyCredParams,
+      authenticatorSelection: api.authn_params_public_key.authenticatorSelection,
+      timeout: api.authn_params_public_key.timeout,
+    },
+  };
+}
+
+/**
+ * Transforms API login challenge response to SDK format.
+ * @internal
+ */
+export function transformLoginChallengeResponse(
+  api: PasskeyLoginChallengeApiResponse
+): PasskeyLoginChallengeResponse {
+  return {
+    authSession: api.auth_session,
+    authnParamsPublicKey: {
+      challenge: api.authn_params_public_key.challenge,
+      rpId: api.authn_params_public_key.rpId,
+      timeout: api.authn_params_public_key.timeout,
+      userVerification: api.authn_params_public_key.userVerification,
+    },
+  };
+}

--- a/packages/auth0-auth-js/src/passkey/utils.ts
+++ b/packages/auth0-auth-js/src/passkey/utils.ts
@@ -14,14 +14,7 @@ export function transformSignupChallengeResponse(
 ): PasskeySignupChallengeResponse {
   return {
     authSession: api.auth_session,
-    authnParamsPublicKey: {
-      challenge: api.authn_params_public_key.challenge,
-      rp: api.authn_params_public_key.rp,
-      user: api.authn_params_public_key.user,
-      pubKeyCredParams: api.authn_params_public_key.pubKeyCredParams,
-      authenticatorSelection: api.authn_params_public_key.authenticatorSelection,
-      timeout: api.authn_params_public_key.timeout,
-    },
+    authnParamsPublicKey: { ...api.authn_params_public_key },
   };
 }
 
@@ -34,11 +27,6 @@ export function transformLoginChallengeResponse(
 ): PasskeyLoginChallengeResponse {
   return {
     authSession: api.auth_session,
-    authnParamsPublicKey: {
-      challenge: api.authn_params_public_key.challenge,
-      rpId: api.authn_params_public_key.rpId,
-      timeout: api.authn_params_public_key.timeout,
-      userVerification: api.authn_params_public_key.userVerification,
-    },
+    authnParamsPublicKey: { ...api.authn_params_public_key },
   };
 }


### PR DESCRIPTION
## Summary
- Add `PasskeyClient` module with native WebAuthn passkey authentication support
- Expose three public methods: `register()` (signup challenge), `challenge()` (login challenge), and `getTokenByPasskey()` (token exchange via `urn:okta:params:oauth:grant-type:webauthn` grant)
- Integrate `PasskeyClient` as `authClient.passkey` property on `AuthClient`

## Design decisions
- **Platform-agnostic**: SDK does not call WebAuthn browser APIs — consumers handle `navigator.credentials.create()`/`.get()` and pass serialized (base64url) credentials
- **Enrollment excluded**: Passkey enrollment (My Account `/me/v1` endpoints) is intentionally not in this package — it belongs in the per-SDK My Account layer (see architecture doc)
- **Delegate pattern for token exchange**: `getTokenByPasskey()` uses an injected `grantRequest` function from `AuthClient`, so it inherits client authentication, DPoP support, and OIDC discovery without duplicating logic

## Test plan
- [x] 59 unit tests covering all 3 operations (register, challenge, getTokenByPasskey)
- [x] Error path coverage (HTTP 400/401/403/409/500, non-JSON responses, network failures)
- [x] Response transformation tests (snake_case → camelCase, optional field handling)
- [x] Custom fetch delegation tests
- [x] `npm run build` passes
- [x] Tested end-to-end with `auth0-spa-js` sample app against a real tenant
