### PR TITLE
chore: correct root package.json name and mark it private

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "auth0-server-js",
+  "name": "auth0-auth-js",
   "version": "1.0.0",
+  "private": true,
   "workspaces": [
     "packages/*",
     "examples/*"


### PR DESCRIPTION
The monorepo root `package.json` had a stale `name` (`auth0-server-js`, a scaffolding leftover) and no `private` flag.

- Renamed root `name` → `auth0-auth-js` to match the repo.
- Added `"private": true` to guard against accidental publish of the workspace root.

## Impact

- No runtime/consumer/pipeline impact. The bare name `auth0-server-js` is referenced nowhere except this line; the release pipeline publishes the scoped sub-packages (`@auth0/auth0-auth-js`, etc.) from `packages/*`, never the root.
- `private: true` only blocks publishing the root (never published anyway) — it does not affect `npm install`/`ci` or `turbo` workspace tasks.
