### PR TITLE
fix(auth0-auth-js): send passkey token exchange as application/json

### DIFF
--- a/packages/auth0-auth-js/EXAMPLES.md
+++ b/packages/auth0-auth-js/EXAMPLES.md
@@ -812,6 +812,11 @@ The SDK provides a passkey client for native WebAuthn-based authentication. The 
 
 The SDK is platform-agnostic — it does not call WebAuthn browser APIs directly. Your application is responsible for calling `navigator.credentials.create()` or `navigator.credentials.get()` and serializing the credential response before passing it to the SDK.
 
+> [!IMPORTANT]
+> **Client authentication differs across the passkey methods:**
+> - `register()` and `challenge()` request a challenge using only the `client_id`, so they work with **public clients** (e.g. SPAs / native apps) as well as confidential clients.
+> - `getTokenByPasskey()` performs the token exchange and **requires a confidential client** — you must configure `clientSecret`, `clientAssertionSigningKey` (private key JWT), or `useMtls`. Called on a public client (no credentials), it throws (a `PasskeyGetTokenError` whose `cause` reports that a client secret or client assertion signing key must be provided).
+
 Learn more: [Passkeys](https://auth0.com/docs/authenticate/database-connections/passkeys) | [Native Passkeys API](https://auth0.com/docs/authenticate/database-connections/passkeys/native-passkeys-api)
 
 ### Requesting a Signup Challenge
@@ -923,6 +928,17 @@ const challenge = await authClient.passkey.challenge({
 ### Exchanging a Credential for Tokens
 
 After the user completes the WebAuthn ceremony (either signup or login), exchange the credential response for Auth0 tokens.
+
+> [!IMPORTANT]
+> Unlike `register()` and `challenge()`, `getTokenByPasskey()` **requires a confidential client**. Configure the `AuthClient` with `clientSecret`, `clientAssertionSigningKey`, or `useMtls`:
+>
+> ```ts
+> const authClient = new AuthClient({
+>   domain: '<AUTH0_CUSTOM_DOMAIN>',
+>   clientId: '<AUTH0_CLIENT_ID>',
+>   clientSecret: '<AUTH0_CLIENT_SECRET>', // or clientAssertionSigningKey, or useMtls
+> });
+> ```
 
 The WebAuthn API returns binary `ArrayBuffer` fields. These must be converted to base64url-encoded strings before passing to this method. Here is a helper function you can use:
 

--- a/packages/auth0-auth-js/EXAMPLES.md
+++ b/packages/auth0-auth-js/EXAMPLES.md
@@ -815,7 +815,7 @@ The SDK is platform-agnostic — it does not call WebAuthn browser APIs directly
 > [!IMPORTANT]
 > **Client authentication differs across the passkey methods:**
 > - `register()` and `challenge()` request a challenge using only the `client_id`, so they work with **public clients** (e.g. SPAs / native apps) as well as confidential clients.
-> - `getTokenByPasskey()` performs the token exchange and **requires a confidential client** — you must configure `clientSecret`, `clientAssertionSigningKey` (private key JWT), or `useMtls`. Called on a public client (no credentials), it throws (a `PasskeyGetTokenError` whose `cause` reports that a client secret or client assertion signing key must be provided).
+> - `getTokenByPasskey()` performs the token exchange and **requires a confidential client** — you must configure either a `clientSecret` or a `clientAssertionSigningKey` (private key JWT). Called on a public client (no credentials), it throws (a `PasskeyGetTokenError` whose `cause` reports that a client secret or client assertion signing key must be provided).
 
 Learn more: [Passkeys](https://auth0.com/docs/authenticate/database-connections/passkeys) | [Native Passkeys API](https://auth0.com/docs/authenticate/database-connections/passkeys/native-passkeys-api)
 
@@ -930,13 +930,13 @@ const challenge = await authClient.passkey.challenge({
 After the user completes the WebAuthn ceremony (either signup or login), exchange the credential response for Auth0 tokens.
 
 > [!IMPORTANT]
-> Unlike `register()` and `challenge()`, `getTokenByPasskey()` **requires a confidential client**. Configure the `AuthClient` with `clientSecret`, `clientAssertionSigningKey`, or `useMtls`:
+> Unlike `register()` and `challenge()`, `getTokenByPasskey()` **requires a confidential client**. Configure the `AuthClient` with a `clientSecret` or a `clientAssertionSigningKey`:
 >
 > ```ts
 > const authClient = new AuthClient({
 >   domain: '<AUTH0_CUSTOM_DOMAIN>',
 >   clientId: '<AUTH0_CLIENT_ID>',
->   clientSecret: '<AUTH0_CLIENT_SECRET>', // or clientAssertionSigningKey, or useMtls
+>   clientSecret: '<AUTH0_CLIENT_SECRET>', // or clientAssertionSigningKey
 > });
 > ```
 

--- a/packages/auth0-auth-js/README.md
+++ b/packages/auth0-auth-js/README.md
@@ -269,20 +269,23 @@ import { AuthClient, PasskeyGetTokenError } from '@auth0/auth0-auth-js';
 const authClient = new AuthClient({
   domain: '<AUTH0_CUSTOM_DOMAIN>',
   clientId: '<AUTH0_CLIENT_ID>',
+  // Required for getTokenByPasskey() (step 3) — it needs a confidential client.
+  // register() and challenge() also work with public clients (no secret).
+  clientSecret: '<AUTH0_CLIENT_SECRET>',
 });
 
-// 1. Register a new passkey (signup)
+// 1. Register a new passkey (signup) — works with public or confidential clients
 const signupChallenge = await authClient.passkey.register({
   email: 'user@example.com',
   name: 'Jane Doe',
 });
 // Pass signupChallenge.authnParamsPublicKey to navigator.credentials.create()
 
-// 2. Authenticate with an existing passkey (login)
+// 2. Authenticate with an existing passkey (login) — works with public or confidential clients
 const loginChallenge = await authClient.passkey.challenge();
 // Pass loginChallenge.authnParamsPublicKey to navigator.credentials.get()
 
-// 3. Exchange the serialized credential response for tokens
+// 3. Exchange the serialized credential response for tokens — confidential client only
 const tokens = await authClient.passkey.getTokenByPasskey({
   authSession: signupChallenge.authSession,
   credential: serializedCredential,
@@ -292,7 +295,7 @@ const tokens = await authClient.passkey.getTokenByPasskey({
 ```
 
 > [!IMPORTANT]
-> Passkeys require the following prerequisites:
+> `getTokenByPasskey()` requires a **confidential client** (`clientSecret`, `clientAssertionSigningKey`, or `useMtls`); only `register()` and `challenge()` work with public clients. Passkeys also require the following prerequisites:
 > - A [custom domain](https://auth0.com/docs/customize/custom-domains) configured on your Auth0 tenant (e.g., `auth.example.com`, not `example.auth0.com`). The custom domain serves as the WebAuthn Relying Party (RP) ID, which must match or be a registrable domain suffix of your application's origin.
 > - A database connection with the `passkey` authentication method enabled.
 > - Your application must be served over HTTPS on a domain that aligns with the configured RP ID.

--- a/packages/auth0-auth-js/README.md
+++ b/packages/auth0-auth-js/README.md
@@ -295,7 +295,7 @@ const tokens = await authClient.passkey.getTokenByPasskey({
 ```
 
 > [!IMPORTANT]
-> `getTokenByPasskey()` requires a **confidential client** (`clientSecret`, `clientAssertionSigningKey`, or `useMtls`); only `register()` and `challenge()` work with public clients. Passkeys also require the following prerequisites:
+> `getTokenByPasskey()` requires a **confidential client** (`clientSecret` or `clientAssertionSigningKey`); only `register()` and `challenge()` work with public clients. Passkeys also require the following prerequisites:
 > - A [custom domain](https://auth0.com/docs/customize/custom-domains) configured on your Auth0 tenant (e.g., `auth.example.com`, not `example.auth0.com`). The custom domain serves as the WebAuthn Relying Party (RP) ID, which must match or be a registrable domain suffix of your application's origin.
 > - A database connection with the `passkey` authentication method enabled.
 > - Your application must be served over HTTPS on a domain that aligns with the configured RP ID.

--- a/packages/auth0-auth-js/src/auth-client.spec.ts
+++ b/packages/auth0-auth-js/src/auth-client.spec.ts
@@ -3,6 +3,7 @@ import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
 import { AuthClient } from './auth-client.js';
 import { NotSupportedError, isMfaRequiredError, TokenByPasswordError } from './errors.js';
+import { PasskeyGetTokenError } from './passkey/errors.js';
 import { ExchangeProfileOptions } from './types.js';
 
 import { generateToken, jwks } from './test-utils/tokens.js';
@@ -2907,6 +2908,147 @@ describe('exchangeToken with Token Exchange Profile', () => {
     });
 
     expect(capturedOrganization).toBeNull();
+  });
+});
+
+describe('getTokenByPasskey (WebAuthn grant)', () => {
+  const credential = {
+    id: 'cred-id',
+    rawId: 'cred-raw-id',
+    type: 'public-key',
+    authenticatorAttachment: 'platform',
+    response: {
+      clientDataJSON: 'base64url-client-data',
+      authenticatorData: 'base64url-authenticator-data',
+      signature: 'base64url-signature',
+      userHandle: 'base64url-user-handle',
+    },
+    clientExtensionResults: {},
+  };
+
+  /**
+   * Registers a JSON handler on the token endpoint that captures the request
+   * and returns a valid token response (id_token aud=<client_id>, iss=domain).
+   */
+  const mockPasskeyTokenEndpoint = async (overrides?: { idToken?: string }) => {
+    const captured: { contentType?: string | null; body?: Record<string, unknown> } = {};
+    const idToken = overrides?.idToken ?? (await generateToken(domain, 'user_passkey', '<client_id>'));
+    server.use(
+      http.post(mockOpenIdConfiguration.token_endpoint, async ({ request }) => {
+        captured.contentType = request.headers.get('content-type');
+        captured.body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          access_token: accessToken,
+          id_token: idToken,
+          expires_in: 3600,
+          token_type: 'Bearer',
+          scope: 'openid profile',
+        });
+      })
+    );
+    return captured;
+  };
+
+  test('sends application/json with authn_response as a nested object', async () => {
+    const captured = await mockPasskeyTokenEndpoint();
+    const authClient = new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });
+
+    await authClient.passkey.getTokenByPasskey({
+      authSession: 'auth-session-abc',
+      credential,
+      scope: 'openid profile',
+    });
+
+    expect(captured.contentType).toContain('application/json');
+    expect(captured.body!.grant_type).toBe('urn:okta:params:oauth:grant-type:webauthn');
+    expect(captured.body!.auth_session).toBe('auth-session-abc');
+    expect(captured.body!.scope).toBe('openid profile');
+    expect(typeof captured.body!.authn_response).toBe('object');
+    expect(captured.body!.authn_response).toEqual(credential);
+  });
+
+  test('includes client_secret for confidential clients (client_secret_post)', async () => {
+    const captured = await mockPasskeyTokenEndpoint();
+    const authClient = new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });
+
+    await authClient.passkey.getTokenByPasskey({ authSession: 'auth-session-abc', credential });
+
+    expect(captured.body!.client_id).toBe('<client_id>');
+    expect(captured.body!.client_secret).toBe('<client_secret>');
+    expect('client_assertion' in captured.body!).toBe(false);
+  });
+
+  test('includes client_assertion for private_key_jwt clients', async () => {
+    const { privateKey } = await crypto.subtle.generateKey(
+      { name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+      true,
+      ['sign', 'verify']
+    );
+    const clientAssertionSigningKey = await exportPrivateKeyToPem(privateKey);
+
+    const captured = await mockPasskeyTokenEndpoint();
+    const authClient = new AuthClient({ domain, clientId: '<client_id>', clientAssertionSigningKey });
+
+    await authClient.passkey.getTokenByPasskey({ authSession: 'auth-session-abc', credential });
+
+    expect(captured.body!.client_id).toBe('<client_id>');
+    expect(captured.body!.client_assertion_type).toBe(
+      'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
+    );
+    expect(typeof captured.body!.client_assertion).toBe('string');
+    expect('client_secret' in captured.body!).toBe(false);
+  });
+
+  test('rejects public clients (no client credentials); cause carries the MissingClientAuth reason', async () => {
+    // The passkey token exchange is confidential-only: it authenticates the
+    // client like any other grant. A client without credentials is rejected as
+    // a PasskeyGetTokenError whose cause surfaces the underlying reason.
+    const authClient = new AuthClient({ domain, clientId: '<client_id>' });
+
+    try {
+      await authClient.passkey.getTokenByPasskey({ authSession: 'auth-session-abc', credential });
+      expect.fail('Should have thrown');
+    } catch (e) {
+      const error = e as PasskeyGetTokenError;
+      expect(error.name).toBe('PasskeyGetTokenError');
+      expect(error.cause?.message).toBe('The client secret or client assertion signing key must be provided.');
+    }
+  });
+
+  test('returns a TokenResponse with decoded id_token claims', async () => {
+    await mockPasskeyTokenEndpoint();
+    const authClient = new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });
+
+    const result = await authClient.passkey.getTokenByPasskey({ authSession: 'auth-session-abc', credential });
+
+    expect(result.accessToken).toBe(accessToken);
+    expect(result.scope).toBe('openid profile');
+    expect(result.claims?.sub).toBe('user_passkey');
+    expect(result.claims?.iss).toBe(`https://${domain}/`);
+  });
+
+  test('rejects when the id_token audience does not match the client', async () => {
+    // id_token issued for a different audience → openid-client validation fails.
+    const wrongAudienceIdToken = await generateToken(domain, 'user_passkey', '<other_client>');
+    await mockPasskeyTokenEndpoint({ idToken: wrongAudienceIdToken });
+    const authClient = new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });
+
+    await expect(
+      authClient.passkey.getTokenByPasskey({ authSession: 'auth-session-abc', credential })
+    ).rejects.toThrow();
+  });
+
+  test('throws PasskeyGetTokenError when the token endpoint returns an error', async () => {
+    server.use(
+      http.post(mockOpenIdConfiguration.token_endpoint, () =>
+        HttpResponse.json({ error: 'invalid_grant', error_description: 'session expired' }, { status: 400 })
+      )
+    );
+    const authClient = new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });
+
+    await expect(
+      authClient.passkey.getTokenByPasskey({ authSession: 'expired', credential })
+    ).rejects.toMatchObject({ name: 'PasskeyGetTokenError' });
   });
 });
 

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -20,7 +20,8 @@ import {
 } from './errors.js';
 import { stripUndefinedProperties } from './utils.js';
 import { MfaClient } from './mfa/mfa-client.js';
