### PR TITLE
feat(auth0-auth-js): add multi-factor authentication (MFA) support

### DIFF
--- a/packages/auth0-auth-js/EXAMPLES.md
+++ b/packages/auth0-auth-js/EXAMPLES.md
@@ -644,9 +644,77 @@ When the verification is successful, the `sid` and `sub` claims will be returned
 The SDK provides an MFA client to manage multi-factor authentication for your users. The MFA client is accessible via the `mfa` property on the `AuthClient` instance.
 
 > [!IMPORTANT]
-> MFA operations require an MFA token, which is typically obtained from an MFA challenge response during the authentication flow. The MFA token must be passed as part of the parameters object for each method.
+> MFA operations require an MFA token. This token is available on the error's `cause` when the server returns `mfa_required` during the authentication flow. Use the `isMfaRequiredError` type guard to detect this condition and access the token.
 
 [Refer API Docs ](https://auth0.com/docs/api/authentication/muti-factor-authentication/request-mfa-challenge)
+
+### Handling the MFA Required Response
+
+When the server requires multi-factor authentication, token request methods (`getTokenByPassword`, `getTokenByRefreshToken`, `exchangeToken`) throw their usual error class (`TokenByPasswordError`, `TokenByRefreshTokenError`, `TokenExchangeError`) with extra MFA context on `cause`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cause.error` | `'mfa_required'` | Indicates MFA is required |
+| `cause.mfa_token` | `string` | Token to pass to MFA APIs |
+| `cause.mfa_requirements` | `{ challenge?: Array<{ type: string }>; enroll?: Array<{ type: string }> }` | Which factors the user must challenge or enroll (optional) |
+
+Use the exported `isMfaRequiredError` type guard to detect and narrow the error:
+
+```ts
+import { AuthClient, isMfaRequiredError } from '@auth0/auth0-auth-js';
+
+const authClient = new AuthClient({
+  domain: '<AUTH0_DOMAIN>',
+  clientId: '<AUTH0_CLIENT_ID>',
+  clientSecret: '<AUTH0_CLIENT_SECRET>',
+});
+
+try {
+  const tokens = await authClient.getTokenByPassword({
+    username: 'user@example.com',
+    password: 'password123',
+  });
+} catch (error) {
+  if (isMfaRequiredError(error)) {
+    // TypeScript narrows: error.cause.mfa_token is guaranteed to be a string
+    const { mfa_token, mfa_requirements } = error.cause;
+
+    if (mfa_requirements?.enroll?.length) {
+      // User needs to enroll a new factor — see "Enrolling an Authenticator" below
+      const enrollment = await authClient.mfa.enrollAuthenticator({
+        mfaToken: mfa_token,
+        authenticatorTypes: ['otp'],
+      });
+    } else {
+      // User has enrolled factors — see "Challenging an Authenticator" below
+      const challenge = await authClient.mfa.challengeAuthenticator({
+        mfaToken: mfa_token,
+        challengeType: 'otp',
+      });
+    }
+  }
+}
+```
+
+The same pattern works for refresh token and token exchange flows:
+
+```ts
+import { isMfaRequiredError } from '@auth0/auth0-auth-js';
+
+try {
+  const tokens = await authClient.getTokenByRefreshToken({
+    refreshToken: 'existing_refresh_token',
+  });
+} catch (error) {
+  if (isMfaRequiredError(error)) {
+    // Step-up MFA required for this audience/scope
+    const challenge = await authClient.mfa.challengeAuthenticator({
+      mfaToken: error.cause.mfa_token,
+      challengeType: 'otp',
+    });
+  }
+}
+```
 
 ### Enrolling an Authenticator
 

--- a/packages/auth0-auth-js/src/auth-client.spec.ts
+++ b/packages/auth0-auth-js/src/auth-client.spec.ts
@@ -2,7 +2,7 @@ import { expect, test, afterAll, beforeAll, beforeEach, vi, afterEach, describe 
 import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
 import { AuthClient } from './auth-client.js';
-import { NotSupportedError } from './errors.js';
+import { NotSupportedError, isMfaRequiredError, TokenByPasswordError } from './errors.js';
 import { ExchangeProfileOptions } from './types.js';
 
 import { generateToken, jwks } from './test-utils/tokens.js';
@@ -107,6 +107,18 @@ const restHandlers = [
 
     // Handle refresh_token grant type with audience and/or scope
     if (info.get('grant_type') === 'refresh_token') {
+      if (info.get('refresh_token') === '<refresh_token_mfa_required>') {
+        return HttpResponse.json(
+          {
+            error: 'mfa_required',
+            error_description: 'MFA required.',
+            mfa_token: '<mfa_token>',
+            mfa_requirements: { challenge: [{ type: 'otp' }] },
+          },
+          { status: 403 }
+        );
+      }
+
       const audience = info.get('audience');
       const scope = info.get('scope');
 
@@ -123,6 +135,18 @@ const restHandlers = [
 
     // Handle password grant type
     if (info.get('grant_type') === 'password') {
+      if (info.get('username') === 'user_mfa_required') {
+        return HttpResponse.json(
+          {
+            error: 'mfa_required',
+            error_description: 'MFA required.',
+            mfa_token: '<mfa_token>',
+            mfa_requirements: { challenge: [{ type: 'otp' }] },
+          },
+          { status: 403 }
+        );
+      }
+
       const shouldFailPassword =
         info.get('username') === 'user_should_fail' ||
         info.get('password') === 'password_should_fail';
@@ -3027,5 +3051,78 @@ describe('Telemetry', () => {
     const decoded = JSON.parse(atob(capturedHeader!));
     expect(decoded.name).toBe('@auth0/auth0-auth-js');
     expect(decoded.version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});
+
+describe('isMfaRequiredError', () => {
+  test('returns true for a TokenByPasswordError caused by mfa_required', () => {
+    const error = new TokenByPasswordError('There was an error while trying to request a token.', {
+      error: 'mfa_required',
+      error_description: 'MFA required.',
+      mfa_token: '<mfa_token>',
+      mfa_requirements: { challenge: [{ type: 'otp' }] },
+    });
+    expect(isMfaRequiredError(error)).toBe(true);
+    if (isMfaRequiredError(error)) {
+      expect(error.cause.mfa_token).toBe('<mfa_token>');
+      expect(error.cause.mfa_requirements).toEqual({ challenge: [{ type: 'otp' }] });
+      expect(error.code).toBe('token_by_password_error');
+    }
+  });
+
+  test('returns false for a regular error with no cause', () => {
+    const error = new Error('some error');
+    expect(isMfaRequiredError(error)).toBe(false);
+  });
+
+  test('returns false when mfa_token is missing from cause', () => {
+    const error = new TokenByPasswordError('There was an error while trying to request a token.', {
+      error: 'mfa_required',
+      error_description: 'MFA required.',
+    });
+    expect(isMfaRequiredError(error)).toBe(false);
+  });
+
+  test('returns false for a non-mfa error', () => {
+    const error = new TokenByPasswordError('There was an error while trying to request a token.', {
+      error: 'invalid_grant',
+      error_description: 'Wrong email or password.',
+    });
+    expect(isMfaRequiredError(error)).toBe(false);
+  });
+
+  test('getTokenByPassword throws an error that passes isMfaRequiredError when server returns mfa_required', async () => {
+    const authClient = new AuthClient({
+      domain,
+      clientId: '<client_id>',
+      clientSecret: '<client_secret>',
+      telemetry: { enabled: false },
+    });
+
+    let caughtError: unknown;
+    try {
+      await authClient.getTokenByPassword({ username: 'user_mfa_required', password: 'password' });
+    } catch (e) {
+      caughtError = e;
+    }
+
+    expect(isMfaRequiredError(caughtError)).toBe(true);
+    if (isMfaRequiredError(caughtError)) {
+      expect(caughtError.cause.mfa_token).toBe('<mfa_token>');
+      expect(caughtError.cause.mfa_requirements).toEqual({ challenge: [{ type: 'otp' }] });
+    }
+  });
+
+  test('getTokenByRefreshToken throws an error that passes isMfaRequiredError when server returns mfa_required', async () => {
+    const authClient = new AuthClient({
+      domain,
+      clientId: '<client_id>',
+      clientSecret: '<client_secret>',
+      telemetry: { enabled: false },
+    });
+
+    await expect(
+      authClient.getTokenByRefreshToken({ refreshToken: '<refresh_token_mfa_required>' })
+    ).rejects.toSatisfy(isMfaRequiredError);
   });
 });

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -141,6 +141,26 @@ function validateSubjectToken(token: string): void {
   }
 }
 
+function toOAuth2Error(e: unknown): OAuth2Error {
+  if (typeof e !== 'object' || e === null) {
+    return { error: 'unknown_error', error_description: String(e) };
+  }
+  const err = e as { error?: string; error_description?: string; cause?: Record<string, unknown>; message?: string };
+  const base: OAuth2Error = {
+    error: err.error ?? '',
+    error_description: err.error_description ?? '',
+    message: err.message,
+  };
+  if (err.error === 'mfa_required' && err.cause) {
+    base.mfa_token = typeof err.cause.mfa_token === 'string' ? err.cause.mfa_token : undefined;
+    const req = err.cause.mfa_requirements;
+    if (typeof req === 'object' && req !== null) {
+      base.mfa_requirements = req as OAuth2Error['mfa_requirements'];
+    }
+  }
+  return base;
+}
+
 /**
  * Appends extra parameters to URLSearchParams while enforcing security constraints.
  */
@@ -253,7 +273,9 @@ export class AuthClient {
     this.mfa = new MfaClient({
       domain: this.#options.domain,
       clientId: this.#options.clientId,
+      clientSecret: this.#options.clientSecret,
       customFetch: this.#customFetch,
+      getConfiguration: async () => (await this.#discover()).configuration,
     });
 
     this.passkey = new PasskeyClient({
@@ -710,7 +732,7 @@ export class AuthClient {
     } catch (e) {
       throw new TokenExchangeError(
         `Failed to exchange token for connection '${options.connection}'.`,
-        e as OAuth2Error
+        toOAuth2Error(e)
       );
     }
   }
@@ -767,7 +789,7 @@ export class AuthClient {
     } catch (e) {
       throw new TokenExchangeError(
         `Failed to exchange token of type '${options.subjectTokenType}'${options.audience ? ` for audience '${options.audience}'` : ''}.`,
-        e as OAuth2Error
+        toOAuth2Error(e)
       );
     }
   }
@@ -877,7 +899,7 @@ export class AuthClient {
 
       return TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
     } catch (e) {
-      throw new TokenByCodeError('There was an error while trying to request a token.', e as OAuth2Error);
+      throw new TokenByCodeError('There was an error while trying to request a token.', toOAuth2Error(e));
     }
   }
 
@@ -913,7 +935,7 @@ export class AuthClient {
     } catch (e) {
       throw new TokenByRefreshTokenError(
         'The access token has expired and there was an error while trying to refresh it.',
-        e as OAuth2Error
+        toOAuth2Error(e)
       );
     }
   }
@@ -983,7 +1005,7 @@ export class AuthClient {
     } catch (e) {
       throw new TokenByPasswordError(
         'There was an error while trying to request a token.',
-        e as OAuth2Error
+        toOAuth2Error(e)
       );
     }
   }
@@ -1012,7 +1034,7 @@ export class AuthClient {
 
       return TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
     } catch (e) {
-      throw new TokenByClientCredentialsError('There was an error while trying to request a token.', e as OAuth2Error);
+      throw new TokenByClientCredentialsError('There was an error while trying to request a token.', toOAuth2Error(e));
     }
   }
 

--- a/packages/auth0-auth-js/src/errors.ts
+++ b/packages/auth0-auth-js/src/errors.ts
@@ -1,10 +1,33 @@
 /**
+ * Factor types that can appear in an `mfa_required` error's `mfa_requirements` payload.
+ */
+export type MfaRequiredFactorType =
+  | 'otp'
+  | 'oob'
+  | 'email'
+  | 'webauthn-roaming'
+  | 'webauthn-platform'
+  | 'push-notification'
+  | 'phone';
+
+/**
+ * Describes which MFA factors the user must challenge or enroll.
+ */
+export interface MfaRequirements {
+  challenge?: Array<{ type: MfaRequiredFactorType }>;
+  enroll?: Array<{ type: MfaRequiredFactorType }>;
+}
+
+/**
  * Interface to represent an OAuth2 error.
+ * When the error is `mfa_required`, `mfa_token` and `mfa_requirements` will be populated.
  */
 export interface OAuth2Error {
   error: string;
   error_description: string;
   message?: string;
+  mfa_token?: string;
+  mfa_requirements?: MfaRequirements;
 }
 
 /**
@@ -44,6 +67,8 @@ abstract class ApiError extends Error {
       error: cause.error,
       error_description: cause.error_description,
       message: cause.message,
+      mfa_token: cause.mfa_token,
+      mfa_requirements: cause.mfa_requirements,
     };
   }
 }
@@ -171,6 +196,52 @@ export class BuildUnlinkUserUrlError extends ApiError {
     super('build_unlink_user_url_error', 'There was an error when trying to build the Unlink User URL.', cause);
     this.name = 'BuildUnlinkUserUrlError';
   }
+}
+
+/**
+ * Narrows an error thrown by a token request method to one caused by an `mfa_required` response.
+ *
+ * When the Auth0 server requires multi-factor authentication, token request methods
+ * (`getTokenByPassword`, `getTokenByRefreshToken`, `exchangeToken`) throw their usual error
+ * (e.g. `TokenByPasswordError`) with `cause.error` set to `'mfa_required'`.
+ * The `cause` will also contain:
+ * - `mfa_token` — the token needed to proceed with enrollment or challenge MFA APIs
+ * - `mfa_requirements` — (optional) describes which factors to challenge or enroll
+ *
+ * This type guard checks whether an error was caused by an `mfa_required` response and
+ * narrows the type so that `cause` and `cause.mfa_token` are guaranteed to be defined.
+ *
+ * @param error - The error caught from a token request method
+ * @returns `true` if the error was caused by an `mfa_required` server response
+ *
+ * @example
+ * ```typescript
+ * import { AuthClient, isMfaRequiredError } from '@auth0/auth0-auth-js';
+ *
+ * try {
+ *   await authClient.getTokenByPassword({ username, password });
+ * } catch (error) {
+ *   if (isMfaRequiredError(error)) {
+ *     // error.cause.mfa_token is guaranteed to be defined here
+ *     const challenge = await authClient.mfa.challengeAuthenticator({
+ *       mfaToken: error.cause.mfa_token,
+ *       challengeType: 'otp',
+ *     });
+ *   }
+ * }
+ * ```
+ */
+export interface MfaRequiredError extends Error {
+  code: string;
+  cause: OAuth2Error & { error: 'mfa_required'; mfa_token: string; mfa_requirements?: MfaRequirements };
+}
+
+export function isMfaRequiredError(error: unknown): error is MfaRequiredError {
+  return (
+    error instanceof Error &&
+    (error as { cause?: OAuth2Error }).cause?.error === 'mfa_required' &&
+    typeof (error as { cause?: OAuth2Error }).cause?.mfa_token === 'string'
+  );
 }
 
 /**

--- a/packages/auth0-auth-js/src/mfa/errors.ts
+++ b/packages/auth0-auth-js/src/mfa/errors.ts
@@ -65,3 +65,13 @@ export class MfaChallengeError extends MfaError {
     this.name = 'MfaChallengeError';
   }
 }
+
+/**
+ * Error thrown when MFA verification fails (e.g., invalid OTP, invalid MFA token).
+ */
+export class MfaVerifyError extends MfaError {
+  constructor(message: string, cause?: MfaApiErrorResponse) {
+    super('mfa_verify_error', message, cause);
+    this.name = 'MfaVerifyError';
+  }
+}

--- a/packages/auth0-auth-js/src/mfa/index.ts
+++ b/packages/auth0-auth-js/src/mfa/index.ts
@@ -14,6 +14,11 @@ export type {
   OobEnrollmentResponse,
   EnrollmentResponse,
   ChallengeOptions,
-  ChallengeResponse
+  ChallengeResponse,
+  MfaFactorType,
+  MfaVerifyOtpOptions,
+  MfaVerifyOobOptions,
+  MfaVerifyRecoveryCodeOptions,
+  MfaVerifyOptions,
 } from './types.js';
 

--- a/packages/auth0-auth-js/src/mfa/mfa-client.spec.ts
+++ b/packages/auth0-auth-js/src/mfa/mfa-client.spec.ts
@@ -1,16 +1,33 @@
 import { expect, test, describe, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
+import * as oidcClient from 'openid-client';
 import { MfaClient } from './mfa-client.js';
 import {
   MfaListAuthenticatorsError,
   MfaDeleteAuthenticatorError,
   MfaEnrollmentError,
   MfaChallengeError,
+  MfaVerifyError,
 } from './errors.js';
+import { generateToken, jwks } from '../test-utils/tokens.js';
 
 const domain = 'auth0.local';
 const clientId = 'test-client-id';
+
+const makeGetConfiguration = (d: string, cId: string, cSecret?: string) => {
+  const config = new oidcClient.Configuration(
+    {
+      issuer: `https://${d}/`,
+      token_endpoint: `https://${d}/oauth/token`,
+      jwks_uri: `https://${d}/.well-known/jwks.json`,
+      token_endpoint_auth_methods_supported: cSecret ? ['client_secret_post'] : ['none'],
+    },
+    cId,
+    cSecret
+  );
+  return () => Promise.resolve(config);
+};
 const mfaToken = 'test-mfa-token';
 
 const mockAuthenticators = [
@@ -30,6 +47,11 @@ const mockAuthenticators = [
 ];
 
 const restHandlers = [
+  // JWKS endpoint for openid-client id_token validation
+  http.get(`https://${domain}/.well-known/jwks.json`, () => {
+    return HttpResponse.json({ keys: jwks });
+  }),
+
   // List authenticators
   http.get(`https://${domain}/mfa/authenticators`, ({ request }) => {
     const authHeader = request.headers.get('Authorization');
@@ -396,6 +418,56 @@ describe('MfaClient', () => {
         })
       ).rejects.toThrow(MfaChallengeError);
     });
+
+    test('should include client_secret in request body for confidential clients', async () => {
+      let capturedBody: Record<string, string> | undefined;
+
+      server.use(
+        http.post(`https://${domain}/mfa/challenge`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, string>;
+          return HttpResponse.json({ challenge_type: 'otp' });
+        })
+      );
+
+      const client = new MfaClient({ domain, clientId, clientSecret: 'test-client-secret' });
+      await client.challengeAuthenticator({ challengeType: 'otp', mfaToken });
+
+      expect(capturedBody!.client_secret).toBe('test-client-secret');
+      expect(capturedBody!.client_id).toBe(clientId);
+    });
+
+    test('should not include client_secret for public clients', async () => {
+      let capturedBody: Record<string, string> | undefined;
+
+      server.use(
+        http.post(`https://${domain}/mfa/challenge`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, string>;
+          return HttpResponse.json({ challenge_type: 'otp' });
+        })
+      );
+
+      const client = new MfaClient({ domain, clientId });
+      await client.challengeAuthenticator({ challengeType: 'otp', mfaToken });
+
+      expect(capturedBody!.client_secret).toBeUndefined();
+    });
+
+    test('should throw MfaChallengeError when server returns non-JSON error response', async () => {
+      server.use(
+        http.post(`https://${domain}/mfa/challenge`, () => {
+          return new HttpResponse('<html>Bad Gateway</html>', {
+            status: 502,
+            headers: { 'Content-Type': 'text/html' },
+          });
+        })
+      );
+
+      const client = new MfaClient({ domain, clientId });
+
+      await expect(
+        client.challengeAuthenticator({ challengeType: 'otp', mfaToken })
+      ).rejects.toThrow(MfaChallengeError);
+    });
   });
 
   describe('customFetch', () => {
@@ -418,6 +490,199 @@ describe('MfaClient', () => {
           }),
         })
       );
