### PR TITLE
feat(auth0-server-js): enforce IPSIE session_expiry as a session ceiling

### DIFF
--- a/packages/auth0-server-js/EXAMPLES.md
+++ b/packages/auth0-server-js/EXAMPLES.md
@@ -1054,6 +1054,63 @@ const accessToken = await serverClient.getAccessTokenForConnection({}, storeOpti
 
 Read more above in [Configuring the Store](#configuring-the-store)
 
+## Session expiry from upstream IdP (IPSIE `session_expiry`)
+
+When you use an Okta or OIDC **enterprise connection** configured with `id_token_session_expiry_supported: true`, Auth0 includes a `session_expiry` claim in the ID token it issues to your application. This claim is an absolute Unix timestamp (seconds) that marks the latest moment the upstream identity provider considers the session valid. It is computed by Auth0 as the earliest of: your tenant's absolute session lifetime, the upstream IdP's own session expiry, and any value an Action sets via `api.session.setExpiresAt`.
+
+### What the SDK does automatically
+
+No configuration or code change is required. When the claim is present, the SDK:
+
+- persists it on the session as a top-level `sessionExpiresAt` (Unix seconds);
+- treats the session as expired once `sessionExpiresAt` is reached (with a small 30-second leeway for clock skew), on **every** `getSession()` / `getUser()` / `getAccessToken()` / `getAccessTokenForConnection()` call;
+- never refreshes a token once the ceiling has passed; and
+- caps the session cookie lifetime at the ceiling as a defense-in-depth backstop.
+
+This is layered **on top of** your existing idle and absolute session timeouts — it does not replace them. The session ends at whichever limit is reached first.
+
+### Behavior on expiry
+
+- `getSession()` and `getUser()` return `undefined` (the session is also cleared from the store). Your existing "not logged in → redirect to login" path runs unchanged.
+- `getAccessToken()` and `getAccessTokenForConnection()` throw `SessionExpiredError` (`error.code === 'session_expired'`). Catch it and send the user to log in again.
+
+```ts
+import { SessionExpiredError } from '@auth0/auth0-server-js';
+
+try {
+  const { accessToken } = await serverClient.getAccessToken(storeOptions);
+  // use accessToken
+} catch (error) {
+  if (error instanceof SessionExpiredError) {
+    return redirect(await serverClient.startInteractiveLogin({ authorizationParams: { prompt: 'login' } }, storeOptions));
+  }
+  throw error;
+}
+```
+
+### Reading the value (optional)
+
+To show a "your session ends soon" prompt, read the ceiling off the session:
+
+```ts
+const session = await serverClient.getSession(storeOptions);
+if (session?.sessionExpiresAt) {
+  const remainingSeconds = session.sessionExpiresAt - Math.floor(Date.now() / 1000);
+  // e.g. show a banner when remainingSeconds < 5 * 60
+}
+```
+
+Do not copy `sessionExpiresAt` into a separate long-lived store and trust it later — always re-read it relative to the current wall clock.
+
+### Upgrading existing apps
+
+Once an enterprise connection has the option enabled, `getSession()` / `getUser()` can return `undefined` for a user who was previously logged in, once the ceiling is reached. If your code assumed these always return a value after login, add a null check. Sessions created before the upgrade (or through connections without the option) have no `sessionExpiresAt` and behave exactly as before.
+
+### Prerequisites
+
+- The connection must be an `okta` or `oidc` enterprise connection with `id_token_session_expiry_supported: true` (Dashboard toggle "Use ID Token for Session Expiry", Management API, or Terraform).
+- Authorization Code flow.
+
 ## Logout
 
 Logging out ensures the stored tokens and user information are removed, and that the user is no longer considered logged-in by the SDK.

--- a/packages/auth0-server-js/README.md
+++ b/packages/auth0-server-js/README.md
@@ -11,6 +11,7 @@ Using this SDK as-is in your application may not be trivial, as it is designed t
 ## Documentation
 
 - [Examples](https://github.com/auth0/auth0-auth-js/blob/main/packages/auth0-server-js/EXAMPLES.md) - examples for your different use cases.
+  - [Session expiry from upstream IdP (IPSIE `session_expiry`)](https://github.com/auth0/auth0-auth-js/blob/main/packages/auth0-server-js/EXAMPLES.md#session-expiry-from-upstream-idp-ipsie-session_expiry) - enforce the upstream IdP session ceiling.
 - [Docs Site](https://auth0.com/docs) - explore our docs site and learn more about Auth0.
 
 ## Getting Started

--- a/packages/auth0-server-js/src/errors.spec.ts
+++ b/packages/auth0-server-js/src/errors.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { StartLinkUserError } from './errors.js';
+import { SessionExpiredError, StartLinkUserError } from './errors.js';
 
 describe('StartLinkUserError', () => {
   test('sets name and code', () => {
@@ -8,5 +8,22 @@ describe('StartLinkUserError', () => {
     expect(error.message).toBe('link failed');
     expect(error.name).toBe('StartLinkUserError');
     expect(error.code).toBe('start_link_user_error');
+  });
+});
+
+describe('SessionExpiredError', () => {
+  test('sets name, code, and default message', () => {
+    const error = new SessionExpiredError();
+
+    expect(error.name).toBe('SessionExpiredError');
+    expect(error.code).toBe('session_expired');
+    expect(error.message.length).toBeGreaterThan(0);
+  });
+
+  test('accepts a custom message', () => {
+    const error = new SessionExpiredError('ceiling reached');
+
+    expect(error.message).toBe('ceiling reached');
+    expect(error.code).toBe('session_expired');
   });
 });

--- a/packages/auth0-server-js/src/errors.ts
+++ b/packages/auth0-server-js/src/errors.ts
@@ -82,3 +82,19 @@ export class IssuerValidationError extends Error {
     this.name = 'IssuerValidationError';
   }
 }
+
+/**
+ * Error thrown when the session has passed its upstream IdP-asserted
+ * `session_expiry` ceiling (IPSIE SL1). The user must re-authenticate.
+ */
+export class SessionExpiredError extends Error {
+  public code: string = 'session_expired';
+
+  constructor(message?: string) {
+    super(
+      message ??
+        'The session has expired because the upstream identity provider session ceiling was reached. The user needs to re-authenticate.'
+    );
+    this.name = 'SessionExpiredError';
+  }
+}

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, afterAll, afterEach, beforeAll, beforeEach, vi } from 'vitest';
 import { ServerClient } from './server-client.js';
-import { InvalidConfigurationError, MissingSessionError } from './errors.js';
+import { InvalidConfigurationError, MissingSessionError, SessionExpiredError } from './errors.js';
 import { AuthClient, TokenResponse } from '@auth0/auth0-auth-js';
 
 import * as Auth0AuthJs from '@auth0/auth0-auth-js';
@@ -1631,6 +1631,62 @@ test('completeInteractiveLogin - should call cookieHandler.setCookie with custom
     expect.objectContaining({ path: '/custom_path', secure: false, sameSite: 'none' }),
     undefined
   );
+});
+
+test('completeInteractiveLogin - throws SessionExpiredError and persists nothing when session_expiry is at or before iat (lockout guard)', async () => {
+  const iat = Math.floor(Date.now() / 1000);
+  const mockStateStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+  const mockTransactionStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+  };
+
+  mockTransactionStore.get.mockResolvedValue({
+    codeVerifier: '<code_verifier>',
+    domain,
+  });
+  mockStateStore.get.mockResolvedValue(undefined);
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: mockTransactionStore,
+    stateStore: mockStateStore,
+  });
+
+  const tokenResponse = new TokenResponse(
+    accessToken,
+    iat + 500,
+    '<id_token>',
+    '<refresh_token>',
+    '<scope>',
+    asIdTokenClaims({
+      sub: 'user_123',
+      iat,
+      exp: iat + 500,
+      session_expiry: iat, // Already expired at login (session_expiry <= iat)
+    })
+  );
+
+  const getTokenByCodeSpy = vi.spyOn(AuthClient.prototype, 'getTokenByCode').mockResolvedValue(tokenResponse);
+
+  try {
+    await expect(
+      serverClient.completeInteractiveLogin(new URL(`https://${domain}?code=123`))
+    ).rejects.toBeInstanceOf(SessionExpiredError);
+
+    // State must NOT be persisted when lockout guard triggers
+    expect(mockStateStore.set).not.toHaveBeenCalled();
+  } finally {
+    getTokenByCodeSpy.mockRestore();
+  }
 });
 
 test('completeLinkUser - should throw when no transaction', async () => {
@@ -4337,4 +4393,288 @@ test('Telemetry - should include Auth0-Client header in token requests', async (
   const decoded = JSON.parse(Buffer.from(capturedHeader!, 'base64').toString());
   expect(decoded.name).toBe('@auth0/auth0-server-js');
   expect(decoded.version).toMatch(/^\d+\.\d+\.\d+/);
+});
+
+test('getSession - returns undefined and deletes the session once the session_expiry ceiling is reached', async () => {
+  const mockStateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [],
+    sessionExpiresAt: Math.floor(Date.now() / 1000) - 60, // already past
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const session = await serverClient.getSession();
+
+  expect(session).toBeUndefined();
+  expect(mockStateStore.delete).toHaveBeenCalled();
+});
+
+test('getSession - returns the session (including sessionExpiresAt) when the ceiling is in the future', async () => {
+  const mockStateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  const future = Math.floor(Date.now() / 1000) + 3600;
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [],
+    sessionExpiresAt: future,
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const session = await serverClient.getSession();
+
+  expect(session).toBeDefined();
+  expect(session!.sessionExpiresAt).toBe(future);
+  expect(mockStateStore.delete).not.toHaveBeenCalled();
+});
+
+test('getSession - a session without sessionExpiresAt is returned unchanged (non-breaking)', async () => {
+  const mockStateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [],
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const session = await serverClient.getSession();
+
+  expect(session).toBeDefined();
+  expect(mockStateStore.delete).not.toHaveBeenCalled();
+});
+
+test('getUser - returns undefined and deletes the session once the ceiling is reached', async () => {
+  const mockStateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [],
+    sessionExpiresAt: Math.floor(Date.now() / 1000) - 60,
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const user = await serverClient.getUser();
+
+  expect(user).toBeUndefined();
+  expect(mockStateStore.delete).toHaveBeenCalled();
+});
+
+test('getSession - in resolver mode, a different-domain session returns undefined WITHOUT deleting (not ours to kill)', async () => {
+  const domainResolver = vi.fn().mockResolvedValue('other.local');
+  const mockStateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
+  const serverClient = new ServerClient({
+    domain: domainResolver,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [],
+    domain, // different from resolved 'other.local'
+    sessionExpiresAt: Math.floor(Date.now() / 1000) - 60, // even though past
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const session = await serverClient.getSession();
+
+  expect(session).toBeUndefined();
+  expect(mockStateStore.delete).not.toHaveBeenCalled();
+});
+
+test('getAccessToken - throws SessionExpiredError and never calls the token endpoint once the ceiling is reached', async () => {
+  const mockStateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [{ audience: 'default', accessToken: '<access_token>', expiresAt: 0, scope: '<scope>' }],
+    sessionExpiresAt: Math.floor(Date.now() / 1000) - 60,
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const refreshSpy = vi.spyOn(AuthClient.prototype, 'getTokenByRefreshToken');
+
+  try {
+    await expect(serverClient.getAccessToken()).rejects.toBeInstanceOf(SessionExpiredError);
+    expect(refreshSpy).not.toHaveBeenCalled();
+    expect(mockStateStore.delete).toHaveBeenCalled();
+  } finally {
+    refreshSpy.mockRestore();
+  }
+});
+
+test('getAccessToken - still serves a valid cached token when the ceiling is in the future (regression)', async () => {
+  const mockStateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [{ audience: 'default', accessToken: '<access_token>', expiresAt: Math.floor(Date.now() / 1000) + 500, scope: '<scope>' }],
+    sessionExpiresAt: Math.floor(Date.now() / 1000) + 3600,
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const result = await serverClient.getAccessToken();
+
+  expect(result.accessToken).toBe('<access_token>');
+  expect(mockStateStore.delete).not.toHaveBeenCalled();
+});
+
+test('getAccessTokenForConnection - throws SessionExpiredError and never calls the token endpoint once the ceiling is reached', async () => {
+  const mockStateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [],
+    connectionTokenSets: [{ connection: '<connection>', accessToken: '<c_token>', expiresAt: 0, scope: '<scope>' }],
+    sessionExpiresAt: Math.floor(Date.now() / 1000) - 60,
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const connSpy = vi.spyOn(AuthClient.prototype, 'getTokenForConnection');
+
+  try {
+    await expect(serverClient.getAccessTokenForConnection({ connection: '<connection>' })).rejects.toBeInstanceOf(SessionExpiredError);
+    expect(connSpy).not.toHaveBeenCalled();
+    expect(mockStateStore.delete).toHaveBeenCalled();
+  } finally {
+    connSpy.mockRestore();
+  }
+});
+
+test('startLinkUser - throws SessionExpiredError and never builds the link URL once the ceiling is reached', async () => {
+  const mockStateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [],
+    sessionExpiresAt: Math.floor(Date.now() / 1000) - 60,
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const buildSpy = vi.spyOn(AuthClient.prototype, 'buildLinkUserUrl');
+
+  try {
+    await expect(serverClient.startLinkUser({ connection: '<connection>', connectionScope: '<scope>' })).rejects.toBeInstanceOf(SessionExpiredError);
+    expect(buildSpy).not.toHaveBeenCalled();
+    expect(mockStateStore.delete).toHaveBeenCalled();
+  } finally {
+    buildSpy.mockRestore();
+  }
+});
+
+test('startUnlinkUser - throws SessionExpiredError and never builds the unlink URL once the ceiling is reached', async () => {
+  const mockStateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [],
+    sessionExpiresAt: Math.floor(Date.now() / 1000) - 60,
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const buildSpy = vi.spyOn(AuthClient.prototype, 'buildUnlinkUserUrl');
+
+  try {
+    await expect(serverClient.startUnlinkUser({ connection: '<connection>' })).rejects.toBeInstanceOf(SessionExpiredError);
+    expect(buildSpy).not.toHaveBeenCalled();
+    expect(mockStateStore.delete).toHaveBeenCalled();
+  } finally {
+    buildSpy.mockRestore();
+  }
 });

--- a/packages/auth0-server-js/src/server-client.ts
+++ b/packages/auth0-server-js/src/server-client.ts
@@ -22,8 +22,9 @@ import {
   MissingRequiredArgumentError,
   MissingSessionError,
   MissingTransactionError,
+  SessionExpiredError,
 } from './errors.js';
-import { updateStateData, updateStateDataForConnectionTokenSet } from './state/utils.js';
+import { updateStateData, updateStateDataForConnectionTokenSet, isSessionExpiryReached } from './state/utils.js';
 import {
   TokenForConnectionError,
   AuthClient,
@@ -334,6 +335,11 @@ export class ServerClient<TStoreOptions = unknown> {
       }
     }
 
+    if (isSessionExpiryReached(stateData.sessionExpiresAt)) {
+      await this.#stateStore.delete(this.#stateStoreIdentifier, storeOptions);
+      throw new SessionExpiredError();
+    }
+
     const domain = this.#getSessionDomain(stateData)!;
     const authClient = this.#getAuthClient(domain);
     const { linkUserUrl, codeVerifier } = await authClient.buildLinkUserUrl({
@@ -404,6 +410,11 @@ export class ServerClient<TStoreOptions = unknown> {
       if (!isCurrentDomain) {
         throw new MissingSessionError('Session domain does not match the current domain.');
       }
+    }
+
+    if (isSessionExpiryReached(stateData.sessionExpiresAt)) {
+      await this.#stateStore.delete(this.#stateStoreIdentifier, storeOptions);
+      throw new SessionExpiredError();
     }
 
     const domain = this.#getSessionDomain(stateData)!;
@@ -514,6 +525,11 @@ export class ServerClient<TStoreOptions = unknown> {
       }
     }
 
+    if (isSessionExpiryReached(stateData.sessionExpiresAt)) {
+      await this.#stateStore.delete(this.#stateStoreIdentifier, storeOptions);
+      return;
+    }
+
     return stateData.user;
   }
 
@@ -531,6 +547,11 @@ export class ServerClient<TStoreOptions = unknown> {
         if (!isCurrentDomain) {
           return;
         }
+      }
+
+      if (isSessionExpiryReached(stateData.sessionExpiresAt)) {
+        await this.#stateStore.delete(this.#stateStoreIdentifier, storeOptions);
+        return;
       }
 
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -565,6 +586,11 @@ export class ServerClient<TStoreOptions = unknown> {
       if (sessionDomain !== resolvedDomain) {
         throw new MissingSessionError('Session domain does not match the current domain.');
       }
+    }
+
+    if (stateData && isSessionExpiryReached(stateData.sessionExpiresAt)) {
+      await this.#stateStore.delete(this.#stateStoreIdentifier, storeOptions);
+      throw new SessionExpiredError();
     }
 
     const tokenSet = stateData?.tokenSets.find(
@@ -633,6 +659,11 @@ export class ServerClient<TStoreOptions = unknown> {
       if (sessionDomain !== resolvedDomain) {
         throw new MissingSessionError('Session domain does not match the current domain.');
       }
+    }
+
+    if (stateData && isSessionExpiryReached(stateData.sessionExpiresAt)) {
+      await this.#stateStore.delete(this.#stateStoreIdentifier, storeOptions);
+      throw new SessionExpiredError();
     }
 
     const connectionTokenSet = stateData?.connectionTokenSets?.find(

--- a/packages/auth0-server-js/src/state/utils.spec.ts
+++ b/packages/auth0-server-js/src/state/utils.spec.ts
@@ -1,7 +1,14 @@
 import { expect, test } from 'vitest';
 import { TokenResponse } from '@auth0/auth0-auth-js';
 import type { StateData } from '../types.js';
-import { updateStateData, updateStateDataForConnectionTokenSet } from './utils.js';
+import { SessionExpiredError } from '../errors.js';
+import {
+  updateStateData,
+  updateStateDataForConnectionTokenSet,
+  extractSessionExpiry,
+  isSessionExpiryReached,
+  SESSION_EXPIRY_LEEWAY,
+} from './utils.js';
 
 test('updateStateData - should add when state undefined', () => {
   const response = {
@@ -535,4 +542,189 @@ test('updateStateData - should retain or override domain for existing sessions',
     domain: 'auth0.override',
   });
   expect(overridden.domain).toBe('auth0.override');
+});
+
+test('extractSessionExpiry - returns the value for a positive integer', () => {
+  expect(extractSessionExpiry({ session_expiry: 1748566800 } as never)).toBe(1748566800);
+});
+
+test('extractSessionExpiry - returns undefined when the claim is absent', () => {
+  expect(extractSessionExpiry({ sub: '<sub>' } as never)).toBeUndefined();
+  expect(extractSessionExpiry(undefined)).toBeUndefined();
+});
+
+test('extractSessionExpiry - returns undefined for invalid shapes (fail-open)', () => {
+  expect(extractSessionExpiry({ session_expiry: '1748566800' } as never)).toBeUndefined(); // string
+  expect(extractSessionExpiry({ session_expiry: 1748566800.5 } as never)).toBeUndefined(); // float
+  expect(extractSessionExpiry({ session_expiry: 0 } as never)).toBeUndefined(); // zero
+  expect(extractSessionExpiry({ session_expiry: -5 } as never)).toBeUndefined(); // negative
+  expect(extractSessionExpiry({ session_expiry: Number.NaN } as never)).toBeUndefined(); // NaN
+});
+
+test('extractSessionExpiry - accepts a far-future integer (documents the milliseconds limitation: ms values look like valid far-future seconds and are NOT rejected)', () => {
+  const millisecondsLikeValue = 1748566800000;
+  expect(extractSessionExpiry({ session_expiry: millisecondsLikeValue } as never)).toBe(millisecondsLikeValue);
+});
+
+test('isSessionExpiryReached - undefined ceiling means no ceiling (never reached)', () => {
+  expect(isSessionExpiryReached(undefined)).toBe(false);
+});
+
+test('isSessionExpiryReached - false when now is well before the ceiling', () => {
+  const now = 1_000_000;
+  expect(isSessionExpiryReached(now + 3600, now)).toBe(false);
+});
+
+test('isSessionExpiryReached - true when now is past the ceiling', () => {
+  const now = 1_000_000;
+  expect(isSessionExpiryReached(now - 1, now)).toBe(true);
+});
+
+test('isSessionExpiryReached - true within the negative leeway window (expires early for clock skew)', () => {
+  const now = 1_000_000;
+  // ceiling is 10s in the future, but leeway is 30s, so it is already considered reached
+  expect(isSessionExpiryReached(now + 10, now)).toBe(true);
+});
+
+test('isSessionExpiryReached - true exactly at ceiling minus leeway (boundary inclusive)', () => {
+  const now = 1_000_000;
+  expect(isSessionExpiryReached(now + SESSION_EXPIRY_LEEWAY, now)).toBe(true);
+});
+
+test('isSessionExpiryReached - false just before the leeway boundary', () => {
+  const now = 1_000_000;
+  expect(isSessionExpiryReached(now + SESSION_EXPIRY_LEEWAY + 1, now)).toBe(false);
+});
+
+test('updateStateData - stamps sessionExpiresAt on a fresh login when the claim is present', () => {
+  const iat = Math.floor(Date.now() / 1000);
+  const response = {
+    idToken: '<id_token>',
+    accessToken: '<access_token>',
+    refreshToken: '<refresh_token>',
+    expiresAt: iat + 500,
+    scope: '<scope>',
+    claims: { iss: '<iss>', aud: '<audience>', sub: '<sub>', iat, exp: iat + 500, session_expiry: iat + 3600 },
+  } as unknown as TokenResponse;
+
+  const updatedState = updateStateData('<audience>', undefined, response);
+
+  expect(updatedState.sessionExpiresAt).toBe(iat + 3600);
+});
+
+test('updateStateData - leaves sessionExpiresAt undefined on a fresh login when the claim is absent (non-breaking)', () => {
+  const iat = Math.floor(Date.now() / 1000);
+  const response = {
+    idToken: '<id_token>',
+    accessToken: '<access_token>',
+    expiresAt: iat + 500,
+    claims: { iss: '<iss>', aud: '<audience>', sub: '<sub>', iat, exp: iat + 500 },
+  } as unknown as TokenResponse;
+
+  const updatedState = updateStateData('<audience>', undefined, response);
+
+  expect(updatedState.sessionExpiresAt).toBeUndefined();
+});
+
+test('updateStateData - throws SessionExpiredError when session_expiry is at or before iat (lockout guard)', () => {
+  const iat = Math.floor(Date.now() / 1000);
+  const response = {
+    idToken: '<id_token>',
+    accessToken: '<access_token>',
+    expiresAt: iat + 500,
+    claims: { iss: '<iss>', aud: '<audience>', sub: '<sub>', iat, exp: iat + 500, session_expiry: iat },
+  } as unknown as TokenResponse;
+
+  expect(() => updateStateData('<audience>', undefined, response)).toThrow(SessionExpiredError);
+});
+
+test('updateStateData - lockout guard falls back to now when iat is absent', () => {
+  const now = Math.floor(Date.now() / 1000);
+  const response = {
+    idToken: '<id_token>',
+    accessToken: '<access_token>',
+    expiresAt: now + 500,
+    claims: { iss: '<iss>', aud: '<audience>', sub: '<sub>', exp: now + 500, session_expiry: now - 10 },
+  } as unknown as TokenResponse;
+
+  expect(() => updateStateData('<audience>', undefined, response)).toThrow(SessionExpiredError);
+});
+
+test('updateStateData - preserves stored sessionExpiresAt across a refresh that lacks the claim', () => {
+  const stored = Math.floor(Date.now() / 1000) + 3600;
+  const initialState: StateData = {
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [{ accessToken: '<access_token>', scope: '<scope>', audience: '<audience>', expiresAt: Date.now() + 500 }],
+    connectionTokenSets: [],
+    user: { sub: '<sub>', iss: '<iss>' },
+    sessionExpiresAt: stored,
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+
+  const response = {
+    idToken: '<id_token_2>',
+    accessToken: '<access_token_2>',
+    expiresAt: Date.now() / 1000 + 500,
+    scope: '<scope>',
+    claims: { iss: '<iss>', aud: '<audience>', sub: '<sub>', iat: Date.now(), exp: Date.now() + 500 },
+  } as unknown as TokenResponse;
+
+  const updatedState = updateStateData('<audience>', initialState, response);
+
+  expect(updatedState.sessionExpiresAt).toBe(stored);
+});
+
+test('updateStateData - updates sessionExpiresAt when a same-user re-login carries a new claim', () => {
+  const stored = 1_000_000;
+  const next = 2_000_000;
+  const initialState: StateData = {
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [{ accessToken: '<access_token>', scope: '<scope>', audience: '<audience>', expiresAt: Date.now() + 500 }],
+    connectionTokenSets: [],
+    user: { sub: '<sub>', iss: '<iss>' },
+    sessionExpiresAt: stored,
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+
+  const response = {
+    idToken: '<id_token_2>',
+    accessToken: '<access_token_2>',
+    expiresAt: Date.now() / 1000 + 500,
+    scope: '<scope>',
+    claims: { iss: '<iss>', aud: '<audience>', sub: '<sub>', iat: 1_000, exp: Date.now() + 500, session_expiry: next },
+  } as unknown as TokenResponse;
+
+  const updatedState = updateStateData('<audience>', initialState, response);
+
+  expect(updatedState.sessionExpiresAt).toBe(next);
+});
+
+test('updateStateData - different-user re-login yields a fresh ceiling, not the stale one', () => {
+  const stale = 1_000_000;
+  const fresh = 2_000_000;
+  const initialState: StateData = {
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [{ accessToken: '<access_token>', scope: '<scope>', audience: '<audience>', expiresAt: Date.now() + 500 }],
+    connectionTokenSets: [],
+    user: { sub: '<sub>', iss: '<iss>' },
+    sessionExpiresAt: stale,
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+
+  const response = {
+    idToken: '<id_token_new>',
+    accessToken: '<access_token_new>',
+    refreshToken: '<refresh_token_new>',
+    expiresAt: Date.now() / 1000 + 500,
+    scope: '<scope>',
+    claims: { iss: '<iss>', aud: '<audience>', sub: '<different_sub>', iat: 1_000, exp: Date.now() + 500, session_expiry: fresh },
+  } as unknown as TokenResponse;
+
+  const updatedState = updateStateData('<audience>', initialState, response);
+
+  expect(updatedState.user!.sub).toBe('<different_sub>');
+  expect(updatedState.sessionExpiresAt).toBe(fresh);
 });

--- a/packages/auth0-server-js/src/state/utils.ts
+++ b/packages/auth0-server-js/src/state/utils.ts
@@ -1,5 +1,44 @@
 import type { AccessTokenForConnectionOptions, StateData } from '../types.js';
 import { TokenResponse } from '@auth0/auth0-auth-js';
+import { SessionExpiredError } from '../errors.js';
+
+/**
+ * Negative leeway (in seconds) applied to the `session_expiry` ceiling to absorb
+ * clock skew between the SDK and the Auth0 platform. The session is treated as
+ * expired slightly BEFORE the wall-clock ceiling, never after.
+ */
+export const SESSION_EXPIRY_LEEWAY = 30;
+
+/**
+ * Reads the IPSIE `session_expiry` claim (absolute Unix seconds) from ID token claims.
+ *
+ * Fail-open by design: returns `undefined` (meaning "no ceiling") unless the value is a
+ * positive integer. A missing or malformed claim MUST NEVER be treated as an already-expired
+ * session — a platform glitch must not lock out every enterprise user.
+ *
+ * @param claims The decoded ID token claims, or undefined.
+ * @returns The ceiling in Unix seconds, or undefined when absent/invalid.
+ */
+export function extractSessionExpiry(claims: TokenResponse['claims'] | undefined): number | undefined {
+  const value = claims?.session_expiry;
+  return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : undefined;
+}
+
+/**
+ * Returns whether the `session_expiry` ceiling has been reached, applying the negative leeway.
+ *
+ * @param sessionExpiresAt The stored ceiling in Unix seconds, or undefined for "no ceiling".
+ * @param nowSeconds Optional current time in Unix seconds (defaults to now). Injectable for tests.
+ * @returns `true` when the session must be treated as expired; `false` when there is no ceiling
+ *          or it has not yet been reached.
+ */
+export function isSessionExpiryReached(sessionExpiresAt: number | undefined, nowSeconds?: number): boolean {
+  if (sessionExpiresAt === undefined) {
+    return false;
+  }
+  const now = nowSeconds ?? Math.floor(Date.now() / 1000);
+  return now >= sessionExpiresAt - SESSION_EXPIRY_LEEWAY;
+}
 
 /**
  * Creates an updated token set object from the token endpoint response
@@ -63,15 +102,29 @@ export function updateStateData(
       refreshToken: tokenEndpointResponse.refreshToken ?? stateData.refreshToken,
       tokenSets,
       domain: context?.domain ?? stateData.domain,
+      sessionExpiresAt: extractSessionExpiry(tokenEndpointResponse.claims) ?? stateData.sessionExpiresAt,
     };
   } else {
     const user = tokenEndpointResponse.claims;
+    const sessionExpiresAt = extractSessionExpiry(tokenEndpointResponse.claims);
+
+    // Lockout guard: never persist a session that is already past its ceiling at login.
+    if (sessionExpiresAt !== undefined) {
+      const iatOrNow = typeof user?.iat === 'number' ? user.iat : Math.floor(Date.now() / 1000);
+      if (sessionExpiresAt <= iatOrNow) {
+        throw new SessionExpiredError(
+          'The upstream identity provider session_expiry is at or before the issued-at time; refusing to create an already-expired session.'
+        );
+      }
+    }
+
     return {
       user,
       idToken: tokenEndpointResponse.idToken,
       refreshToken: tokenEndpointResponse.refreshToken,
       tokenSets: [createUpdatedTokenSet(audience, tokenEndpointResponse)],
       domain: context?.domain,
+      sessionExpiresAt,
       internal: {
         sid: user?.sid as string,
         createdAt: Math.floor(Date.now() / 1000),

--- a/packages/auth0-server-js/src/store/abstract-session-store.ts
+++ b/packages/auth0-server-js/src/store/abstract-session-store.ts
@@ -16,15 +16,27 @@ export abstract class AbstractSessionStore<TStoreOptions> extends AbstractStateS
 
   /**
    * calculateMaxAge calculates the max age of the session based on createdAt and the rolling and absolute durations.
+   * When sessionExpiresAt is provided, caps the maxAge to not exceed the time until that ceiling.
    */
-  protected calculateMaxAge(createdAt: number) {
+  protected calculateMaxAge(createdAt: number, sessionExpiresAt?: number) {
     if (!this.#rolling) {
-      return this.#absoluteDuration;
+      let maxAge = this.#absoluteDuration;
+
+      if (sessionExpiresAt !== undefined) {
+        const now = (Date.now() / 1000) | 0;
+        maxAge = Math.min(maxAge, sessionExpiresAt - now);
+      }
+
+      return maxAge > 0 ? maxAge : 0;
     }
 
     const now = (Date.now() / 1000) | 0;
     const expiresAt = Math.min(now + this.#inactivityDuration, createdAt + this.#absoluteDuration);
-    const maxAge = expiresAt - now;
+    let maxAge = expiresAt - now;
+
+    if (sessionExpiresAt !== undefined) {
+      maxAge = Math.min(maxAge, sessionExpiresAt - now);
+    }
 
     return maxAge > 0 ? maxAge : 0;
   }

--- a/packages/auth0-server-js/src/store/stateful-state-store.ts
+++ b/packages/auth0-server-js/src/store/stateful-state-store.ts
@@ -54,7 +54,7 @@ export class StatefulStateStore<TStoreOptions> extends AbstractSessionStore<TSto
 
     sessionId ??= generateId();
 
-    const maxAge = this.calculateMaxAge(stateData.internal.createdAt);
+    const maxAge = this.calculateMaxAge(stateData.internal.createdAt, stateData.sessionExpiresAt);
     const cookieOpts = this.#getCookieOptions({
       maxAge,
     });

--- a/packages/auth0-server-js/src/store/stateless-state-store.spec.ts
+++ b/packages/auth0-server-js/src/store/stateless-state-store.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, vi } from 'vitest';
 import { StatelessStateStore } from './stateless-state-store.js';
 import { decrypt, encrypt } from './../test-utils/encryption.js';
 import { CookieHandler, CookieSerializeOptions } from './cookie-handler.js';
+import type { StateData } from '../types.js';
 
 export interface StoreOptions {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -217,4 +218,79 @@ test('delete - should call reply to clear the cookie', async () => {
   expect(storeOptions.reply.clearCookie).toHaveBeenCalledTimes(2);
   expect(storeOptions.reply.clearCookie).toHaveBeenNthCalledWith(1, '<identifier>.0');
   expect(storeOptions.reply.clearCookie).toHaveBeenNthCalledWith(2, '<identifier>.1');
+});
+
+test('set - caps the cookie maxAge at sessionExpiresAt when the ceiling is sooner than idle/absolute', async () => {
+  const store = new StatelessStateStore(
+    {
+      secret: '<secret>',
+      rolling: true,
+      absoluteDuration: 60 * 60 * 24 * 3,
+      inactivityDuration: 60 * 60 * 24 * 1,
+    },
+    new TestCookieHandler()
+  );
+
+  const setCookie = vi.fn();
+  const storeOptions = {
+    request: { cookies: {} },
+    reply: { setCookie },
+  } as unknown as StoreOptions;
+
+  const now = Math.floor(Date.now() / 1000);
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [],
+    sessionExpiresAt: now + 100, // ceiling much sooner than the multi-day idle/absolute defaults
+    internal: { sid: '<sid>', createdAt: now },
+  };
+
+  await store.set('__a0_session', stateData, false, storeOptions);
+
+  // TestCookieHandler forwards options as the 3rd arg to reply.setCookie(name, value, options).
+  const maxAges = setCookie.mock.calls
+    .map((call) => (call[2] as CookieSerializeOptions | undefined)?.maxAge)
+    .filter((v): v is number => typeof v === 'number');
+
+  expect(maxAges.length).toBeGreaterThan(0);
+  expect(Math.max(...maxAges)).toBeLessThanOrEqual(101); // capped at the ~100s ceiling, not days
+});
+
+test('set - caps the cookie maxAge at sessionExpiresAt in non-rolling mode', async () => {
+  const store = new StatelessStateStore(
+    {
+      secret: '<secret>',
+      rolling: false,
+      absoluteDuration: 60 * 60 * 24 * 3,
+    },
+    new TestCookieHandler()
+  );
+
+  const setCookie = vi.fn();
+  const storeOptions = {
+    request: { cookies: {} },
+    reply: { setCookie },
+  } as unknown as StoreOptions;
+
+  const now = Math.floor(Date.now() / 1000);
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [],
+    sessionExpiresAt: now + 100, // ceiling much sooner than the 3-day absolute duration
+    internal: { sid: '<sid>', createdAt: now },
+  };
+
+  await store.set('__a0_session', stateData, false, storeOptions);
+
+  // TestCookieHandler forwards options as the 3rd arg to reply.setCookie(name, value, options).
+  const maxAges = setCookie.mock.calls
+    .map((call) => (call[2] as CookieSerializeOptions | undefined)?.maxAge)
+    .filter((v): v is number => typeof v === 'number');
+
+  expect(maxAges.length).toBeGreaterThan(0);
+  expect(Math.max(...maxAges)).toBeLessThanOrEqual(101); // capped at the ~100s ceiling, not the 3-day absolute
 });

--- a/packages/auth0-server-js/src/store/stateless-state-store.ts
+++ b/packages/auth0-server-js/src/store/stateless-state-store.ts
@@ -19,7 +19,7 @@ export class StatelessStateStore<TStoreOptions> extends AbstractSessionStore<TSt
     removeIfExists?: boolean,
     options?: TStoreOptions | undefined
   ): Promise<void> {
-    const maxAge = this.calculateMaxAge(stateData.internal.createdAt);
+    const maxAge = this.calculateMaxAge(stateData.internal.createdAt, stateData.sessionExpiresAt);
     const cookieOpts = this.#getCookieOptions({
       maxAge,
     });

--- a/packages/auth0-server-js/src/types.ts
+++ b/packages/auth0-server-js/src/types.ts
@@ -105,6 +105,15 @@ export interface SessionData {
   tokenSets: TokenSet[];
   connectionTokenSets?: ConnectionTokenSet[];
   domain?: string;
+  /**
+   * IPSIE SL1 `session_expiry` ceiling for this session, as an absolute Unix timestamp in
+   * seconds. Present only when the user logged in through an enterprise connection configured
+   * with `id_token_session_expiry_supported: true`. When set, the SDK treats the session as
+   * expired once this time is reached (minus a small leeway) and forces re-authentication.
+   * Absent for database/social logins, connections without the option, and sessions created
+   * before this feature — those behave unchanged.
+   */
+  sessionExpiresAt?: number;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
Enforces the IPSIE `session_expiry` claim in `@auth0/auth0-server-js` as a hard ceiling on the local session. When an `Okta/OIDC` enterprise  connection has `id_token_session_expiry_supported: true`, Auth0 emits a `session_expiry` claim (absolute Unix seconds) in the ID token; this SDK now treats it as an upper bound the session and any refresh renewal must
 never outlive.

**The change is non-breaking** — all enforcement is gated on the claim being present. Sessions without it (database/social logins, the connection option disabled, or sessions created before this version) behave exactly as before.

## What it does
- **Persists the ceiling** as a top-level `SessionData.sessionExpiresAt?:  number` (Unix seconds) at login, so `getSession()` can read it back. Stamped  in `updateStateData` which is the single funnel for interactive login, backchannel login, and MFA-completed login.
- **Lockout guard** at login: if `session_expiry <= iat` (fallback to now), throws `SessionExpiredError` and persists nothing rather than storing a born-dead session.
- **Reads (`getSession` / `getUser`)** — once the ceiling is reached, the current-domain session is deleted and the call returns `undefined` (silent), so the app's existing not-logged-in redirect path fires transparently.
- **Token paths (`getAccessToken` / `getAccessTokenForConnection`)** — once the ceiling is reached, the session is deleted and `SessionExpiredError` is thrown **before** any cached token is served or any `/oauth/token` refresh is attempted (never refresh past the ceiling).
- **`startLinkUser` / `startUnlinkUser`** — same throwing enforcement, since they use the session ID token for account mutation.
- **Refresh carry-forward**: the stored ceiling is preserved across refreshes (`extractSessionExpiry(claims) ?? stored`), so a refresh that doesn't re-assert the claim can't silently remove the limit. capped at the ceiling, so a stale/stolen cookie can't replay past it. Idle/absolute timeouts stay independent.
- **Fail-open**: a missing or malformed claim means "no ceiling," never "already expired" — a platform glitch can't lock out every enterprise user.
- **~30s negative leeway** for clock skew; integer-seconds comparisons throughout.
- Adds `SessionExpiredError` (`code: 'session_expired'`) and a "Session expiry from upstream IdP" guide in EXAMPLES.md + README link.

## Behavior changes for consumers (opt-in, once the feature is enabled)
No API breakage, but two new runtime behaviors surface **only** after a connection enables the option and a user logs in through it:
- `getSession()` / `getUser()` can return `undefined` for a previously-logged-in user once the ceiling passes — apps that assumed these always return a value after login should add a null check.
- `getAccessToken()` / `getAccessTokenForConnection()` / `startLinkUser()` / `startUnlinkUser()` can throw `SessionExpiredError` past the ceiling.

## Public API (all additive)
- New optional field `SessionData.sessionExpiresAt?: number`
- New exported error `SessionExpiredError`
- New optional param on the `protected calculateMaxAge(createdAt,

Nothing removed, renamed, or retyped.

## Test plan
- [x] `extractSessionExpiry` / `isSessionExpiryReached` unit tests (valid/invalid shapes, leeway boundaries)
- [x] `updateStateData`: stamping, lockout, refresh carry-forward, same-user / different-user re-login
- [x] `getSession` / `getUser`: expired → undefined + delete; future/absent → unchanged; resolver-mode foreign domain not deleted
- [x] `getAccessToken` / `getAccessTokenForConnection`: expired → throws `SessionExpiredError`, no `/oauth/token` call, session deleted; future →cached token served (regression)
- [x] `startLinkUser` / `startUnlinkUser`: expired → throws, URL builder never called
- [x] `completeInteractiveLogin` E2E lockout
- [x] Cookie max-age cap (rolling + non-rolling)
- [x] Full suite green, `tsc --noEmit` clean, lint clean, build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions now automatically expire based on upstream identity provider claims. Expired sessions are cleared from storage, and attempts to retrieve access tokens or perform account linking operations are denied with appropriate error handling.

* **Documentation**
  * Added comprehensive documentation covering session expiry from upstream identity providers, including configuration prerequisites, behavior in login and token refresh scenarios, and upgrade guidance for existing applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->