-import { PasskeyClient } from './passkey/passkey-client.js';
+import { PasskeyClient, PASSKEY_GRANT_TYPE } from './passkey/passkey-client.js';
+import { PasskeyGetTokenError } from './passkey/errors.js';
 import { createTelemetryFetch, getTelemetryConfig } from './telemetry.js';
 import {
   AuthClientOptions,
@@ -229,6 +230,54 @@ const REQUESTED_TOKEN_TYPE_FEDERATED_CONNECTION_ACCESS_TOKEN =
   'http://auth0.com/oauth/token-type/federated-connection-access-token';
 
 /**
+ * Wraps a fetch implementation so that the passkey (WebAuthn) token request is
+ * sent as `application/json` with `authn_response` as a nested object.
+ *
+ * `openid-client`/`oauth4webapi` always serialize token requests as
+ * `application/x-www-form-urlencoded`, which would stringify `authn_response`
+ * and cause Auth0 to reject it (`"authn_response" must be of type object`).
+ * This shim runs after client authentication has been applied to the body, so
+ * any injected `client_secret`/`client_assertion` fields are preserved.
+ *
+ * For any other grant type — or if the body is not the expected
+ * `URLSearchParams` — the request is passed through unchanged.
+ */
+function createPasskeyFetch(customFetch: typeof fetch, grantType: string): typeof fetch {
+  return (input, init) => {
+    const body = init?.body;
+
+    if (grantType !== PASSKEY_GRANT_TYPE || !(body instanceof URLSearchParams)) {
+      return customFetch(input, init);
+    }
+
+    const jsonBody: Record<string, unknown> = {};
+    for (const [key, value] of body) {
+      if (key === 'authn_response') {
+        try {
+          jsonBody[key] = JSON.parse(value);
+        } catch {
+          throw new PasskeyGetTokenError('Failed to serialize the passkey credential for the token request.', {
+            error: 'invalid_request',
+            error_description: 'authn_response is not valid JSON.',
+          });
+        }
+      } else {
+        jsonBody[key] = value;
+      }
+    }
+
+    const headers = new Headers(init?.headers);
+    headers.set('Content-Type', 'application/json');
+
+    return customFetch(input, {
+      ...init,
+      headers,
+      body: JSON.stringify(jsonBody),
+    });
+  };
+}
+
+/**
  * Auth0 authentication client for handling OAuth 2.0 and OIDC flows.
  *
  * Provides methods for authorization, token exchange, token refresh, and verification
@@ -283,7 +332,18 @@ export class AuthClient {
       clientId: this.#options.clientId,
       customFetch: this.#customFetch,
       grantRequest: async (grantType, params) => {
-        const { configuration } = await this.#discover();
+        // The passkey token exchange authenticates the client like any other
+        // grant; `#discover()` throws `MissingClientAuthError` for public
+        // clients that have no credentials configured.
+        const { serverMetadata } = await this.#discover();
+
+        // Build a dedicated configuration so the passkey JSON fetch shim is not
+        // applied to the shared configuration used by other grants. The passkey
+        // token endpoint requires a JSON body with `authn_response` as a nested
+        // object; the shim rewrites the form-encoded request accordingly.
+        const configuration = await this.#createConfiguration(serverMetadata);
+        configuration[client.customFetch] = createPasskeyFetch(this.#customFetch, grantType);
+
         const tokenEndpointResponse = await client.genericGrantRequest(configuration, grantType, params);
         return TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
       },

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -21,7 +21,6 @@ import {
 import { stripUndefinedProperties } from './utils.js';
 import { MfaClient } from './mfa/mfa-client.js';
 import { PasskeyClient, PASSKEY_GRANT_TYPE } from './passkey/passkey-client.js';
-import { PasskeyGetTokenError } from './passkey/errors.js';
 import { createTelemetryFetch, getTelemetryConfig } from './telemetry.js';
 import {
   AuthClientOptions,
@@ -252,18 +251,9 @@ function createPasskeyFetch(customFetch: typeof fetch, grantType: string): typeo
 
     const jsonBody: Record<string, unknown> = {};
     for (const [key, value] of body) {
-      if (key === 'authn_response') {
-        try {
-          jsonBody[key] = JSON.parse(value);
-        } catch {
-          throw new PasskeyGetTokenError('Failed to serialize the passkey credential for the token request.', {
-            error: 'invalid_request',
-            error_description: 'authn_response is not valid JSON.',
-          });
-        }
-      } else {
-        jsonBody[key] = value;
-      }
+      // `authn_response` is serialized by PasskeyClient (JSON.stringify) to fit
+      // through URLSearchParams; restore it to a nested object for the JSON body.
+      jsonBody[key] = key === 'authn_response' ? JSON.parse(value) : value;
     }
 
     const headers = new Headers(init?.headers);

--- a/packages/auth0-auth-js/src/passkey/passkey-client.ts
+++ b/packages/auth0-auth-js/src/passkey/passkey-client.ts
@@ -21,7 +21,12 @@ import {
   transformLoginChallengeResponse,
 } from './utils.js';
 
-const PASSKEY_GRANT_TYPE = 'urn:okta:params:oauth:grant-type:webauthn';
+/**
+ * Grant type for the Auth0 native passkey (WebAuthn) token exchange.
+ *
+ * @internal
+ */
+export const PASSKEY_GRANT_TYPE = 'urn:okta:params:oauth:grant-type:webauthn';
 
 export class PasskeyClient {
   #baseUrl: string;
@@ -159,9 +164,15 @@ export class PasskeyClient {
    * `navigator.credentials.get()` for login), using the challenge obtained from
    * `register()` or `challenge()`.
    *
+   * Unlike `register()` and `challenge()` (which work with public clients), this
+   * token exchange requires a **confidential client** — the `AuthClient` must be
+   * configured with `clientSecret`, `clientAssertionSigningKey`, or `useMtls`.
+   * Without client credentials it throws a `PasskeyGetTokenError` whose `cause`
+   * reports that a client secret or client assertion signing key is required.
+   *
    * @param options - The auth session and serialized credential response
    * @returns Promise resolving to a TokenResponse with access token, ID token, and optional refresh token
-   * @throws {PasskeyGetTokenError} When the token exchange fails
+   * @throws {PasskeyGetTokenError} When the token exchange fails, or when no client credentials are configured
    *
    * @example
    * ```typescript

--- a/packages/auth0-auth-js/src/passkey/passkey-client.ts
+++ b/packages/auth0-auth-js/src/passkey/passkey-client.ts
@@ -166,9 +166,9 @@ export class PasskeyClient {
    *
    * Unlike `register()` and `challenge()` (which work with public clients), this
    * token exchange requires a **confidential client** — the `AuthClient` must be
-   * configured with `clientSecret`, `clientAssertionSigningKey`, or `useMtls`.
-   * Without client credentials it throws a `PasskeyGetTokenError` whose `cause`
-   * reports that a client secret or client assertion signing key is required.
+   * configured with a `clientSecret` or a `clientAssertionSigningKey`. Without
+   * client credentials it throws a `PasskeyGetTokenError` whose `cause` reports
+   * that a client secret or client assertion signing key is required.
    *
    * @param options - The auth session and serialized credential response
    * @returns Promise resolving to a TokenResponse with access token, ID token, and optional refresh token


### PR DESCRIPTION
### Description

Fixes `getTokenByPasskey` (the WebAuthn token exchange), which was broken since passkey support shipped in v1.7.0.

The passkey `grantRequest` delegate routed through openid-client's `genericGrantRequest`, which sends `application/x-www-form-urlencoded` with `authn_response` stringified into a form field. Auth0's [native passkey grant](https://auth0.com/docs/authenticate/database-connections/passkeys/native-passkeys-api) requires `application/json` with `authn_response` as a **nested object** — so the exchange always failed with `"authn_response" must be of type object`.

### Changes

- **`auth-client.ts`** — the passkey delegate now builds a dedicated `Configuration` and attaches a `createPasskeyFetch` shim that rewrites the WebAuthn token request from form-encoded to JSON (with `authn_response` as an object), while still calling `genericGrantRequest`. This preserves client authentication (`client_secret` / `private_key_jwt` / mTLS) and ID token validation (iss/aud/exp). The shim is a strict no-op for any other grant.
- **`passkey-client.ts`** — export `PASSKEY_GRANT_TYPE` (consumed by the shim's grant-type guard).
- **`README.md` / `EXAMPLES.md`** — document that `getTokenByPasskey()` requires a confidential client, while `register()` / `challenge()` work with public clients.

### Notes

- The shared discovery path (`#discover` / `#createConfiguration`) is **unchanged** — no impact to other grants (login, refresh, client credentials, CTE, backchannel, MFA, token vault).
- Confidential-only: a public client calling `getTokenByPasskey()` gets a `PasskeyGetTokenError` whose `cause` explains a client secret/assertion is required.
- `passkey + mTLS` routes to the standard token endpoint rather than the mTLS alias — a **pre-existing** `#createConfiguration` behavior, tracked as a separate fix.
- `auth0-server-js` passkey wiring is out of scope here (separate PR); its tests will re-validate against this JSON wire format.

### Testing

Added a `getTokenByPasskey (WebAuthn grant)` suite covering: JSON content-type + nested `authn_response`, `client_secret` and `private_key_jwt` client auth, public-client rejection, ID token audience-mismatch rejection, and token-endpoint error wrapping. Full suite: 227 passing.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified passkey authentication docs and examples: register() and challenge() work with public clients; getTokenByPasskey() requires a confidential client (client secret or assertion key).
  * Added configuration example for token exchange and expanded error guidance: missing credentials surface a clear PasskeyGetTokenError indicating the required secret or assertion key (or mTLS).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->