### PR TITLE
chore(auth0-auth-js): enable stripInternal to hide @internal symbols …

### DIFF
--- a/packages/auth0-auth-js/tsconfig.json
+++ b/packages/auth0-auth-js/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@auth0/typescript-config/tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "stripInternal": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
`@internal`-tagged symbols were being emitted into the published `.d.ts`, exposing them as de-facto public API — the tags were cosmetic because `stripInternal` was never enabled. This sets `"stripInternal": true` so the tags actually take effect.

Removes 17 internal symbols from the declarations, including `toOAuth2Error` (the only one in the `export {}` list), `GrantRequestFn`, `MfaClientOptions`, `PasskeyClientOptions`, the `*ApiResponse` types, and `transform*` helpers.

## Impact

- Declarations-only: no runtime/JS change.
- Public exports: 86 --> 85 (only `toOAuth2Error` removed; all genuine public API preserved).
- Emitted `.d.ts` type-checks clean (no dangling references).
- Verified `auth0-server-js`, `auth0-api-js`, and `auth0-spa-js` import none of the stripped symbols and build green.

## Breaking changes

Technically a type-surface change (names removed from `.d.ts`), but no real consumer depends on the stripped internals. This change should be shipped as a **minor**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to strip internal declarations from compiled output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->