+    });
+  });
+
+  describe('verify', () => {
+    let idToken: string;
+
+    beforeAll(async () => {
+      idToken = await generateToken(domain, 'user|123', clientId);
+    });
+
+    test('should verify OTP and return TokenResponse', async () => {
+      server.use(
+        http.post(`https://${domain}/oauth/token`, async () =>
+          HttpResponse.json({
+            access_token: 'mfa_access_token',
+            id_token: idToken,
+            refresh_token: 'mfa_refresh_token',
+            token_type: 'Bearer',
+            expires_in: 86400,
+            scope: 'openid profile email',
+          })
+        )
+      );
+
+      const client = new MfaClient({ domain, clientId, getConfiguration: makeGetConfiguration(domain, clientId) });
+      const result = await client.verify({ mfaToken, factorType: 'otp', otp: '123456' });
+
+      expect(result.accessToken).toBe('mfa_access_token');
+      expect(result.idToken).toBe(idToken);
+      expect(result.refreshToken).toBe('mfa_refresh_token');
+      expect(result.tokenType).toBe('bearer');
+      expect(result.expiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
+      expect(result.scope).toBe('openid profile email');
+      expect(result.claims?.sub).toBe('user|123');
+    });
+
+    test('should verify OOB and return TokenResponse', async () => {
+      server.use(
+        http.post(`https://${domain}/oauth/token`, async () =>
+          HttpResponse.json({
+            access_token: 'oob_access_token',
+            id_token: idToken,
+            token_type: 'Bearer',
+            expires_in: 86400,
+          })
+        )
+      );
+
+      const client = new MfaClient({ domain, clientId, getConfiguration: makeGetConfiguration(domain, clientId) });
+      const result = await client.verify({ mfaToken, factorType: 'oob', oobCode: 'oob_123' });
+
+      expect(result.accessToken).toBe('oob_access_token');
+    });
+
+    test('should verify recovery-code and set recoveryCode on TokenResponse', async () => {
+      server.use(
+        http.post(`https://${domain}/oauth/token`, async () =>
+          HttpResponse.json({
+            access_token: 'recovery_access_token',
+            id_token: idToken,
+            token_type: 'Bearer',
+            expires_in: 86400,
+            recovery_code: 'NEW_RECOVERY_CODE',
+          })
+        )
+      );
+
+      const client = new MfaClient({ domain, clientId, getConfiguration: makeGetConfiguration(domain, clientId) });
+      const result = await client.verify({ mfaToken, factorType: 'recovery-code', recoveryCode: 'OLD_CODE' });
+
+      expect(result.accessToken).toBe('recovery_access_token');
+      expect(result.recoveryCode).toBe('NEW_RECOVERY_CODE');
+    });
+
+    test('should include client_secret in token request', async () => {
+      let capturedBody: FormData | undefined;
+
+      server.use(
+        http.post(`https://${domain}/oauth/token`, async ({ request }) => {
+          capturedBody = await request.formData();
+          return HttpResponse.json({
+            access_token: 'token',
+            token_type: 'Bearer',
+            expires_in: 86400,
+          });
+        })
+      );
+
+      const client = new MfaClient({ domain, clientId, clientSecret: 'test-secret', getConfiguration: makeGetConfiguration(domain, clientId, 'test-secret') });
+      await client.verify({ mfaToken, factorType: 'otp', otp: '123456' });
+
+      expect(capturedBody!.get('client_secret')).toBe('test-secret');
+      expect(capturedBody!.get('grant_type')).toBe('http://auth0.com/oauth/grant-type/mfa-otp');
+      expect(capturedBody!.get('otp')).toBe('123456');
+    });
+
+    test('should include oob_code and binding_code for OOB', async () => {
+      let capturedBody: FormData | undefined;
+
+      server.use(
+        http.post(`https://${domain}/oauth/token`, async ({ request }) => {
+          capturedBody = await request.formData();
+          return HttpResponse.json({ access_token: 'token', token_type: 'Bearer', expires_in: 86400 });
+        })
+      );
+
+      const client = new MfaClient({ domain, clientId, getConfiguration: makeGetConfiguration(domain, clientId) });
+      await client.verify({ mfaToken, factorType: 'oob', oobCode: 'oob_123', bindingCode: 'bind_456' });
+
+      expect(capturedBody!.get('oob_code')).toBe('oob_123');
+      expect(capturedBody!.get('binding_code')).toBe('bind_456');
+      expect(capturedBody!.get('grant_type')).toBe('http://auth0.com/oauth/grant-type/mfa-oob');
+    });
+
+    test('should forward audience to token request body', async () => {
+      let capturedBody: FormData | undefined;
+
+      server.use(
+        http.post(`https://${domain}/oauth/token`, async ({ request }) => {
+          capturedBody = await request.formData();
+          return HttpResponse.json({ access_token: 'token', token_type: 'Bearer', expires_in: 86400 });
+        })
+      );
+
+      const client = new MfaClient({ domain, clientId, getConfiguration: makeGetConfiguration(domain, clientId) });
+      await client.verify({ mfaToken, factorType: 'otp', otp: '123456', audience: 'https://api.example.com' });
+
+      expect(capturedBody!.get('audience')).toBe('https://api.example.com');
+    });
+
+    test('should throw MfaVerifyError on invalid mfa_token', async () => {
+      server.use(
+        http.post(`https://${domain}/oauth/token`, () =>
+          HttpResponse.json({ error: 'invalid_grant', error_description: 'Malformed mfa_token' }, { status: 403 })
+        )
+      );
+
+      const client = new MfaClient({ domain, clientId, getConfiguration: makeGetConfiguration(domain, clientId) });
+      await expect(client.verify({ mfaToken: 'bad', factorType: 'otp', otp: '123456' })).rejects.toThrow(
+        MfaVerifyError
+      );
+    });
+
+    test('should throw MfaVerifyError with error details', async () => {
+      server.use(
+        http.post(`https://${domain}/oauth/token`, () =>
+          HttpResponse.json({ error: 'invalid_grant', error_description: 'Invalid OTP' }, { status: 403 })
+        )
+      );
+
+      const client = new MfaClient({ domain, clientId, getConfiguration: makeGetConfiguration(domain, clientId) });
+      try {
+        await client.verify({ mfaToken, factorType: 'otp', otp: 'wrong' });
+        expect.fail('should have thrown');
+      } catch (e) {
+        expect(e).toBeInstanceOf(MfaVerifyError);
+        const err = e as MfaVerifyError;
+        expect(err.cause?.error).toBe('invalid_grant');
+        expect(err.cause?.error_description).toBe('Invalid OTP');
+      }
+    });
+
+    test('should throw MfaVerifyError when access_token is missing', async () => {
+      server.use(
+        http.post(`https://${domain}/oauth/token`, () =>
+          HttpResponse.json({ token_type: 'Bearer', expires_in: 86400 })
+        )
+      );
+
+      const client = new MfaClient({ domain, clientId, getConfiguration: makeGetConfiguration(domain, clientId) });
+      await expect(client.verify({ mfaToken, factorType: 'otp', otp: '123456' })).rejects.toThrow(MfaVerifyError);
+    });
+
+    test('should throw MfaVerifyError when id_token is a malformed JWT', async () => {
+      server.use(
+        http.post(`https://${domain}/oauth/token`, () =>
+          HttpResponse.json({ access_token: 'token', id_token: 'not.a.jwt', token_type: 'Bearer', expires_in: 86400 })
+        )
+      );
+
+      const client = new MfaClient({ domain, clientId, getConfiguration: makeGetConfiguration(domain, clientId) });
+      await expect(client.verify({ mfaToken, factorType: 'otp', otp: '123456' })).rejects.toThrow(MfaVerifyError);
+    });
+
+    test('should throw MfaVerifyError when server returns non-JSON error', async () => {
+      server.use(
+        http.post(`https://${domain}/oauth/token`, () =>
+          new HttpResponse('<html>Bad Gateway</html>', { status: 502, headers: { 'Content-Type': 'text/html' } })
+        )
+      );
+
+      const client = new MfaClient({ domain, clientId, getConfiguration: makeGetConfiguration(domain, clientId) });
+      await expect(client.verify({ mfaToken, factorType: 'otp', otp: '123456' })).rejects.toThrow(MfaVerifyError);
     });
   });
 });

