### PR TITLE
fix(auth0-auth-js): surface mfa_required from passkey token exchange

### DIFF
--- a/packages/auth0-auth-js/EXAMPLES.md
+++ b/packages/auth0-auth-js/EXAMPLES.md
@@ -656,7 +656,7 @@ The SDK provides an MFA client to manage multi-factor authentication for your us
 
 ### Handling the MFA Required Response
 
-When the server requires multi-factor authentication, token request methods (`getTokenByPassword`, `getTokenByRefreshToken`, `exchangeToken`) throw their usual error class (`TokenByPasswordError`, `TokenByRefreshTokenError`, `TokenExchangeError`) with extra MFA context on `cause`:
+When the server requires multi-factor authentication, token request methods (`getTokenByPassword`, `getTokenByRefreshToken`, `exchangeToken`, `passkey.getTokenByPasskey`) throw their usual error class (`TokenByPasswordError`, `TokenByRefreshTokenError`, `TokenExchangeError`, `PasskeyGetTokenError`) with extra MFA context on `cause`:
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -1094,6 +1094,29 @@ try {
   }
 }
 ```
+> [!NOTE]
+> When MFA is enabled, `getTokenByPasskey()` can fail with an `mfa_required` response — the passkey is verified, but the user must still complete a second factor. The thrown `PasskeyGetTokenError` carries `cause.mfa_token` and `cause.mfa_requirements` so you can continue with the MFA APIs. Use the `isMfaRequiredError` type guard to detect and narrow it:
+>
+> ```ts
+> import { isMfaRequiredError } from '@auth0/auth0-auth-js';
+>
+> try {
+>   const tokens = await authClient.passkey.getTokenByPasskey({
+>     authSession: challenge.authSession,
+>     credential: serializedCredential,
+>   });
+> } catch (error) {
+>   if (isMfaRequiredError(error)) {
+>     // error.cause.mfa_token is guaranteed to be a string here
+>     const challenge = await authClient.mfa.challengeAuthenticator({
+>       mfaToken: error.cause.mfa_token,
+>       challengeType: 'otp',
+>     });
+>   }
+> }
+> ```
+>
+> See [Handling the MFA Required Response](#handling-the-mfa-required-response) for the full flow.
 
 ## Custom Token Exchange
 

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -11,6 +11,7 @@ import {
   NotSupportedError,
   NotSupportedErrorCode,
   OAuth2Error,
+  toOAuth2Error,
   TokenByClientCredentialsError,
   TokenByCodeError,
   TokenByPasswordError,
@@ -141,26 +142,6 @@ function validateSubjectToken(token: string): void {
   if (/^bearer\s+/i.test(token)) {
     throw new TokenExchangeError("subject_token must not include the 'Bearer ' prefix");
   }
-}
-
-function toOAuth2Error(e: unknown): OAuth2Error {
-  if (typeof e !== 'object' || e === null) {
-    return { error: 'unknown_error', error_description: String(e) };
-  }
-  const err = e as { error?: string; error_description?: string; cause?: Record<string, unknown>; message?: string };
-  const base: OAuth2Error = {
-    error: err.error ?? '',
-    error_description: err.error_description ?? '',
-    message: err.message,
-  };
-  if (err.error === 'mfa_required' && err.cause) {
-    base.mfa_token = typeof err.cause.mfa_token === 'string' ? err.cause.mfa_token : undefined;
-    const req = err.cause.mfa_requirements;
-    if (typeof req === 'object' && req !== null) {
-      base.mfa_requirements = req as OAuth2Error['mfa_requirements'];
-    }
-  }
-  return base;
 }
 
 /**

--- a/packages/auth0-auth-js/src/errors.ts
+++ b/packages/auth0-auth-js/src/errors.ts
@@ -31,6 +31,37 @@ export interface OAuth2Error {
 }
 
 /**
+ * Normalizes an unknown error (typically thrown by `openid-client`) into an
+ * {@link OAuth2Error}.
+ *
+ * On an `mfa_required` response, `openid-client` nests the server's `mfa_token`
+ * and `mfa_requirements` under `error.cause`; this lifts them to the top level
+ * so {@link isMfaRequiredError} can detect the error and callers can continue
+ * with the MFA APIs.
+ *
+ * @internal
+ */
+export function toOAuth2Error(e: unknown): OAuth2Error {
+  if (typeof e !== 'object' || e === null) {
+    return { error: 'unknown_error', error_description: String(e) };
+  }
+  const err = e as { error?: string; error_description?: string; cause?: Record<string, unknown>; message?: string };
+  const base: OAuth2Error = {
+    error: err.error ?? '',
+    error_description: err.error_description ?? '',
+    message: err.message,
+  };
+  if (err.error === 'mfa_required' && err.cause) {
+    base.mfa_token = typeof err.cause.mfa_token === 'string' ? err.cause.mfa_token : undefined;
+    const req = err.cause.mfa_requirements;
+    if (typeof req === 'object' && req !== null) {
+      base.mfa_requirements = req as OAuth2Error['mfa_requirements'];
+    }
+  }
+  return base;
+}
+
+/**
  * Error codes used for {@link NotSupportedError}
  */
 export enum NotSupportedErrorCode {
@@ -202,8 +233,9 @@ export class BuildUnlinkUserUrlError extends ApiError {
  * Narrows an error thrown by a token request method to one caused by an `mfa_required` response.
  *
  * When the Auth0 server requires multi-factor authentication, token request methods
- * (`getTokenByPassword`, `getTokenByRefreshToken`, `exchangeToken`) throw their usual error
- * (e.g. `TokenByPasswordError`) with `cause.error` set to `'mfa_required'`.
+ * (`getTokenByPassword`, `getTokenByRefreshToken`, `exchangeToken`, `passkey.getTokenByPasskey`)
+ * throw their usual error (e.g. `TokenByPasswordError`, `PasskeyGetTokenError`) with
+ * `cause.error` set to `'mfa_required'`.
  * The `cause` will also contain:
  * - `mfa_token` — the token needed to proceed with enrollment or challenge MFA APIs
  * - `mfa_requirements` — (optional) describes which factors to challenge or enroll

--- a/packages/auth0-auth-js/src/passkey/errors.ts
+++ b/packages/auth0-auth-js/src/passkey/errors.ts
@@ -1,3 +1,5 @@
+import type { MfaRequirements } from '../errors.js';
+
 /**
  * Interface to represent a Passkey API error response.
  */
@@ -5,6 +7,19 @@ export interface PasskeyApiErrorResponse {
   error: string;
   error_description: string;
   message?: string;
+}
+
+/**
+ * Passkey token exchange (`getTokenByPasskey`) error response.
+ *
+ * In addition to the common fields, an `mfa_required` response carries
+ * `mfa_token` and `mfa_requirements` (mirroring {@link OAuth2Error}). Only the
+ * token exchange can require MFA; the signup/login challenge requests cannot.
+ * Use {@link isMfaRequiredError} to detect this case and continue with the MFA APIs.
+ */
+export interface PasskeyGetTokenApiErrorResponse extends PasskeyApiErrorResponse {
+  mfa_token?: string;
+  mfa_requirements?: MfaRequirements;
 }
 
 /**
@@ -48,10 +63,20 @@ export class PasskeyChallengeError extends PasskeyError {
 
 /**
  * Error thrown when exchanging a passkey credential for tokens fails.
+ *
+ * Unlike the challenge errors, this carries `mfa_token` / `mfa_requirements` on
+ * its `cause` when the server responds with `mfa_required`.
  */
 export class PasskeyGetTokenError extends PasskeyError {
-  constructor(message: string, cause?: PasskeyApiErrorResponse) {
+  declare public cause?: PasskeyGetTokenApiErrorResponse;
+
+  constructor(message: string, cause?: PasskeyGetTokenApiErrorResponse) {
     super('passkey_get_token_error', message, cause);
     this.name = 'PasskeyGetTokenError';
+
+    if (this.cause && cause) {
+      this.cause.mfa_token = cause.mfa_token;
+      this.cause.mfa_requirements = cause.mfa_requirements;
+    }
   }
 }

--- a/packages/auth0-auth-js/src/passkey/errors.ts
+++ b/packages/auth0-auth-js/src/passkey/errors.ts
@@ -74,9 +74,16 @@ export class PasskeyGetTokenError extends PasskeyError {
     super('passkey_get_token_error', message, cause);
     this.name = 'PasskeyGetTokenError';
 
-    if (this.cause && cause) {
-      this.cause.mfa_token = cause.mfa_token;
-      this.cause.mfa_requirements = cause.mfa_requirements;
-    }
+    // The base constructor intentionally drops `mfa_token` / `mfa_requirements`
+    // (the challenge errors must not expose them). This error is the only one
+    // that can carry them, so set the full cause here rather than relying on
+    // the base's narrowed copy.
+    this.cause = cause && {
+      error: cause.error,
+      error_description: cause.error_description,
+      message: cause.message,
+      mfa_token: cause.mfa_token,
+      mfa_requirements: cause.mfa_requirements,
+    };
   }
 }

--- a/packages/auth0-auth-js/src/passkey/passkey-client.spec.ts
+++ b/packages/auth0-auth-js/src/passkey/passkey-client.spec.ts
@@ -1097,6 +1097,28 @@ describe('PasskeyClient', () => {
         }
       }
     });
+
+    test('does not satisfy isMfaRequiredError when mfa_required has no mfa_token', async () => {
+      // Auth0 can return mfa_required without an mfa_token (e.g. enrollment-required).
+      // isMfaRequiredError requires a string mfa_token, so it must return false here,
+      // while the error still reports error === 'mfa_required'.
+      const grantRequest = vi.fn().mockRejectedValue({
+        error: 'mfa_required',
+        error_description: 'MFA enrollment required',
+        cause: {},
+      });
+      const client = createClient({ grantRequest });
+
+      try {
+        await client.getTokenByPasskey({ authSession: 'session', credential: mockCredentialCreation });
+        expect.fail('Should have thrown');
+      } catch (e) {
+        expect(isMfaRequiredError(e)).toBe(false);
+        const error = e as PasskeyGetTokenError;
+        expect(error.cause?.error).toBe('mfa_required');
+        expect(error.cause?.mfa_token).toBeUndefined();
+      }
+    });
   });
 
   // ─── customFetch ───────────────────────────────────────────────────

--- a/packages/auth0-auth-js/src/passkey/passkey-client.spec.ts
+++ b/packages/auth0-auth-js/src/passkey/passkey-client.spec.ts
@@ -9,6 +9,7 @@ import {
 } from './errors.js';
 import type { GrantRequestFn } from './types.js';
 import { TokenResponse } from '../types.js';
+import { isMfaRequiredError } from '../errors.js';
 
 const domain = 'auth0.local';
 const clientId = 'test-client-id';
@@ -1050,6 +1051,50 @@ describe('PasskeyClient', () => {
         expect(error.message).toBe('Authentication session expired');
         expect(error.cause?.error).toBe('invalid_grant');
         expect(error.cause?.error_description).toBe('Authentication session expired');
+      }
+    });
+
+    test('preserves mfa_token and mfa_requirements in the cause on an mfa_required error', async () => {
+      // openid-client surfaces the token endpoint's mfa_required body nested under `cause`.
+      const grantRequest = vi.fn().mockRejectedValue({
+        error: 'mfa_required',
+        error_description: 'Multifactor authentication required',
+        cause: {
+          mfa_token: 'mfa_tok_abc123',
+          mfa_requirements: { challenge: [{ type: 'otp' }] },
+        },
+      });
+      const client = createClient({ grantRequest });
+
+      try {
+        await client.getTokenByPasskey({ authSession: 'session', credential: mockCredentialCreation });
+        expect.fail('Should have thrown');
+      } catch (e) {
+        const error = e as PasskeyGetTokenError;
+        expect(error).toBeInstanceOf(PasskeyGetTokenError);
+        expect(error.cause?.error).toBe('mfa_required');
+        expect(error.cause?.mfa_token).toBe('mfa_tok_abc123');
+        expect(error.cause?.mfa_requirements).toEqual({ challenge: [{ type: 'otp' }] });
+      }
+    });
+
+    test('is recognized by isMfaRequiredError so the MFA flow can continue', async () => {
+      const grantRequest = vi.fn().mockRejectedValue({
+        error: 'mfa_required',
+        error_description: 'Multifactor authentication required',
+        cause: { mfa_token: 'mfa_tok_xyz789' },
+      });
+      const client = createClient({ grantRequest });
+
+      try {
+        await client.getTokenByPasskey({ authSession: 'session', credential: mockCredentialCreation });
+        expect.fail('Should have thrown');
+      } catch (e) {
+        expect(isMfaRequiredError(e)).toBe(true);
+        if (isMfaRequiredError(e)) {
+          // Narrowed: cause.mfa_token is guaranteed defined.
+          expect(e.cause.mfa_token).toBe('mfa_tok_xyz789');
+        }
       }
     });
   });

--- a/packages/auth0-auth-js/src/passkey/passkey-client.ts
+++ b/packages/auth0-auth-js/src/passkey/passkey-client.ts
@@ -10,6 +10,7 @@ import type {
   GrantRequestFn,
 } from './types.js';
 import type { TokenResponse } from '../types.js';
+import { toOAuth2Error } from '../errors.js';
 import {
   PasskeyRegisterError,
   PasskeyChallengeError,
@@ -201,9 +202,10 @@ export class PasskeyClient {
     try {
       return await this.#grantRequest(PASSKEY_GRANT_TYPE, params);
     } catch (e) {
+      const apiError = toOAuth2Error(e);
       throw new PasskeyGetTokenError(
-        (e as PasskeyApiErrorResponse).error_description || 'Failed to exchange passkey credential for tokens.',
-        e as PasskeyApiErrorResponse,
+        apiError.error_description || 'Failed to exchange passkey credential for tokens.',
+        apiError,
       );
     }
   }


### PR DESCRIPTION
## Description

When MFA is enabled, Auth0's passkey token exchange (`getTokenByPasskey`, grant `urn:okta:params:oauth:grant-type:webauthn`) returns an `mfa_required` error at `/oauth/token` with an `mfa_token` — just like ROPG and other grants. The SDK was **dropping** `mfa_token` / `mfa_requirements` when building `PasskeyGetTokenError`, so `isMfaRequiredError()` returned `false` and callers couldn't continue into the MFA flow after a passkey login. Passkey was the only token method missing this parity.

## Changes

- **`passkey-client.ts`** — `getTokenByPasskey` now normalizes the thrown error via the shared `toOAuth2Error`, lifting `mfa_token` / `mfa_requirements` from the nested `openid-client` error cause.
- **`errors.ts`** — moved `toOAuth2Error` out of `auth-client.ts` into `errors.ts` (a leaf module) and exported it, so `auth-client` and `passkey-client` share one canonical implementation with no circular import. `isMfaRequiredError` JSDoc now lists `getTokenByPasskey`.
- **`auth-client.ts`** — imports `toOAuth2Error` from `errors.js`; behavior unchanged for existing flows.
- **`passkey/errors.ts`** — added `PasskeyGetTokenApiErrorResponse` and scoped the MFA fields to `PasskeyGetTokenError` only. `PasskeyRegisterError` / `PasskeyChallengeError` keep the base type, since challenge requests can't return `mfa_required`.
- **`EXAMPLES.md`** — documented MFA handling for `getTokenByPasskey`.

## Usage

```ts
try {
  await authClient.passkey.getTokenByPasskey({ authSession, credential });
} catch (error) {
  if (isMfaRequiredError(error)) {
    await authClient.mfa.challengeAuthenticator({
      mfaToken: error.cause.mfa_token,
      challengeType: 'otp',
    });
  }
}
```
## Breaking changes
None. Additive only — error class names, code values, and constructor signatures are unchanged. Verified backward-compatible with auth0-spa-js.

## Note for reviewers
`toOAuth2Error` is now reachable from the public type surface (via `export * in index.ts`), alongside the pre-existing transitive leak of `GrantRequestFn` / `*ClientOptions`. This is intentionally deferred to a follow-up PR that will tighten the public API (e.g. stripInternal) in one deliberate, verified change — out of scope here.

## Testing
New tests: `mfa_token` / `mfa_requirements` preserved on `PasskeyGetTokenError.cause; isMfaRequiredError()` recognizes it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MFA error handling for passkey sign-in so MFA details (MFA token and requirements) are preserved and surfaced for recovery flows.

* **Documentation**
  * Expanded guidance and examples for handling MFA-required responses during passkey authentication, including how to continue with an MFA challenge.

* **Tests**
  * Added tests covering MFA error scenarios in the passkey token exchange.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->