--- a/packages/auth0-auth-js/src/mfa/mfa-client.ts
+++ b/packages/auth0-auth-js/src/mfa/mfa-client.ts
@@ -1,3 +1,4 @@
+import * as client from 'openid-client';
 import type {
   MfaClientOptions,
   AuthenticatorResponse,
@@ -10,20 +11,31 @@ import type {
   ChallengeOptions,
   ChallengeResponse,
   ChallengeApiResponse,
+  MfaVerifyOptions,
 } from './types.js';
 import {
   MfaListAuthenticatorsError,
   MfaEnrollmentError,
   MfaDeleteAuthenticatorError,
   MfaChallengeError,
+  MfaVerifyError,
   type MfaApiErrorResponse,
 } from './errors.js';
 import { transformAuthenticatorResponse, transformEnrollmentResponse, transformChallengeResponse } from './utils.js';
+import { TokenResponse } from '../types.js';
+
+const GRANT_TYPE_MAP = {
+  otp: 'http://auth0.com/oauth/grant-type/mfa-otp',
+  oob: 'http://auth0.com/oauth/grant-type/mfa-oob',
+  'recovery-code': 'http://auth0.com/oauth/grant-type/mfa-recovery-code',
+} as const;
 
 export class MfaClient {
   #baseUrl: string;
   #clientId: string;
+  #clientSecret?: string;
   #customFetch: typeof fetch;
+  #getConfiguration?: () => Promise<client.Configuration>;
 
   /**
    * @internal
@@ -31,7 +43,9 @@ export class MfaClient {
   constructor(options: MfaClientOptions) {
     this.#baseUrl = `https://${options.domain}`;
     this.#clientId = options.clientId;
+    this.#clientSecret = options.clientSecret;
     this.#customFetch = options.customFetch ?? ((...args) => fetch(...args));
+    this.#getConfiguration = options.getConfiguration;
   }
 
   /**
@@ -68,7 +82,12 @@ export class MfaClient {
     });
 
     if (!response.ok) {
-      const error = (await response.json()) as MfaApiErrorResponse;
+      let error: MfaApiErrorResponse;
+      try {
+        error = (await response.json()) as MfaApiErrorResponse;
+      } catch {
+        throw new MfaListAuthenticatorsError('Failed to list authenticators');
+      }
       throw new MfaListAuthenticatorsError(error.error_description || 'Failed to list authenticators', error);
     }
 
@@ -145,7 +164,12 @@ export class MfaClient {
     });
 
     if (!response.ok) {
-      const error = (await response.json()) as MfaApiErrorResponse;
+      let error: MfaApiErrorResponse;
+      try {
+        error = (await response.json()) as MfaApiErrorResponse;
+      } catch {
+        throw new MfaEnrollmentError('Failed to enroll authenticator');
+      }
       throw new MfaEnrollmentError(error.error_description || 'Failed to enroll authenticator', error);
     }
 
@@ -192,7 +216,12 @@ export class MfaClient {
     });
 
     if (!response.ok) {
-      const error = (await response.json()) as MfaApiErrorResponse;
+      let error: MfaApiErrorResponse;
+      try {
+        error = (await response.json()) as MfaApiErrorResponse;
+      } catch {
+        throw new MfaDeleteAuthenticatorError('Failed to delete authenticator');
+      }
       throw new MfaDeleteAuthenticatorError(error.error_description || 'Failed to delete authenticator', error);
     }
   }
@@ -239,6 +268,10 @@ export class MfaClient {
       challenge_type: challengeParams.challengeType,
     };
 
+    if (this.#clientSecret) {
+      body.client_secret = this.#clientSecret;
+    }
+
     if (challengeParams.authenticatorId) {
       body.authenticator_id = challengeParams.authenticatorId;
     }
@@ -252,11 +285,75 @@ export class MfaClient {
     });
 
     if (!response.ok) {
-      const error = (await response.json()) as MfaApiErrorResponse;
+      let error: MfaApiErrorResponse;
+      try {
+        error = (await response.json()) as MfaApiErrorResponse;
+      } catch {
+        throw new MfaChallengeError('Failed to challenge authenticator');
+      }
       throw new MfaChallengeError(error.error_description || 'Failed to challenge authenticator', error);
     }
 
     const apiResponse = (await response.json()) as ChallengeApiResponse;
     return transformChallengeResponse(apiResponse);
+  }
+
+  /**
+   * Verifies an MFA challenge by exchanging the MFA token and code for access tokens.
+   *
+   * @param options - The MFA token, factor type (otp / oob / recovery-code), and the code to verify
+   * @returns Promise resolving to a TokenResponse containing the issued tokens
+   * @throws {MfaVerifyError} When verification fails (e.g. invalid token, wrong code, malformed response)
+   */
+  async verify(options: MfaVerifyOptions): Promise<TokenResponse> {
+    if (!this.#getConfiguration) {
+      throw new Error('MFA verify requires a configuration provider (getConfiguration was not set)');
+    }
+
+    const configuration = await this.#getConfiguration();
+
+    const params: Record<string, string> = {
+      mfa_token: options.mfaToken,
+    };
+
+    if (options.audience) {
+      params.audience = options.audience;
+    }
+
+    if (options.factorType === 'otp') {
+      params.otp = options.otp;
+    } else if (options.factorType === 'oob') {
+      params.oob_code = options.oobCode;
+      if (options.bindingCode) {
+        params.binding_code = options.bindingCode;
+      }
+    } else if (options.factorType === 'recovery-code') {
+      params.recovery_code = options.recoveryCode;
+    }
+
+    try {
+      const tokenEndpointResponse = await client.genericGrantRequest(
+        configuration,
+        GRANT_TYPE_MAP[options.factorType],
+        params
+      );
+
+      const tokenResponse = TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
+
+      if ((tokenEndpointResponse as Record<string, unknown>).recovery_code) {
+        tokenResponse.recoveryCode = (tokenEndpointResponse as Record<string, unknown>).recovery_code as string;
+      }
+
+      return tokenResponse;
+    } catch (e) {
+      if (e instanceof MfaVerifyError) {
+        throw e;
+      }
+      const err = e as { error?: string; error_description?: string; message?: string };
+      throw new MfaVerifyError(err.error_description || err.message || 'Failed to verify MFA challenge', {
+        error: err.error ?? 'mfa_verify_error',
+        error_description: err.error_description ?? err.message ?? 'Failed to verify MFA challenge',
+      });
+    }
   }
 }

--- a/packages/auth0-auth-js/src/mfa/types.ts
+++ b/packages/auth0-auth-js/src/mfa/types.ts
@@ -1,3 +1,5 @@
+import type { Configuration } from 'openid-client';
+
 /**
  * Configuration options for the MFA client.
  */
@@ -12,9 +14,19 @@ export interface MfaClientOptions {
    */
   clientId: string;
   /**
+   * The client secret of the application (confidential clients only).
+   * When provided, it is included in the challenge request body.
+   */
+  clientSecret?: string;
+  /**
    * Optional, custom Fetch implementation to use.
    */
   customFetch?: typeof fetch;
+  /**
+   * @internal
+   * Callback to retrieve the openid-client Configuration for token endpoint requests.
+   */
+  getConfiguration?: () => Promise<Configuration>;
 }
 
 /**
@@ -175,6 +187,61 @@ export interface ChallengeResponse {
   /** Binding method for OOB (e.g., 'prompt') */
   bindingMethod?: string;
 }
+
+/**
+ * MFA factor types for verifying MFA challenges.
+ */
+export type MfaFactorType = 'otp' | 'oob' | 'recovery-code';
+
+/**
+ * Options for verifying an MFA challenge with an OTP code.
+ */
+export interface MfaVerifyOtpOptions {
+  /** MFA token from authentication response */
+  mfaToken: string;
+  /** Must be the OTP factor type */
+  factorType: 'otp';
+  /** The OTP code from the user's authenticator app */
+  otp: string;
+  /** Optional audience for the requested access token */
+  audience?: string;
+}
+
+/**
+ * Options for verifying an MFA challenge with an out-of-band code.
+ */
+export interface MfaVerifyOobOptions {
+  /** MFA token from authentication response */
+  mfaToken: string;
+  /** Must be the OOB factor type */
+  factorType: 'oob';
+  /** The out-of-band code received from the MFA challenge */
+  oobCode: string;
+  /** Optional binding code entered by the user (for prompt-based OOB) */
+  bindingCode?: string;
+  /** Optional audience for the requested access token */
+  audience?: string;
+}
+
+/**
+ * Options for verifying an MFA challenge with a recovery code.
+ */
+export interface MfaVerifyRecoveryCodeOptions {
+  /** MFA token from authentication response */
+  mfaToken: string;
+  /** Must be the recovery-code factor type */
+  factorType: 'recovery-code';
+  /** The recovery code */
+  recoveryCode: string;
+  /** Optional audience for the requested access token */
+  audience?: string;
+}
+
+/**
+ * Union type for all MFA verify options.
+ */
+export type MfaVerifyOptions = MfaVerifyOtpOptions | MfaVerifyOobOptions | MfaVerifyRecoveryCodeOptions;
+
 
 // Internal API Response Types (snake_case - matches Auth0 API)
 /**

--- a/packages/auth0-auth-js/src/types.ts
+++ b/packages/auth0-auth-js/src/types.ts
@@ -583,6 +583,12 @@ export class TokenResponse {
    */
   issuedTokenType?: string;
 
+  /**
+   * A new recovery code returned after verifying with a recovery code.
+   * Only present when using the recovery-code MFA factor.
+   */
+  recoveryCode?: string;
+
   constructor(
     accessToken: string,
     expiresAt: number,


### PR DESCRIPTION
## Summary
- New `verify` method - exchange MFA token + code for access tokens (otp, oob, recovery-code)
- Added `clientSecret` support to `challengeAuthenticator`
- Added `getConfiguration` option for openid-client integration
- `OAuth2Error` extended with `mfa_token` and `mfa_requirements`
- New `isMfaRequiredError(error)` type guard to detect `mfa_required` responses
- Exposes `authClient.mfa`
- Token errors now propagate `mfa_token` and `mfa_requirements` when Auth0 returns `mfa_required`

## Design decisions
- **`MfaClient` (`src/mfa/`)**: New `verify` method — exchange MFA token + code for access tokens (otp, oob, recovery-code); Added `clientSecret` support to `challengeAuthenticator`; Added `getConfiguration` option for openid-client integration
- **`errors.ts`**: `OAuth2Error` extended with `mfa_token` and `mfa_requirements`; New `isMfaRequiredError(error)` type guard to detect `mfa_required` responses
- **`AuthClient`**: Exposes `authClient.mfa`; Token errors now propagate `mfa_token` and `mfa_requirements` when Auth0 returns `mfa_required`

## Test plan
- [x] 33 unit tests covering all MFA operations (listAuthenticators, enrollAuthenticator, deleteAuthenticator, challengeAuthenticator, verify)
- [x] `verify` method coverage  flows
- [x] `npm run build` passes
