### PR TITLE
feat(auth0-server-js): enforce IPSIE session_expiry as a session ceiling

### DIFF
--- a/packages/auth0-auth-js/src/types.ts
+++ b/packages/auth0-auth-js/src/types.ts
@@ -654,6 +654,22 @@ export interface ActClaim {
 }
 
 /**
+ * The decoded claims of an ID token issued by Auth0.
+ *
+ * Extends the base `IDToken` (which carries the standard OIDC claims plus an index signature for
+ * arbitrary claims) with explicit typings for Auth0-specific claims, so consumers get IntelliSense
+ * without casting.
+ */
+export interface IDTokenClaims extends IDToken {
+  /**
+   * IPSIE SL1 `session_expiry` claim: the absolute Unix timestamp (seconds) at which the upstream
+   * identity provider session expires. Present only for enterprise connections configured with
+   * `id_token_session_expiry_supported: true`. Absent for other connections.
+   */
+  session_expiry?: number;
+}
+
+/**
  * Represents a successful token response from Auth0.
  *
  * Contains all tokens and metadata returned from Auth0 token endpoints,
@@ -683,7 +699,7 @@ export class TokenResponse {
   /**
    * The claims of the id token.
    */
-  claims?: IDToken;
+  claims?: IDTokenClaims;
   /**
    * The authorization details of the token response.
    */
@@ -726,7 +742,7 @@ export class TokenResponse {
     idToken?: string,
     refreshToken?: string,
     scope?: string,
-    claims?: IDToken,
+    claims?: IDTokenClaims,
     authorizationDetails?: AuthorizationDetails[]
   ) {
     this.accessToken = accessToken;

--- a/packages/auth0-server-js/EXAMPLES.md
+++ b/packages/auth0-server-js/EXAMPLES.md
@@ -1367,16 +1367,18 @@ When you use an Okta or OIDC **enterprise connection** configured with `id_token
 No configuration or code change is required. When the claim is present, the SDK:
 
 - persists it on the session as a top-level `sessionExpiresAt` (Unix seconds);
-- treats the session as expired once `sessionExpiresAt` is reached (with a small 30-second leeway for clock skew), on **every** `getSession()` / `getUser()` / `getAccessToken()` / `getAccessTokenForConnection()` call;
+- treats the session as expired once `sessionExpiresAt` is reached (with a small 30-second leeway for clock skew), on **every** `getSession()` / `getUser()` / `getAccessToken()` call;
 - never refreshes a token once the ceiling has passed; and
 - caps the session cookie lifetime at the ceiling as a defense-in-depth backstop.
+
+`getAccessTokenForConnection()` is **not** capped by the ceiling: connection (Token Vault) tokens are the upstream IdP's own tokens, governed by that IdP's `expires_in` rather than the Auth0 session, so they keep working past the ceiling.
 
 This is layered **on top of** your existing idle and absolute session timeouts — it does not replace them. The session ends at whichever limit is reached first.
 
 ### Behavior on expiry
 
 - `getSession()` and `getUser()` return `undefined` (the session is also cleared from the store). Your existing "not logged in → redirect to login" path runs unchanged.
-- `getAccessToken()` and `getAccessTokenForConnection()` throw `SessionExpiredError` (`error.code === 'session_expired'`). Catch it and send the user to log in again.
+- `getAccessToken()` throws `SessionExpiredError` (`error.code === 'session_expired'`) — as do `startLinkUser()` and `startUnlinkUser()`. Catch it and send the user to log in again. (`getAccessTokenForConnection()` does not throw on the ceiling; see the note above.)
 
 ```ts
 import { SessionExpiredError } from '@auth0/auth0-server-js';

--- a/packages/auth0-server-js/EXAMPLES.md
+++ b/packages/auth0-server-js/EXAMPLES.md
@@ -1358,6 +1358,63 @@ const accessToken = await serverClient.getAccessTokenForConnection({}, storeOpti
 
 Read more above in [Configuring the Store](#configuring-the-store)
 
+## Session expiry from upstream IdP (IPSIE `session_expiry`)
+
+When you use an Okta or OIDC **enterprise connection** configured with `id_token_session_expiry_supported: true`, Auth0 includes a `session_expiry` claim in the ID token it issues to your application. This claim is an absolute Unix timestamp (seconds) that marks the latest moment the upstream identity provider considers the session valid. It is computed by Auth0 as the earliest of: your tenant's absolute session lifetime, the upstream IdP's own session expiry, and any value an Action sets via `api.session.setExpiresAt`.
+
+### What the SDK does automatically
+
+No configuration or code change is required. When the claim is present, the SDK:
+
+- persists it on the session as a top-level `sessionExpiresAt` (Unix seconds);
+- treats the session as expired once `sessionExpiresAt` is reached (with a small 30-second leeway for clock skew), on **every** `getSession()` / `getUser()` / `getAccessToken()` / `getAccessTokenForConnection()` call;
+- never refreshes a token once the ceiling has passed; and
+- caps the session cookie lifetime at the ceiling as a defense-in-depth backstop.
+
+This is layered **on top of** your existing idle and absolute session timeouts — it does not replace them. The session ends at whichever limit is reached first.
+
+### Behavior on expiry
+
+- `getSession()` and `getUser()` return `undefined` (the session is also cleared from the store). Your existing "not logged in → redirect to login" path runs unchanged.
+- `getAccessToken()` and `getAccessTokenForConnection()` throw `SessionExpiredError` (`error.code === 'session_expired'`). Catch it and send the user to log in again.
+
+```ts
+import { SessionExpiredError } from '@auth0/auth0-server-js';
+
+try {
+  const { accessToken } = await serverClient.getAccessToken(storeOptions);
+  // use accessToken
+} catch (error) {
+  if (error instanceof SessionExpiredError) {
+    return redirect(await serverClient.startInteractiveLogin({ authorizationParams: { prompt: 'login' } }, storeOptions));
+  }
+  throw error;
+}
+```
+
+### Reading the value (optional)
+
+To show a "your session ends soon" prompt, read the ceiling off the session:
+
+```ts
+const session = await serverClient.getSession(storeOptions);
+if (session?.sessionExpiresAt) {
+  const remainingSeconds = session.sessionExpiresAt - Math.floor(Date.now() / 1000);
+  // e.g. show a banner when remainingSeconds < 5 * 60
+}
+```
+
+Do not copy `sessionExpiresAt` into a separate long-lived store and trust it later — always re-read it relative to the current wall clock.
+
+### Upgrading existing apps
+
+Once an enterprise connection has the option enabled, `getSession()` / `getUser()` can return `undefined` for a user who was previously logged in, once the ceiling is reached. If your code assumed these always return a value after login, add a null check. Sessions created before the upgrade (or through connections without the option) have no `sessionExpiresAt` and behave exactly as before.
+
+### Prerequisites
+
+- The connection must be an `okta` or `oidc` enterprise connection with `id_token_session_expiry_supported: true` (Dashboard toggle "Use ID Token for Session Expiry", Management API, or Terraform).
+- Authorization Code flow.
+
 ## Logout
 
 Logging out ensures the stored tokens and user information are removed, and that the user is no longer considered logged-in by the SDK.

--- a/packages/auth0-server-js/README.md
+++ b/packages/auth0-server-js/README.md
@@ -11,7 +11,6 @@ Using this SDK as-is in your application may not be trivial, as it is designed t
 ## Documentation
 
 - [Examples](https://github.com/auth0/auth0-auth-js/blob/main/packages/auth0-server-js/EXAMPLES.md) - examples for your different use cases.
-  - [Session expiry from upstream IdP (IPSIE `session_expiry`)](https://github.com/auth0/auth0-auth-js/blob/main/packages/auth0-server-js/EXAMPLES.md#session-expiry-from-upstream-idp-ipsie-session_expiry) - enforce the upstream IdP session ceiling.
 - [Docs Site](https://auth0.com/docs) - explore our docs site and learn more about Auth0.
 
 ## Getting Started

--- a/packages/auth0-server-js/README.md
+++ b/packages/auth0-server-js/README.md
@@ -11,6 +11,7 @@ Using this SDK as-is in your application may not be trivial, as it is designed t
 ## Documentation
 
 - [Examples](https://github.com/auth0/auth0-auth-js/blob/main/packages/auth0-server-js/EXAMPLES.md) - examples for your different use cases.
+  - [Session expiry from upstream IdP (IPSIE `session_expiry`)](https://github.com/auth0/auth0-auth-js/blob/main/packages/auth0-server-js/EXAMPLES.md#session-expiry-from-upstream-idp-ipsie-session_expiry) - enforce the upstream IdP session ceiling.
 - [Docs Site](https://auth0.com/docs) - explore our docs site and learn more about Auth0.
 
 ## Getting Started

--- a/packages/auth0-server-js/src/errors.spec.ts
+++ b/packages/auth0-server-js/src/errors.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { StartLinkUserError } from './errors.js';
+import { SessionExpiredError, StartLinkUserError } from './errors.js';
 
 describe('StartLinkUserError', () => {
   test('sets name and code', () => {
@@ -8,5 +8,22 @@ describe('StartLinkUserError', () => {
     expect(error.message).toBe('link failed');
     expect(error.name).toBe('StartLinkUserError');
     expect(error.code).toBe('start_link_user_error');
+  });
+});
+
+describe('SessionExpiredError', () => {
+  test('sets name, code, and default message', () => {
+    const error = new SessionExpiredError();
+
+    expect(error.name).toBe('SessionExpiredError');
+    expect(error.code).toBe('session_expired');
+    expect(error.message.length).toBeGreaterThan(0);
+  });
+
+  test('accepts a custom message', () => {
+    const error = new SessionExpiredError('ceiling reached');
+
+    expect(error.message).toBe('ceiling reached');
+    expect(error.code).toBe('session_expired');
   });
 });

--- a/packages/auth0-server-js/src/errors.ts
+++ b/packages/auth0-server-js/src/errors.ts
@@ -82,3 +82,19 @@ export class IssuerValidationError extends Error {
     this.name = 'IssuerValidationError';
   }
 }
+
+/**
+ * Error thrown when the session has passed its upstream IdP-asserted
+ * `session_expiry` ceiling (IPSIE SL1). The user must re-authenticate.
+ */
+export class SessionExpiredError extends Error {
+  public code: string = 'session_expired';
+
+  constructor(message?: string) {
+    super(
+      message ??
+        'The session has expired because the upstream identity provider session ceiling was reached. The user needs to re-authenticate.'
+    );
+    this.name = 'SessionExpiredError';
+  }
+}

--- a/packages/auth0-server-js/src/mfa/server-mfa-client.spec.ts
+++ b/packages/auth0-server-js/src/mfa/server-mfa-client.spec.ts
@@ -5,7 +5,7 @@ import { ServerClient } from '../server-client.js';
 import { generateToken, jwks } from '../test-utils/tokens.js';
 import { DefaultStateStore } from '../test-utils/default-state-store.js';
 import { DefaultTransactionStore } from '../test-utils/default-transaction-store.js';
-import { InvalidConfigurationError } from '../errors.js';
+import { InvalidConfigurationError, SessionExpiredError } from '../errors.js';
 import {
   MfaListAuthenticatorsError,
   MfaEnrollmentError,
@@ -675,6 +675,66 @@ describe('ServerMfaClient', () => {
       const newSession = await client.getSession();
       expect(newSession!.user!.sub).toBe('user|different');
       expect(newSession!.tokenSets).toHaveLength(1);
+    });
+
+    test('stamps sessionExpiresAt from the id_token session_expiry claim on the persisted session', async () => {
+      const iat = Math.floor(Date.now() / 1000);
+      const sessionExpiry = iat + 3600;
+      const tokenWithCeiling = await generateToken(domain, 'user|123', clientId, undefined, {
+        session_expiry: sessionExpiry,
+      });
+
+      server.use(
+        http.post(`https://${domain}/custom/token`, async () => {
+          return HttpResponse.json({
+            access_token: 'mfa_access_token',
+            id_token: tokenWithCeiling,
+            refresh_token: 'mfa_refresh_token',
+            token_type: 'Bearer',
+            expires_in: 86400,
+            scope: 'openid profile email',
+          });
+        })
+      );
+
+      const client = createServerClient();
+
+      await client.mfa.verify({ mfaToken, factorType: 'otp', otp: '123456' });
+
+      const session = await client.getSession();
+      expect(session!.sessionExpiresAt).toBe(sessionExpiry);
+    });
+
+    test('throws SessionExpiredError and persists nothing when the id_token session_expiry is already past', async () => {
+      const iat = Math.floor(Date.now() / 1000);
+      // session_expiry at iat → born expired (lockout guard at the MFA login site).
+      const bornExpiredToken = await generateToken(domain, 'user|123', clientId, undefined, {
+        iat,
+        session_expiry: iat,
+      });
+
+      server.use(
+        http.post(`https://${domain}/custom/token`, async () => {
+          return HttpResponse.json({
+            access_token: 'mfa_access_token',
+            id_token: bornExpiredToken,
+            refresh_token: 'mfa_refresh_token',
+            token_type: 'Bearer',
+            expires_in: 86400,
+            scope: 'openid profile email',
+          });
+        })
+      );
+
+      const client = createServerClient();
+
+      await expect(client.mfa.verify({ mfaToken, factorType: 'otp', otp: '123456' })).rejects.toBeInstanceOf(
+        SessionExpiredError
+      );
+
+      // The born-expired session must not have been persisted.
+      const session = await client.getSession();
+      expect(session).toBeUndefined();
     });
   });
 

--- a/packages/auth0-server-js/src/mfa/server-mfa-client.ts
+++ b/packages/auth0-server-js/src/mfa/server-mfa-client.ts
@@ -1,4 +1,4 @@
-import { updateStateData } from '../state/utils.js';
+import { updateStateData, applySessionExpiryAtLogin } from '../state/utils.js';
 import type { ServerMfaClientOptions, MfaVerifyResponse } from './types.js';
 import type {
   ListAuthenticatorsOptions,
@@ -74,9 +74,12 @@ export class ServerMfaClient<TStoreOptions = unknown> {
       storeOptions
     );
 
-    const updatedStateData = updateStateData(audience, existingStateData, tokenResponse, {
-      domain: this.#options.domain,
-    });
+    const updatedStateData = applySessionExpiryAtLogin(
+      updateStateData(audience, existingStateData, tokenResponse, {
+        domain: this.#options.domain,
+      }),
+      tokenResponse.claims
+    );
 
     await this.#options.stateStore.set(
       this.#options.stateStoreIdentifier,

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -6144,9 +6144,54 @@ test('completeInteractiveLogin - throws SessionExpiredError and persists nothing
 
     // State must NOT be persisted when lockout guard triggers
     expect(mockStateStore.set).not.toHaveBeenCalled();
+    // The spent transaction must still be cleaned up even though the lockout threw
+    expect(mockTransactionStore.delete).toHaveBeenCalled();
   } finally {
     getTokenByCodeSpy.mockRestore();
   }
+});
+
+test('loginBackchannel - throws SessionExpiredError and persists nothing when session_expiry is already past at login', async () => {
+  const iat = Math.floor(Date.now() / 1000);
+  // The token endpoint returns an ID token whose session_expiry is at iat → born expired.
+  const bornExpiredIdToken = await generateToken(domain, 'user_123', '<client_id>', undefined, {
+    iat,
+    session_expiry: iat,
+  });
+
+  server.use(
+    http.post(mockOpenIdConfiguration.token_endpoint, async () => {
+      return HttpResponse.json({
+        access_token: accessToken,
+        id_token: bornExpiredIdToken,
+        expires_in: 60,
+        token_type: 'Bearer',
+        scope: '<scope>',
+      });
+    })
+  );
+
+  const mockStateStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  await expect(
+    serverClient.loginBackchannel({ loginHint: { sub: '<sub>' }, bindingMessage: '<binding_message>' })
+  ).rejects.toBeInstanceOf(SessionExpiredError);
+
+  // A born-expired session must not be persisted.
+  expect(mockStateStore.set).not.toHaveBeenCalled();
 });
 
 test('getSession - returns undefined and deletes the session once the session_expiry ceiling is reached', async () => {
@@ -6254,34 +6299,6 @@ test('getUser - returns undefined and deletes the session once the ceiling is re
   expect(mockStateStore.delete).toHaveBeenCalled();
 });
 
-test('getSession - in resolver mode, a different-domain session returns undefined WITHOUT deleting (not ours to kill)', async () => {
-  const domainResolver = vi.fn().mockResolvedValue('other.local');
-  const mockStateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
-  const serverClient = new ServerClient({
-    domain: domainResolver,
-    clientId: '<client_id>',
-    clientSecret: '<client_secret>',
-    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
-    stateStore: mockStateStore,
-  });
-
-  const stateData: StateData = {
-    user: { sub: '<sub>' },
-    idToken: '<id_token>',
-    refreshToken: '<refresh_token>',
-    tokenSets: [],
-    domain, // different from resolved 'other.local'
-    sessionExpiresAt: Math.floor(Date.now() / 1000) - 60, // even though past
-    internal: { sid: '<sid>', createdAt: Date.now() },
-  };
-  mockStateStore.get.mockResolvedValue(stateData);
-
-  const session = await serverClient.getSession();
-
-  expect(session).toBeUndefined();
-  expect(mockStateStore.delete).not.toHaveBeenCalled();
-});
-
 test('getAccessToken - throws SessionExpiredError and never calls the token endpoint once the ceiling is reached', async () => {
   const mockStateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
   const serverClient = new ServerClient({
@@ -6339,7 +6356,7 @@ test('getAccessToken - still serves a valid cached token when the ceiling is in 
   expect(mockStateStore.delete).not.toHaveBeenCalled();
 });
 
-test('getAccessTokenForConnection - throws SessionExpiredError and never calls the token endpoint once the ceiling is reached', async () => {
+test('getAccessTokenForConnection - is NOT capped by the session_expiry ceiling (connection tokens follow the upstream IdP)', async () => {
   const mockStateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
   const serverClient = new ServerClient({
     domain,
@@ -6349,26 +6366,30 @@ test('getAccessTokenForConnection - throws SessionExpiredError and never calls t
     stateStore: mockStateStore,
   });
 
+  // A still-valid cached connection token, but the Auth0 session ceiling is already in the past.
+  const validConnectionToken = {
+    connection: '<connection>',
+    accessToken: '<c_token>',
+    expiresAt: Math.floor(Date.now() / 1000) + 500,
+    scope: '<scope>',
+  };
   const stateData: StateData = {
     user: { sub: '<sub>' },
     idToken: '<id_token>',
     refreshToken: '<refresh_token>',
     tokenSets: [],
-    connectionTokenSets: [{ connection: '<connection>', accessToken: '<c_token>', expiresAt: 0, scope: '<scope>' }],
-    sessionExpiresAt: Math.floor(Date.now() / 1000) - 60,
+    connectionTokenSets: [validConnectionToken],
+    sessionExpiresAt: Math.floor(Date.now() / 1000) - 60, // ceiling reached
     internal: { sid: '<sid>', createdAt: Date.now() },
   };
   mockStateStore.get.mockResolvedValue(stateData);
 
-  const connSpy = vi.spyOn(AuthClient.prototype, 'getTokenForConnection');
+  // The ceiling must NOT short-circuit this path: the cached connection token is still served,
+  // the call does not throw, and the session is not deleted.
+  const result = await serverClient.getAccessTokenForConnection({ connection: '<connection>' });
 
-  try {
-    await expect(serverClient.getAccessTokenForConnection({ connection: '<connection>' })).rejects.toBeInstanceOf(SessionExpiredError);
-    expect(connSpy).not.toHaveBeenCalled();
-    expect(mockStateStore.delete).toHaveBeenCalled();
-  } finally {
-    connSpy.mockRestore();
-  }
+  expect(result.accessToken).toBe('<c_token>');
+  expect(mockStateStore.delete).not.toHaveBeenCalled();
 });
 
 test('startLinkUser - throws SessionExpiredError and never builds the link URL once the ceiling is reached', async () => {

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -1,6 +1,11 @@
 import { expect, test, afterAll, afterEach, beforeAll, beforeEach, vi, describe } from 'vitest';
 import { ServerClient } from './server-client.js';
-import { InvalidConfigurationError, MissingSessionError, MissingTransactionError } from './errors.js';
+import {
+  InvalidConfigurationError,
+  MissingSessionError,
+  MissingTransactionError,
+  SessionExpiredError,
+} from './errors.js';
 import { AuthClient, TokenResponse, isMfaRequiredError } from '@auth0/auth0-auth-js';
 
 import * as Auth0AuthJs from '@auth0/auth0-auth-js';
@@ -6084,4 +6089,346 @@ describe('passwordless (session layer)', () => {
     expect(stateStore.set).toHaveBeenCalledTimes(1);
     expect(transactionStore.delete).toHaveBeenCalledTimes(1);
   });
+});
+
+// ─── IPSIE session_expiry enforcement (rebased onto main) ───
+
+test('completeInteractiveLogin - throws SessionExpiredError and persists nothing when session_expiry is at or before iat (lockout guard)', async () => {
+  const iat = Math.floor(Date.now() / 1000);
+  const mockStateStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+  const mockTransactionStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+  };
+
+  mockTransactionStore.get.mockResolvedValue({
+    codeVerifier: '<code_verifier>',
+    domain,
+  });
+  mockStateStore.get.mockResolvedValue(undefined);
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: mockTransactionStore,
+    stateStore: mockStateStore,
+  });
+
+  const tokenResponse = new TokenResponse(
+    accessToken,
+    iat + 500,
+    '<id_token>',
+    '<refresh_token>',
+    '<scope>',
+    asIdTokenClaims({
+      sub: 'user_123',
+      iat,
+      exp: iat + 500,
+      session_expiry: iat, // Already expired at login (session_expiry <= iat)
+    })
+  );
+
+  const getTokenByCodeSpy = vi.spyOn(AuthClient.prototype, 'getTokenByCode').mockResolvedValue(tokenResponse);
+
+  try {
+    await expect(
+      serverClient.completeInteractiveLogin(new URL(`https://${domain}?code=123`))
+    ).rejects.toBeInstanceOf(SessionExpiredError);
+
+    // State must NOT be persisted when lockout guard triggers
+    expect(mockStateStore.set).not.toHaveBeenCalled();
+  } finally {
+    getTokenByCodeSpy.mockRestore();
+  }
+});
+
+test('getSession - returns undefined and deletes the session once the session_expiry ceiling is reached', async () => {
+  const mockStateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [],
+    sessionExpiresAt: Math.floor(Date.now() / 1000) - 60, // already past
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const session = await serverClient.getSession();
+
+  expect(session).toBeUndefined();
+  expect(mockStateStore.delete).toHaveBeenCalled();
+});
+
+test('getSession - returns the session (including sessionExpiresAt) when the ceiling is in the future', async () => {
+  const mockStateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  const future = Math.floor(Date.now() / 1000) + 3600;
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [],
+    sessionExpiresAt: future,
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const session = await serverClient.getSession();
+
+  expect(session).toBeDefined();
+  expect(session!.sessionExpiresAt).toBe(future);
+  expect(mockStateStore.delete).not.toHaveBeenCalled();
+});
+
+test('getSession - a session without sessionExpiresAt is returned unchanged (non-breaking)', async () => {
+  const mockStateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [],
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const session = await serverClient.getSession();
+
+  expect(session).toBeDefined();
+  expect(mockStateStore.delete).not.toHaveBeenCalled();
+});
+
+test('getUser - returns undefined and deletes the session once the ceiling is reached', async () => {
+  const mockStateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [],
+    sessionExpiresAt: Math.floor(Date.now() / 1000) - 60,
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const user = await serverClient.getUser();
+
+  expect(user).toBeUndefined();
+  expect(mockStateStore.delete).toHaveBeenCalled();
+});
+
+test('getSession - in resolver mode, a different-domain session returns undefined WITHOUT deleting (not ours to kill)', async () => {
+  const domainResolver = vi.fn().mockResolvedValue('other.local');
+  const mockStateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
+  const serverClient = new ServerClient({
+    domain: domainResolver,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [],
+    domain, // different from resolved 'other.local'
+    sessionExpiresAt: Math.floor(Date.now() / 1000) - 60, // even though past
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const session = await serverClient.getSession();
+
+  expect(session).toBeUndefined();
+  expect(mockStateStore.delete).not.toHaveBeenCalled();
+});
+
+test('getAccessToken - throws SessionExpiredError and never calls the token endpoint once the ceiling is reached', async () => {
+  const mockStateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [{ audience: 'default', accessToken: '<access_token>', expiresAt: 0, scope: '<scope>' }],
+    sessionExpiresAt: Math.floor(Date.now() / 1000) - 60,
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const refreshSpy = vi.spyOn(AuthClient.prototype, 'getTokenByRefreshToken');
+
+  try {
+    await expect(serverClient.getAccessToken()).rejects.toBeInstanceOf(SessionExpiredError);
+    expect(refreshSpy).not.toHaveBeenCalled();
+    expect(mockStateStore.delete).toHaveBeenCalled();
+  } finally {
+    refreshSpy.mockRestore();
+  }
+});
+
+test('getAccessToken - still serves a valid cached token when the ceiling is in the future (regression)', async () => {
+  const mockStateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [{ audience: 'default', accessToken: '<access_token>', expiresAt: Math.floor(Date.now() / 1000) + 500, scope: '<scope>' }],
+    sessionExpiresAt: Math.floor(Date.now() / 1000) + 3600,
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const result = await serverClient.getAccessToken();
+
+  expect(result.accessToken).toBe('<access_token>');
+  expect(mockStateStore.delete).not.toHaveBeenCalled();
+});
+
+test('getAccessTokenForConnection - throws SessionExpiredError and never calls the token endpoint once the ceiling is reached', async () => {
+  const mockStateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [],
+    connectionTokenSets: [{ connection: '<connection>', accessToken: '<c_token>', expiresAt: 0, scope: '<scope>' }],
+    sessionExpiresAt: Math.floor(Date.now() / 1000) - 60,
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const connSpy = vi.spyOn(AuthClient.prototype, 'getTokenForConnection');
+
+  try {
+    await expect(serverClient.getAccessTokenForConnection({ connection: '<connection>' })).rejects.toBeInstanceOf(SessionExpiredError);
+    expect(connSpy).not.toHaveBeenCalled();
+    expect(mockStateStore.delete).toHaveBeenCalled();
+  } finally {
+    connSpy.mockRestore();
+  }
+});
+
+test('startLinkUser - throws SessionExpiredError and never builds the link URL once the ceiling is reached', async () => {
+  const mockStateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [],
+    sessionExpiresAt: Math.floor(Date.now() / 1000) - 60,
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const buildSpy = vi.spyOn(AuthClient.prototype, 'buildLinkUserUrl');
+
+  try {
+    await expect(serverClient.startLinkUser({ connection: '<connection>', connectionScope: '<scope>' })).rejects.toBeInstanceOf(SessionExpiredError);
+    expect(buildSpy).not.toHaveBeenCalled();
+    expect(mockStateStore.delete).toHaveBeenCalled();
+  } finally {
+    buildSpy.mockRestore();
+  }
+});
+
+test('startUnlinkUser - throws SessionExpiredError and never builds the unlink URL once the ceiling is reached', async () => {
+  const mockStateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [],
+    sessionExpiresAt: Math.floor(Date.now() / 1000) - 60,
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const buildSpy = vi.spyOn(AuthClient.prototype, 'buildUnlinkUserUrl');
+
+  try {
+    await expect(serverClient.startUnlinkUser({ connection: '<connection>' })).rejects.toBeInstanceOf(SessionExpiredError);
+    expect(buildSpy).not.toHaveBeenCalled();
+    expect(mockStateStore.delete).toHaveBeenCalled();
+  } finally {
+    buildSpy.mockRestore();
+  }
 });

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -6330,6 +6330,36 @@ test('getAccessToken - throws SessionExpiredError and never calls the token endp
   }
 });
 
+test('getAccessToken - clears the session using the caller store options (single-arg call) when the ceiling is reached', async () => {
+  // Guards the MRRT-overload integration: a single-arg getAccessToken(storeOptions) call delivers
+  // the store options via the FIRST parameter, so the ceiling-breach delete must use the resolved
+  // store options — not the (here undefined) second parameter — or the session is never cleared.
+  const mockStateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
+  const serverClient = new ServerClient<{ marker: string }>({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [{ audience: 'default', accessToken: '<access_token>', expiresAt: 0, scope: '<scope>' }],
+    sessionExpiresAt: Math.floor(Date.now() / 1000) - 60,
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const callerStoreOptions = { marker: 'from-caller' };
+
+  await expect(serverClient.getAccessToken(callerStoreOptions)).rejects.toBeInstanceOf(SessionExpiredError);
+  // The delete must receive the caller's store options, not undefined.
+  expect(mockStateStore.delete).toHaveBeenCalledWith('__a0_session', callerStoreOptions);
+});
+
 test('getAccessToken - still serves a valid cached token when the ceiling is in the future (regression)', async () => {
   const mockStateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
   const serverClient = new ServerClient({

--- a/packages/auth0-server-js/src/server-client.ts
+++ b/packages/auth0-server-js/src/server-client.ts
@@ -31,7 +31,12 @@ import {
   MissingTransactionError,
   SessionExpiredError,
 } from './errors.js';
-import { updateStateData, updateStateDataForConnectionTokenSet, isSessionExpiryReached } from './state/utils.js';
+import {
+  updateStateData,
+  updateStateDataForConnectionTokenSet,
+  isSessionExpiryReached,
+  applySessionExpiryAtLogin,
+} from './state/utils.js';
 import {
   TokenForConnectionError,
   AuthClient,
@@ -296,6 +301,7 @@ export class ServerClient<TStoreOptions = unknown> {
    *
    * @throws {MissingTransactionError} When no transaction was found.
    * @throws {TokenByCodeError} If there was an issue requesting the access token.
+   * @throws {SessionExpiredError} When the ID token's `session_expiry` is already in the past at login (the session is born expired); nothing is persisted.
    *
    * @returns A promise resolving to an object, containing the original appState (if present) and the authorizationDetails (when RAR was used).
    */
@@ -313,13 +319,20 @@ export class ServerClient<TStoreOptions = unknown> {
       codeVerifier: transactionData.codeVerifier!,
     });
 
+    // The transaction (and its code_verifier) is single-use and spent once the code is exchanged.
+    // Delete it now — before applySessionExpiryAtLogin, which can throw the session_expiry lockout
+    // — so a born-expired login does not leave the spent transaction lingering until its TTL.
+    await this.#transactionStore.delete(this.#transactionStoreIdentifier, storeOptions);
+
     const existingStateData = await this.#stateStore.get(this.#stateStoreIdentifier, storeOptions);
-    const stateData = updateStateData(transactionData.audience ?? 'default', existingStateData, tokenEndpointResponse, {
-      domain,
-    });
+    const stateData = applySessionExpiryAtLogin(
+      updateStateData(transactionData.audience ?? 'default', existingStateData, tokenEndpointResponse, {
+        domain,
+      }),
+      tokenEndpointResponse.claims
+    );
 
     await this.#stateStore.set(this.#stateStoreIdentifier, stateData, true, storeOptions);
-    await this.#transactionStore.delete(this.#transactionStoreIdentifier, storeOptions);
 
     return { appState: transactionData.appState, authorizationDetails: tokenEndpointResponse.authorizationDetails } as {
       appState?: TAppState;
@@ -334,6 +347,7 @@ export class ServerClient<TStoreOptions = unknown> {
    *
    * @throws {MissingSessionError} If there is no active session.
    * @throws {BuildLinkUserUrlError} If there was an issue when building the Authorization URL.
+   * @throws {SessionExpiredError} When the session's `session_expiry` ceiling has been reached; the session is cleared and re-authentication is required.
    *
    * @returns A promise resolving to a URL object, representing the URL to redirect the user-agent to to request authorization at Auth0.
    */
@@ -411,6 +425,7 @@ export class ServerClient<TStoreOptions = unknown> {
    *
    * @throws {MissingSessionError} If there is no active session.
    * @throws {BuildUnlinkUserUrlError} If there was an issue when building the User Unlinking URL.
+   * @throws {SessionExpiredError} When the session's `session_expiry` ceiling has been reached; the session is cleared and re-authentication is required.
    *
    * @returns A promise resolving to a URL object, representing the URL to redirect the user-agent to to request authorization at Auth0.
    */
@@ -489,6 +504,7 @@ export class ServerClient<TStoreOptions = unknown> {
    * @param storeOptions Optional options used to pass to the Transaction and State Store.
    *
    * @throws {BackchannelAuthenticationError} If there was an issue when doing backchannel authentication.
+   * @throws {SessionExpiredError} When the ID token's `session_expiry` is already in the past at login (the session is born expired); nothing is persisted.
    *
    * @returns A promise resolving to an object, containing the authorizationDetails (when RAR was used).
    */
@@ -510,11 +526,11 @@ export class ServerClient<TStoreOptions = unknown> {
 
     const existingStateData = await this.#stateStore.get(this.#stateStoreIdentifier, storeOptions);
 
-    const stateData = updateStateData(
-      this.#options.authorizationParams?.audience ?? 'default',
-      existingStateData,
-      tokenEndpointResponse,
-      { domain }
+    const stateData = applySessionExpiryAtLogin(
+      updateStateData(this.#options.authorizationParams?.audience ?? 'default', existingStateData, tokenEndpointResponse, {
+        domain,
+      }),
+      tokenEndpointResponse.claims
     );
 
     await this.#stateStore.set(this.#stateStoreIdentifier, stateData, true, storeOptions);
@@ -809,6 +825,7 @@ export class ServerClient<TStoreOptions = unknown> {
    * @param storeOptions Optional options used to pass to the Transaction and State Store.
    *
    * @throws {TokenByRefreshTokenError} If the refresh token was not found or there was an issue requesting the access token. When the cause is `mfa_required`, use `isMfaRequiredError(error)` to narrow the error and read `cause.mfa_token`.
+   * @throws {SessionExpiredError} When the session's `session_expiry` ceiling has been reached; the session is cleared and no refresh is attempted — the user must re-authenticate.
    *
    * @returns The Token Set, containing the access token, as well as additional information.
    */
@@ -933,11 +950,12 @@ export class ServerClient<TStoreOptions = unknown> {
       }
     }
 
-    if (stateData && isSessionExpiryReached(stateData.sessionExpiresAt)) {
-      await this.#stateStore.delete(this.#stateStoreIdentifier, storeOptions);
-      throw new SessionExpiredError();
-    }
-
+    // NOTE: the IPSIE `session_expiry` ceiling is intentionally NOT enforced here. Connection
+    // (Token Vault) tokens are the upstream IdP's own tokens — Auth0 stores and returns them, it
+    // does not mint them — so their lifetime is governed by the upstream IdP's `expires_in`, not by
+    // the Auth0 app-session ceiling. Gating this path would reject a connection-token fetch that
+    // should still succeed. (The ceiling IS enforced on getAccessToken/getUser/getSession and the
+    // link/unlink flows, which depend on the Auth0 session itself.)
     const connectionTokenSet = stateData?.connectionTokenSets?.find(
       (tokenSet) => tokenSet.connection === options.connection
     );

--- a/packages/auth0-server-js/src/server-client.ts
+++ b/packages/auth0-server-js/src/server-client.ts
@@ -869,7 +869,7 @@ export class ServerClient<TStoreOptions = unknown> {
     }
 
     if (stateData && isSessionExpiryReached(stateData.sessionExpiresAt)) {
-      await this.#stateStore.delete(this.#stateStoreIdentifier, storeOptions);
+      await this.#stateStore.delete(this.#stateStoreIdentifier, resolvedStoreOptions);
       throw new SessionExpiredError();
     }
 

--- a/packages/auth0-server-js/src/server-client.ts
+++ b/packages/auth0-server-js/src/server-client.ts
@@ -29,8 +29,9 @@ import {
   MissingRequiredArgumentError,
   MissingSessionError,
   MissingTransactionError,
+  SessionExpiredError,
 } from './errors.js';
-import { updateStateData, updateStateDataForConnectionTokenSet } from './state/utils.js';
+import { updateStateData, updateStateDataForConnectionTokenSet, isSessionExpiryReached } from './state/utils.js';
 import {
   TokenForConnectionError,
   AuthClient,
@@ -352,6 +353,11 @@ export class ServerClient<TStoreOptions = unknown> {
       }
     }
 
+    if (isSessionExpiryReached(stateData.sessionExpiresAt)) {
+      await this.#stateStore.delete(this.#stateStoreIdentifier, storeOptions);
+      throw new SessionExpiredError();
+    }
+
     const domain = this.#getSessionDomain(stateData)!;
     const authClient = this.#getAuthClient(domain);
     const { linkUserUrl, codeVerifier } = await authClient.buildLinkUserUrl({
@@ -422,6 +428,11 @@ export class ServerClient<TStoreOptions = unknown> {
       if (!isCurrentDomain) {
         throw new MissingSessionError('Session domain does not match the current domain.');
       }
+    }
+
+    if (isSessionExpiryReached(stateData.sessionExpiresAt)) {
+      await this.#stateStore.delete(this.#stateStoreIdentifier, storeOptions);
+      throw new SessionExpiredError();
     }
 
     const domain = this.#getSessionDomain(stateData)!;
@@ -747,6 +758,11 @@ export class ServerClient<TStoreOptions = unknown> {
       }
     }
 
+    if (isSessionExpiryReached(stateData.sessionExpiresAt)) {
+      await this.#stateStore.delete(this.#stateStoreIdentifier, storeOptions);
+      return;
+    }
+
     return stateData.user;
   }
 
@@ -764,6 +780,11 @@ export class ServerClient<TStoreOptions = unknown> {
         if (!isCurrentDomain) {
           return;
         }
+      }
+
+      if (isSessionExpiryReached(stateData.sessionExpiresAt)) {
+        await this.#stateStore.delete(this.#stateStoreIdentifier, storeOptions);
+        return;
       }
 
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -828,6 +849,11 @@ export class ServerClient<TStoreOptions = unknown> {
       if (sessionDomain !== resolvedDomain) {
         throw new MissingSessionError('Session domain does not match the current domain.');
       }
+    }
+
+    if (stateData && isSessionExpiryReached(stateData.sessionExpiresAt)) {
+      await this.#stateStore.delete(this.#stateStoreIdentifier, storeOptions);
+      throw new SessionExpiredError();
     }
 
     const tokenSet = stateData?.tokenSets.find(
@@ -905,6 +931,11 @@ export class ServerClient<TStoreOptions = unknown> {
       if (sessionDomain !== resolvedDomain) {
         throw new MissingSessionError('Session domain does not match the current domain.');
       }
+    }
+
+    if (stateData && isSessionExpiryReached(stateData.sessionExpiresAt)) {
+      await this.#stateStore.delete(this.#stateStoreIdentifier, storeOptions);
+      throw new SessionExpiredError();
     }
 
     const connectionTokenSet = stateData?.connectionTokenSets?.find(

--- a/packages/auth0-server-js/src/state/utils.spec.ts
+++ b/packages/auth0-server-js/src/state/utils.spec.ts
@@ -7,6 +7,8 @@ import {
   updateStateDataForConnectionTokenSet,
   extractSessionExpiry,
   isSessionExpiryReached,
+  isSessionExpiryInPast,
+  applySessionExpiryAtLogin,
   SESSION_EXPIRY_LEEWAY,
 } from './utils.js';
 
@@ -561,9 +563,18 @@ test('extractSessionExpiry - returns undefined for invalid shapes (fail-open)', 
   expect(extractSessionExpiry({ session_expiry: Number.NaN } as never)).toBeUndefined(); // NaN
 });
 
-test('extractSessionExpiry - accepts a far-future integer (documents the milliseconds limitation: ms values look like valid far-future seconds and are NOT rejected)', () => {
+test('extractSessionExpiry - rejects a millisecond-scale value (would otherwise be a far-future seconds ceiling that never triggers)', () => {
   const millisecondsLikeValue = 1748566800000;
-  expect(extractSessionExpiry({ session_expiry: millisecondsLikeValue } as never)).toBe(millisecondsLikeValue);
+  expect(extractSessionExpiry({ session_expiry: millisecondsLikeValue } as never)).toBeUndefined();
+});
+
+test('extractSessionExpiry - accepts a plausible far-future seconds value just below the bound', () => {
+  const farFutureSeconds = 9_999_999_999; // < 1e10 (10,000,000,000), year ~2286
+  expect(extractSessionExpiry({ session_expiry: farFutureSeconds } as never)).toBe(farFutureSeconds);
+});
+
+test('extractSessionExpiry - rejects exactly the bound (10,000,000,000) and above', () => {
+  expect(extractSessionExpiry({ session_expiry: 10_000_000_000 } as never)).toBeUndefined();
 });
 
 test('isSessionExpiryReached - undefined ceiling means no ceiling (never reached)', () => {
@@ -596,7 +607,9 @@ test('isSessionExpiryReached - false just before the leeway boundary', () => {
   expect(isSessionExpiryReached(now + SESSION_EXPIRY_LEEWAY + 1, now)).toBe(false);
 });
 
-test('updateStateData - stamps sessionExpiresAt on a fresh login when the claim is present', () => {
+// --- updateStateData: the ceiling is preserve-only here; stamping/lockout live at login sites ---
+
+test('updateStateData - does NOT stamp sessionExpiresAt on a fresh login (stamping happens at the login site)', () => {
   const iat = Math.floor(Date.now() / 1000);
   const response = {
     idToken: '<id_token>',
@@ -609,45 +622,8 @@ test('updateStateData - stamps sessionExpiresAt on a fresh login when the claim 
 
   const updatedState = updateStateData('<audience>', undefined, response);
 
-  expect(updatedState.sessionExpiresAt).toBe(iat + 3600);
-});
-
-test('updateStateData - leaves sessionExpiresAt undefined on a fresh login when the claim is absent (non-breaking)', () => {
-  const iat = Math.floor(Date.now() / 1000);
-  const response = {
-    idToken: '<id_token>',
-    accessToken: '<access_token>',
-    expiresAt: iat + 500,
-    claims: { iss: '<iss>', aud: '<audience>', sub: '<sub>', iat, exp: iat + 500 },
-  } as unknown as TokenResponse;
-
-  const updatedState = updateStateData('<audience>', undefined, response);
-
+  // updateStateData no longer derives the ceiling; applySessionExpiryAtLogin does.
   expect(updatedState.sessionExpiresAt).toBeUndefined();
-});
-
-test('updateStateData - throws SessionExpiredError when session_expiry is at or before iat (lockout guard)', () => {
-  const iat = Math.floor(Date.now() / 1000);
-  const response = {
-    idToken: '<id_token>',
-    accessToken: '<access_token>',
-    expiresAt: iat + 500,
-    claims: { iss: '<iss>', aud: '<audience>', sub: '<sub>', iat, exp: iat + 500, session_expiry: iat },
-  } as unknown as TokenResponse;
-
-  expect(() => updateStateData('<audience>', undefined, response)).toThrow(SessionExpiredError);
-});
-
-test('updateStateData - lockout guard falls back to now when iat is absent', () => {
-  const now = Math.floor(Date.now() / 1000);
-  const response = {
-    idToken: '<id_token>',
-    accessToken: '<access_token>',
-    expiresAt: now + 500,
-    claims: { iss: '<iss>', aud: '<audience>', sub: '<sub>', exp: now + 500, session_expiry: now - 10 },
-  } as unknown as TokenResponse;
-
-  expect(() => updateStateData('<audience>', undefined, response)).toThrow(SessionExpiredError);
 });
 
 test('updateStateData - preserves stored sessionExpiresAt across a refresh that lacks the claim', () => {
@@ -675,9 +651,9 @@ test('updateStateData - preserves stored sessionExpiresAt across a refresh that 
   expect(updatedState.sessionExpiresAt).toBe(stored);
 });
 
-test('updateStateData - updates sessionExpiresAt when a same-user re-login carries a new claim', () => {
-  const stored = 1_000_000;
-  const next = 2_000_000;
+test('updateStateData - preserves stored sessionExpiresAt across a refresh EVEN WHEN the response carries a session_expiry (write-once; never re-derived on refresh)', () => {
+  const stored = 1_700_000_000;
+  const laterCeiling = 1_900_000_000; // an Action could stamp this on a refresh grant — must be ignored
   const initialState: StateData = {
     idToken: '<id_token>',
     refreshToken: '<refresh_token>',
@@ -693,17 +669,140 @@ test('updateStateData - updates sessionExpiresAt when a same-user re-login carri
     accessToken: '<access_token_2>',
     expiresAt: Date.now() / 1000 + 500,
     scope: '<scope>',
-    claims: { iss: '<iss>', aud: '<audience>', sub: '<sub>', iat: 1_000, exp: Date.now() + 500, session_expiry: next },
+    claims: { iss: '<iss>', aud: '<audience>', sub: '<sub>', iat: 1_000, exp: Date.now() + 500, session_expiry: laterCeiling },
   } as unknown as TokenResponse;
 
   const updatedState = updateStateData('<audience>', initialState, response);
 
-  expect(updatedState.sessionExpiresAt).toBe(next);
+  // The refresh response's session_expiry must NOT push the ceiling out.
+  expect(updatedState.sessionExpiresAt).toBe(stored);
 });
 
-test('updateStateData - different-user re-login yields a fresh ceiling, not the stale one', () => {
+// --- isSessionExpiryInPast: the login-site lockout predicate ---
+
+test('isSessionExpiryInPast - undefined ceiling is never in the past', () => {
+  expect(isSessionExpiryInPast(undefined)).toBe(false);
+  expect(isSessionExpiryInPast(undefined, 1000)).toBe(false);
+});
+
+test('isSessionExpiryInPast - ceiling at or before iat is in the past (born expired)', () => {
+  const iat = 1_000_000;
+  expect(isSessionExpiryInPast(iat, iat)).toBe(true);
+  expect(isSessionExpiryInPast(iat - 1, iat)).toBe(true);
+});
+
+test('isSessionExpiryInPast - ceiling within the leeway window of iat counts as past', () => {
+  const iat = 1_000_000;
+  expect(isSessionExpiryInPast(iat + SESSION_EXPIRY_LEEWAY, iat)).toBe(true);
+  expect(isSessionExpiryInPast(iat + SESSION_EXPIRY_LEEWAY + 1, iat)).toBe(false);
+});
+
+test('isSessionExpiryInPast - falls back to now when iat is in milliseconds (a bad iat cannot manufacture a lockout)', () => {
+  const now = Math.floor(Date.now() / 1000);
+  // ms iat would, if trusted, make any seconds ceiling look "in the past"; it must fall back to now.
+  expect(isSessionExpiryInPast(now + 3600, Date.now())).toBe(false);
+});
+
+// --- applySessionExpiryAtLogin: extract + lockout + stamp, used by the login sites ---
+
+const loginState = (sub = '<sub>'): StateData => ({
+  idToken: '<id_token>',
+  refreshToken: '<refresh_token>',
+  tokenSets: [{ accessToken: '<access_token>', scope: '<scope>', audience: '<audience>', expiresAt: Date.now() + 500 }],
+  connectionTokenSets: [],
+  user: { sub, iss: '<iss>' },
+  internal: { sid: '<sid>', createdAt: Date.now() },
+});
+
+test('applySessionExpiryAtLogin - stamps sessionExpiresAt from the claim', () => {
+  const iat = Math.floor(Date.now() / 1000);
+  const stamped = applySessionExpiryAtLogin(loginState(), {
+    iss: '<iss>',
+    aud: '<audience>',
+    sub: '<sub>',
+    iat,
+    exp: iat + 500,
+    session_expiry: iat + 3600,
+  } as never);
+
+  expect(stamped.sessionExpiresAt).toBe(iat + 3600);
+});
+
+test('applySessionExpiryAtLogin - leaves sessionExpiresAt undefined when the claim is absent (non-breaking)', () => {
+  const iat = Math.floor(Date.now() / 1000);
+  const stamped = applySessionExpiryAtLogin(loginState(), {
+    iss: '<iss>',
+    aud: '<audience>',
+    sub: '<sub>',
+    iat,
+    exp: iat + 500,
+  } as never);
+
+  expect(stamped.sessionExpiresAt).toBeUndefined();
+});
+
+test('applySessionExpiryAtLogin - throws SessionExpiredError when session_expiry is at or before iat', () => {
+  const iat = Math.floor(Date.now() / 1000);
+  expect(() =>
+    applySessionExpiryAtLogin(loginState(), {
+      iss: '<iss>',
+      aud: '<audience>',
+      sub: '<sub>',
+      iat,
+      exp: iat + 500,
+      session_expiry: iat,
+    } as never)
+  ).toThrow(SessionExpiredError);
+});
+
+test('applySessionExpiryAtLogin - throws falling back to now when iat is absent', () => {
+  const now = Math.floor(Date.now() / 1000);
+  expect(() =>
+    applySessionExpiryAtLogin(loginState(), {
+      iss: '<iss>',
+      aud: '<audience>',
+      sub: '<sub>',
+      exp: now + 500,
+      session_expiry: now - 10,
+    } as never)
+  ).toThrow(SessionExpiredError);
+});
+
+test('applySessionExpiryAtLogin - re-login UPDATES a preserved ceiling (login site overwrites)', () => {
+  const stored = 1_700_000_000;
+  const next = 1_900_000_000;
+  // simulate the login-site composition: updateStateData (preserves stored) then stamp from new claim
+  const preserved = { ...loginState(), sessionExpiresAt: stored };
+  const restamped = applySessionExpiryAtLogin(preserved, {
+    iss: '<iss>',
+    aud: '<audience>',
+    sub: '<sub>',
+    iat: 1_000,
+    exp: Date.now() + 500,
+    session_expiry: next,
+  } as never);
+
+  expect(restamped.sessionExpiresAt).toBe(next);
+});
+
+test('applySessionExpiryAtLogin - re-login through a no-ceiling connection CLEARS a preserved ceiling', () => {
+  const stored = 1_900_000_000;
+  const preserved = { ...loginState(), sessionExpiresAt: stored };
+  const restamped = applySessionExpiryAtLogin(preserved, {
+    iss: '<iss>',
+    aud: '<audience>',
+    sub: '<sub>',
+    iat: 1_000,
+    exp: Date.now() + 500,
+    // no session_expiry — the new login asserts no ceiling
+  } as never);
+
+  expect(restamped.sessionExpiresAt).toBeUndefined();
+});
+
+test('updateStateData + applySessionExpiryAtLogin - different-user re-login yields a fresh ceiling, not the stale one', () => {
   const stale = 1_000_000;
-  const fresh = 2_000_000;
+  const fresh = 1_900_000_000;
   const initialState: StateData = {
     idToken: '<id_token>',
     refreshToken: '<refresh_token>',
@@ -723,7 +822,9 @@ test('updateStateData - different-user re-login yields a fresh ceiling, not the 
     claims: { iss: '<iss>', aud: '<audience>', sub: '<different_sub>', iat: 1_000, exp: Date.now() + 500, session_expiry: fresh },
   } as unknown as TokenResponse;
 
-  const updatedState = updateStateData('<audience>', initialState, response);
+  // login-site composition: updateStateData wipes on sub mismatch, then the claim is stamped
+  const merged = updateStateData('<audience>', initialState, response);
+  const updatedState = applySessionExpiryAtLogin(merged, response.claims);
 
   expect(updatedState.user!.sub).toBe('<different_sub>');
   expect(updatedState.sessionExpiresAt).toBe(fresh);

--- a/packages/auth0-server-js/src/state/utils.spec.ts
+++ b/packages/auth0-server-js/src/state/utils.spec.ts
@@ -1,7 +1,14 @@
 import { expect, test } from 'vitest';
 import { TokenResponse } from '@auth0/auth0-auth-js';
 import type { StateData } from '../types.js';
-import { updateStateData, updateStateDataForConnectionTokenSet } from './utils.js';
+import { SessionExpiredError } from '../errors.js';
+import {
+  updateStateData,
+  updateStateDataForConnectionTokenSet,
+  extractSessionExpiry,
+  isSessionExpiryReached,
+  SESSION_EXPIRY_LEEWAY,
+} from './utils.js';
 
 test('updateStateData - should add when state undefined', () => {
   const response = {
@@ -535,4 +542,189 @@ test('updateStateData - should retain or override domain for existing sessions',
     domain: 'auth0.override',
   });
   expect(overridden.domain).toBe('auth0.override');
+});
+
+test('extractSessionExpiry - returns the value for a positive integer', () => {
+  expect(extractSessionExpiry({ session_expiry: 1748566800 } as never)).toBe(1748566800);
+});
+
+test('extractSessionExpiry - returns undefined when the claim is absent', () => {
+  expect(extractSessionExpiry({ sub: '<sub>' } as never)).toBeUndefined();
+  expect(extractSessionExpiry(undefined)).toBeUndefined();
+});
+
+test('extractSessionExpiry - returns undefined for invalid shapes (fail-open)', () => {
+  expect(extractSessionExpiry({ session_expiry: '1748566800' } as never)).toBeUndefined(); // string
+  expect(extractSessionExpiry({ session_expiry: 1748566800.5 } as never)).toBeUndefined(); // float
+  expect(extractSessionExpiry({ session_expiry: 0 } as never)).toBeUndefined(); // zero
+  expect(extractSessionExpiry({ session_expiry: -5 } as never)).toBeUndefined(); // negative
+  expect(extractSessionExpiry({ session_expiry: Number.NaN } as never)).toBeUndefined(); // NaN
+});
+
+test('extractSessionExpiry - accepts a far-future integer (documents the milliseconds limitation: ms values look like valid far-future seconds and are NOT rejected)', () => {
+  const millisecondsLikeValue = 1748566800000;
+  expect(extractSessionExpiry({ session_expiry: millisecondsLikeValue } as never)).toBe(millisecondsLikeValue);
+});
+
+test('isSessionExpiryReached - undefined ceiling means no ceiling (never reached)', () => {
+  expect(isSessionExpiryReached(undefined)).toBe(false);
+});
+
+test('isSessionExpiryReached - false when now is well before the ceiling', () => {
+  const now = 1_000_000;
+  expect(isSessionExpiryReached(now + 3600, now)).toBe(false);
+});
+
+test('isSessionExpiryReached - true when now is past the ceiling', () => {
+  const now = 1_000_000;
+  expect(isSessionExpiryReached(now - 1, now)).toBe(true);
+});
+
+test('isSessionExpiryReached - true within the negative leeway window (expires early for clock skew)', () => {
+  const now = 1_000_000;
+  // ceiling is 10s in the future, but leeway is 30s, so it is already considered reached
+  expect(isSessionExpiryReached(now + 10, now)).toBe(true);
+});
+
+test('isSessionExpiryReached - true exactly at ceiling minus leeway (boundary inclusive)', () => {
+  const now = 1_000_000;
+  expect(isSessionExpiryReached(now + SESSION_EXPIRY_LEEWAY, now)).toBe(true);
+});
+
+test('isSessionExpiryReached - false just before the leeway boundary', () => {
+  const now = 1_000_000;
+  expect(isSessionExpiryReached(now + SESSION_EXPIRY_LEEWAY + 1, now)).toBe(false);
+});
+
+test('updateStateData - stamps sessionExpiresAt on a fresh login when the claim is present', () => {
+  const iat = Math.floor(Date.now() / 1000);
+  const response = {
+    idToken: '<id_token>',
+    accessToken: '<access_token>',
+    refreshToken: '<refresh_token>',
+    expiresAt: iat + 500,
+    scope: '<scope>',
+    claims: { iss: '<iss>', aud: '<audience>', sub: '<sub>', iat, exp: iat + 500, session_expiry: iat + 3600 },
+  } as unknown as TokenResponse;
+
+  const updatedState = updateStateData('<audience>', undefined, response);
+
+  expect(updatedState.sessionExpiresAt).toBe(iat + 3600);
+});
+
+test('updateStateData - leaves sessionExpiresAt undefined on a fresh login when the claim is absent (non-breaking)', () => {
+  const iat = Math.floor(Date.now() / 1000);
+  const response = {
+    idToken: '<id_token>',
+    accessToken: '<access_token>',
+    expiresAt: iat + 500,
+    claims: { iss: '<iss>', aud: '<audience>', sub: '<sub>', iat, exp: iat + 500 },
+  } as unknown as TokenResponse;
+
+  const updatedState = updateStateData('<audience>', undefined, response);
+
+  expect(updatedState.sessionExpiresAt).toBeUndefined();
+});
+
+test('updateStateData - throws SessionExpiredError when session_expiry is at or before iat (lockout guard)', () => {
+  const iat = Math.floor(Date.now() / 1000);
+  const response = {
+    idToken: '<id_token>',
+    accessToken: '<access_token>',
+    expiresAt: iat + 500,
+    claims: { iss: '<iss>', aud: '<audience>', sub: '<sub>', iat, exp: iat + 500, session_expiry: iat },
+  } as unknown as TokenResponse;
+
+  expect(() => updateStateData('<audience>', undefined, response)).toThrow(SessionExpiredError);
+});
+
+test('updateStateData - lockout guard falls back to now when iat is absent', () => {
+  const now = Math.floor(Date.now() / 1000);
+  const response = {
+    idToken: '<id_token>',
+    accessToken: '<access_token>',
+    expiresAt: now + 500,
+    claims: { iss: '<iss>', aud: '<audience>', sub: '<sub>', exp: now + 500, session_expiry: now - 10 },
+  } as unknown as TokenResponse;
+
+  expect(() => updateStateData('<audience>', undefined, response)).toThrow(SessionExpiredError);
+});
+
+test('updateStateData - preserves stored sessionExpiresAt across a refresh that lacks the claim', () => {
+  const stored = Math.floor(Date.now() / 1000) + 3600;
+  const initialState: StateData = {
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [{ accessToken: '<access_token>', scope: '<scope>', audience: '<audience>', expiresAt: Date.now() + 500 }],
+    connectionTokenSets: [],
+    user: { sub: '<sub>', iss: '<iss>' },
+    sessionExpiresAt: stored,
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+
+  const response = {
+    idToken: '<id_token_2>',
+    accessToken: '<access_token_2>',
+    expiresAt: Date.now() / 1000 + 500,
+    scope: '<scope>',
+    claims: { iss: '<iss>', aud: '<audience>', sub: '<sub>', iat: Date.now(), exp: Date.now() + 500 },
+  } as unknown as TokenResponse;
+
+  const updatedState = updateStateData('<audience>', initialState, response);
+
+  expect(updatedState.sessionExpiresAt).toBe(stored);
+});
+
+test('updateStateData - updates sessionExpiresAt when a same-user re-login carries a new claim', () => {
+  const stored = 1_000_000;
+  const next = 2_000_000;
+  const initialState: StateData = {
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [{ accessToken: '<access_token>', scope: '<scope>', audience: '<audience>', expiresAt: Date.now() + 500 }],
+    connectionTokenSets: [],
+    user: { sub: '<sub>', iss: '<iss>' },
+    sessionExpiresAt: stored,
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+
+  const response = {
+    idToken: '<id_token_2>',
+    accessToken: '<access_token_2>',
+    expiresAt: Date.now() / 1000 + 500,
+    scope: '<scope>',
+    claims: { iss: '<iss>', aud: '<audience>', sub: '<sub>', iat: 1_000, exp: Date.now() + 500, session_expiry: next },
+  } as unknown as TokenResponse;
+
+  const updatedState = updateStateData('<audience>', initialState, response);
+
+  expect(updatedState.sessionExpiresAt).toBe(next);
+});
+
+test('updateStateData - different-user re-login yields a fresh ceiling, not the stale one', () => {
+  const stale = 1_000_000;
+  const fresh = 2_000_000;
+  const initialState: StateData = {
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [{ accessToken: '<access_token>', scope: '<scope>', audience: '<audience>', expiresAt: Date.now() + 500 }],
+    connectionTokenSets: [],
+    user: { sub: '<sub>', iss: '<iss>' },
+    sessionExpiresAt: stale,
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+
+  const response = {
+    idToken: '<id_token_new>',
+    accessToken: '<access_token_new>',
+    refreshToken: '<refresh_token_new>',
+    expiresAt: Date.now() / 1000 + 500,
+    scope: '<scope>',
+    claims: { iss: '<iss>', aud: '<audience>', sub: '<different_sub>', iat: 1_000, exp: Date.now() + 500, session_expiry: fresh },
+  } as unknown as TokenResponse;
+
+  const updatedState = updateStateData('<audience>', initialState, response);
+
+  expect(updatedState.user!.sub).toBe('<different_sub>');
+  expect(updatedState.sessionExpiresAt).toBe(fresh);
 });

--- a/packages/auth0-server-js/src/state/utils.ts
+++ b/packages/auth0-server-js/src/state/utils.ts
@@ -10,18 +10,40 @@ import { SessionExpiredError } from '../errors.js';
 export const SESSION_EXPIRY_LEEWAY = 30;
 
 /**
+ * Upper bound (exclusive) for a value to be accepted as a Unix timestamp in seconds.
+ *
+ * `1e10` (10,000,000,000) is the year ~2286 — far beyond any real session ceiling, yet well below
+ * a millisecond timestamp for the current era (`Date.now()` is ~1.7e12). This lets us reject a
+ * `session_expiry` (or `iat`) that was mistakenly provided in milliseconds: such a value would
+ * otherwise look like a valid far-future seconds timestamp and silently disable the ceiling.
+ * Since `session_expiry` can be set by a customer Post-Login Action, a milliseconds mix-up is a
+ * realistic input, not just a platform glitch. The threshold matches the cross-SDK convention.
+ */
+const MAX_PLAUSIBLE_UNIX_SECONDS = 1e10;
+
+/**
+ * Returns whether a value is a plausible Unix timestamp in seconds: a positive integer below the
+ * milliseconds range. Used to reject values mistakenly expressed in milliseconds.
+ */
+function isPlausibleUnixSeconds(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0 && value < MAX_PLAUSIBLE_UNIX_SECONDS;
+}
+
+/**
  * Reads the IPSIE `session_expiry` claim (absolute Unix seconds) from ID token claims.
  *
- * Fail-open by design: returns `undefined` (meaning "no ceiling") unless the value is a
- * positive integer. A missing or malformed claim MUST NEVER be treated as an already-expired
- * session — a platform glitch must not lock out every enterprise user.
+ * Fail-open by design: returns `undefined` (meaning "no ceiling") unless the value is a plausible
+ * Unix-seconds timestamp (positive integer below the milliseconds range). A missing or malformed
+ * claim MUST NEVER be treated as an already-expired session — a platform glitch must not lock out
+ * every enterprise user. A value in milliseconds is rejected rather than accepted as a far-future
+ * ceiling (which would silently disable enforcement).
  *
  * @param claims The decoded ID token claims, or undefined.
  * @returns The ceiling in Unix seconds, or undefined when absent/invalid.
  */
 export function extractSessionExpiry(claims: TokenResponse['claims'] | undefined): number | undefined {
   const value = claims?.session_expiry;
-  return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : undefined;
+  return isPlausibleUnixSeconds(value) ? value : undefined;
 }
 
 /**
@@ -52,6 +74,69 @@ const createUpdatedTokenSet = (audience: string, response: TokenResponse) => ({
   scope: response.scope,
   expiresAt: response.expiresAt,
 });
+
+/**
+ * Returns whether a `session_expiry` ceiling is already in the past at login — i.e. the session
+ * would be born expired and MUST NOT be persisted (the caller should throw `SessionExpiredError`).
+ *
+ * Compares the ceiling against the ID token `iat` (issued-at), or the current time when `iat` is
+ * absent, applying the same negative leeway as {@link isSessionExpiryReached}. `iat` is only
+ * trusted when it is a plausible Unix-seconds value; an absent or malformed `iat` (e.g.
+ * milliseconds) falls back to now, so a bad `iat` cannot itself manufacture a false lockout.
+ *
+ * This is enforced at the login sites (interactive login, backchannel login, MFA verify) rather
+ * than inside {@link updateStateData}, so the ceiling is only ever derived from a genuine
+ * authentication event — never re-derived from a refresh-token response.
+ *
+ * Companion to {@link isSessionExpiryReached}: that one gates *reads* of an already-stored session
+ * against the current wall clock (`now`), whereas this one gates *login* against the token's `iat`,
+ * so a token minted with an already-past ceiling is rejected before it is ever persisted.
+ *
+ * @param sessionExpiresAt The extracted ceiling in Unix seconds, or undefined for "no ceiling".
+ * @param issuedAt The ID token `iat` claim, if present.
+ * @returns `true` when the ceiling is already reached at login; `false` when there is no ceiling.
+ */
+export function isSessionExpiryInPast(sessionExpiresAt: number | undefined, issuedAt?: number): boolean {
+  if (sessionExpiresAt === undefined) {
+    return false;
+  }
+  const reference = isPlausibleUnixSeconds(issuedAt) ? issuedAt : Math.floor(Date.now() / 1000);
+  return sessionExpiresAt <= reference + SESSION_EXPIRY_LEEWAY;
+}
+
+/**
+ * Stamps the IPSIE `session_expiry` ceiling onto freshly-built login state.
+ *
+ * Call this ONLY at the login sites (interactive login, backchannel login, MFA verify) — i.e.
+ * with the state produced by {@link updateStateData} from a genuine authentication response.
+ * It must NOT be called on the refresh path: the ceiling is write-once per authentication and
+ * preserved unchanged across refreshes (see {@link updateStateData}).
+ *
+ * Behavior:
+ * - Extracts the ceiling from the response claims (rejecting malformed/millisecond values).
+ * - Throws {@link SessionExpiredError} when the ceiling is already in the past at login, so a
+ *   born-expired session is never persisted.
+ * - Returns the state with `sessionExpiresAt` set to the extracted value. On a re-login this
+ *   overwrites any preserved ceiling — including clearing it (to `undefined`) when the new login
+ *   is through a connection that asserts no ceiling — so the value always reflects the most
+ *   recent authentication event.
+ *
+ * @param stateData The login state to stamp (from {@link updateStateData}).
+ * @param claims The decoded ID token claims from the authentication response.
+ * @returns The state data with `sessionExpiresAt` reflecting this login.
+ * @throws {SessionExpiredError} When the ceiling is at or before the issued-at time.
+ */
+export function applySessionExpiryAtLogin(stateData: StateData, claims: TokenResponse['claims']): StateData {
+  const sessionExpiresAt = extractSessionExpiry(claims);
+
+  if (isSessionExpiryInPast(sessionExpiresAt, claims?.iat)) {
+    throw new SessionExpiredError(
+      'The upstream identity provider session_expiry is at or before the issued-at time; refusing to create an already-expired session.'
+    );
+  }
+
+  return { ...stateData, sessionExpiresAt };
+}
 
 /**
  * Utility function to update the state with a new response from the token endpoint
@@ -96,35 +181,26 @@ export function updateStateData(
             : tokenSet
         );
 
+    // The `session_expiry` ceiling is intentionally NOT derived here. It is stamped once at the
+    // login sites (interactive login, backchannel login, MFA verify) and preserved across every
+    // refresh via the `...stateData` spread below. A refresh-token grant must never overwrite the
+    // ceiling — even when a Post-Login Action stamps `session_expiry` on the refreshed ID token —
+    // because that would let the session outlive the bound asserted at the original login.
     return {
       ...stateData,
       idToken: tokenEndpointResponse.idToken ?? stateData.idToken,
       refreshToken: tokenEndpointResponse.refreshToken ?? stateData.refreshToken,
       tokenSets,
       domain: context?.domain ?? stateData.domain,
-      sessionExpiresAt: extractSessionExpiry(tokenEndpointResponse.claims) ?? stateData.sessionExpiresAt,
     };
   } else {
     const user = tokenEndpointResponse.claims;
-    const sessionExpiresAt = extractSessionExpiry(tokenEndpointResponse.claims);
-
-    // Lockout guard: never persist a session that is already past its ceiling at login.
-    if (sessionExpiresAt !== undefined) {
-      const iatOrNow = typeof user?.iat === 'number' ? user.iat : Math.floor(Date.now() / 1000);
-      if (sessionExpiresAt <= iatOrNow) {
-        throw new SessionExpiredError(
-          'The upstream identity provider session_expiry is at or before the issued-at time; refusing to create an already-expired session.'
-        );
-      }
-    }
-
     return {
       user,
       idToken: tokenEndpointResponse.idToken,
       refreshToken: tokenEndpointResponse.refreshToken,
       tokenSets: [createUpdatedTokenSet(audience, tokenEndpointResponse)],
       domain: context?.domain,
-      sessionExpiresAt,
       internal: {
         sid: user?.sid as string,
         createdAt: Math.floor(Date.now() / 1000),

--- a/packages/auth0-server-js/src/state/utils.ts
+++ b/packages/auth0-server-js/src/state/utils.ts
@@ -1,5 +1,44 @@
 import type { AccessTokenForConnectionOptions, StateData } from '../types.js';
 import { TokenResponse } from '@auth0/auth0-auth-js';
+import { SessionExpiredError } from '../errors.js';
+
+/**
+ * Negative leeway (in seconds) applied to the `session_expiry` ceiling to absorb
+ * clock skew between the SDK and the Auth0 platform. The session is treated as
+ * expired slightly BEFORE the wall-clock ceiling, never after.
+ */
+export const SESSION_EXPIRY_LEEWAY = 30;
+
+/**
+ * Reads the IPSIE `session_expiry` claim (absolute Unix seconds) from ID token claims.
+ *
+ * Fail-open by design: returns `undefined` (meaning "no ceiling") unless the value is a
+ * positive integer. A missing or malformed claim MUST NEVER be treated as an already-expired
+ * session — a platform glitch must not lock out every enterprise user.
+ *
+ * @param claims The decoded ID token claims, or undefined.
+ * @returns The ceiling in Unix seconds, or undefined when absent/invalid.
+ */
+export function extractSessionExpiry(claims: TokenResponse['claims'] | undefined): number | undefined {
+  const value = claims?.session_expiry;
+  return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : undefined;
+}
+
+/**
+ * Returns whether the `session_expiry` ceiling has been reached, applying the negative leeway.
+ *
+ * @param sessionExpiresAt The stored ceiling in Unix seconds, or undefined for "no ceiling".
+ * @param nowSeconds Optional current time in Unix seconds (defaults to now). Injectable for tests.
+ * @returns `true` when the session must be treated as expired; `false` when there is no ceiling
+ *          or it has not yet been reached.
+ */
+export function isSessionExpiryReached(sessionExpiresAt: number | undefined, nowSeconds?: number): boolean {
+  if (sessionExpiresAt === undefined) {
+    return false;
+  }
+  const now = nowSeconds ?? Math.floor(Date.now() / 1000);
+  return now >= sessionExpiresAt - SESSION_EXPIRY_LEEWAY;
+}
 
 /**
  * Creates an updated token set object from the token endpoint response
@@ -63,15 +102,29 @@ export function updateStateData(
       refreshToken: tokenEndpointResponse.refreshToken ?? stateData.refreshToken,
       tokenSets,
       domain: context?.domain ?? stateData.domain,
+      sessionExpiresAt: extractSessionExpiry(tokenEndpointResponse.claims) ?? stateData.sessionExpiresAt,
     };
   } else {
     const user = tokenEndpointResponse.claims;
+    const sessionExpiresAt = extractSessionExpiry(tokenEndpointResponse.claims);
+
+    // Lockout guard: never persist a session that is already past its ceiling at login.
+    if (sessionExpiresAt !== undefined) {
+      const iatOrNow = typeof user?.iat === 'number' ? user.iat : Math.floor(Date.now() / 1000);
+      if (sessionExpiresAt <= iatOrNow) {
+        throw new SessionExpiredError(
+          'The upstream identity provider session_expiry is at or before the issued-at time; refusing to create an already-expired session.'
+        );
+      }
+    }
+
     return {
       user,
       idToken: tokenEndpointResponse.idToken,
       refreshToken: tokenEndpointResponse.refreshToken,
       tokenSets: [createUpdatedTokenSet(audience, tokenEndpointResponse)],
       domain: context?.domain,
+      sessionExpiresAt,
       internal: {
         sid: user?.sid as string,
         createdAt: Math.floor(Date.now() / 1000),

--- a/packages/auth0-server-js/src/store/abstract-session-store.ts
+++ b/packages/auth0-server-js/src/store/abstract-session-store.ts
@@ -19,20 +19,11 @@ export abstract class AbstractSessionStore<TStoreOptions> extends AbstractStateS
    * When sessionExpiresAt is provided, caps the maxAge to not exceed the time until that ceiling.
    */
   protected calculateMaxAge(createdAt: number, sessionExpiresAt?: number) {
-    if (!this.#rolling) {
-      let maxAge = this.#absoluteDuration;
-
-      if (sessionExpiresAt !== undefined) {
-        const now = (Date.now() / 1000) | 0;
-        maxAge = Math.min(maxAge, sessionExpiresAt - now);
-      }
-
-      return maxAge > 0 ? maxAge : 0;
-    }
-
     const now = (Date.now() / 1000) | 0;
-    const expiresAt = Math.min(now + this.#inactivityDuration, createdAt + this.#absoluteDuration);
-    let maxAge = expiresAt - now;
+
+    let maxAge = this.#rolling
+      ? Math.min(now + this.#inactivityDuration, createdAt + this.#absoluteDuration) - now
+      : this.#absoluteDuration;
 
     if (sessionExpiresAt !== undefined) {
       maxAge = Math.min(maxAge, sessionExpiresAt - now);

--- a/packages/auth0-server-js/src/store/abstract-session-store.ts
+++ b/packages/auth0-server-js/src/store/abstract-session-store.ts
@@ -16,15 +16,27 @@ export abstract class AbstractSessionStore<TStoreOptions> extends AbstractStateS
 
   /**
    * calculateMaxAge calculates the max age of the session based on createdAt and the rolling and absolute durations.
+   * When sessionExpiresAt is provided, caps the maxAge to not exceed the time until that ceiling.
    */
-  protected calculateMaxAge(createdAt: number) {
+  protected calculateMaxAge(createdAt: number, sessionExpiresAt?: number) {
     if (!this.#rolling) {
-      return this.#absoluteDuration;
+      let maxAge = this.#absoluteDuration;
+
+      if (sessionExpiresAt !== undefined) {
+        const now = (Date.now() / 1000) | 0;
+        maxAge = Math.min(maxAge, sessionExpiresAt - now);
+      }
+
+      return maxAge > 0 ? maxAge : 0;
     }
 
     const now = (Date.now() / 1000) | 0;
     const expiresAt = Math.min(now + this.#inactivityDuration, createdAt + this.#absoluteDuration);
-    const maxAge = expiresAt - now;
+    let maxAge = expiresAt - now;
+
+    if (sessionExpiresAt !== undefined) {
+      maxAge = Math.min(maxAge, sessionExpiresAt - now);
+    }
 
     return maxAge > 0 ? maxAge : 0;
   }

--- a/packages/auth0-server-js/src/store/stateful-state-store.ts
+++ b/packages/auth0-server-js/src/store/stateful-state-store.ts
@@ -54,7 +54,7 @@ export class StatefulStateStore<TStoreOptions> extends AbstractSessionStore<TSto
 
     sessionId ??= generateId();
 
-    const maxAge = this.calculateMaxAge(stateData.internal.createdAt);
+    const maxAge = this.calculateMaxAge(stateData.internal.createdAt, stateData.sessionExpiresAt);
     const cookieOpts = this.#getCookieOptions({
       maxAge,
     });

--- a/packages/auth0-server-js/src/store/stateless-state-store.spec.ts
+++ b/packages/auth0-server-js/src/store/stateless-state-store.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, vi } from 'vitest';
 import { StatelessStateStore } from './stateless-state-store.js';
 import { decrypt, encrypt } from './../test-utils/encryption.js';
 import { CookieHandler, CookieSerializeOptions } from './cookie-handler.js';
+import type { StateData } from '../types.js';
 
 export interface StoreOptions {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -217,4 +218,79 @@ test('delete - should call reply to clear the cookie', async () => {
   expect(storeOptions.reply.clearCookie).toHaveBeenCalledTimes(2);
   expect(storeOptions.reply.clearCookie).toHaveBeenNthCalledWith(1, '<identifier>.0');
   expect(storeOptions.reply.clearCookie).toHaveBeenNthCalledWith(2, '<identifier>.1');
+});
+
+test('set - caps the cookie maxAge at sessionExpiresAt when the ceiling is sooner than idle/absolute', async () => {
+  const store = new StatelessStateStore(
+    {
+      secret: '<secret>',
+      rolling: true,
+      absoluteDuration: 60 * 60 * 24 * 3,
+      inactivityDuration: 60 * 60 * 24 * 1,
+    },
+    new TestCookieHandler()
+  );
+
+  const setCookie = vi.fn();
+  const storeOptions = {
+    request: { cookies: {} },
+    reply: { setCookie },
+  } as unknown as StoreOptions;
+
+  const now = Math.floor(Date.now() / 1000);
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [],
+    sessionExpiresAt: now + 100, // ceiling much sooner than the multi-day idle/absolute defaults
+    internal: { sid: '<sid>', createdAt: now },
+  };
+
+  await store.set('__a0_session', stateData, false, storeOptions);
+
+  // TestCookieHandler forwards options as the 3rd arg to reply.setCookie(name, value, options).
+  const maxAges = setCookie.mock.calls
+    .map((call) => (call[2] as CookieSerializeOptions | undefined)?.maxAge)
+    .filter((v): v is number => typeof v === 'number');
+
+  expect(maxAges.length).toBeGreaterThan(0);
+  expect(Math.max(...maxAges)).toBeLessThanOrEqual(101); // capped at the ~100s ceiling, not days
+});
+
+test('set - caps the cookie maxAge at sessionExpiresAt in non-rolling mode', async () => {
+  const store = new StatelessStateStore(
+    {
+      secret: '<secret>',
+      rolling: false,
+      absoluteDuration: 60 * 60 * 24 * 3,
+    },
+    new TestCookieHandler()
+  );
+
+  const setCookie = vi.fn();
+  const storeOptions = {
+    request: { cookies: {} },
+    reply: { setCookie },
+  } as unknown as StoreOptions;
+
+  const now = Math.floor(Date.now() / 1000);
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [],
+    sessionExpiresAt: now + 100, // ceiling much sooner than the 3-day absolute duration
+    internal: { sid: '<sid>', createdAt: now },
+  };
+
+  await store.set('__a0_session', stateData, false, storeOptions);
+
+  // TestCookieHandler forwards options as the 3rd arg to reply.setCookie(name, value, options).
+  const maxAges = setCookie.mock.calls
+    .map((call) => (call[2] as CookieSerializeOptions | undefined)?.maxAge)
+    .filter((v): v is number => typeof v === 'number');
+
+  expect(maxAges.length).toBeGreaterThan(0);
+  expect(Math.max(...maxAges)).toBeLessThanOrEqual(101); // capped at the ~100s ceiling, not the 3-day absolute
 });

--- a/packages/auth0-server-js/src/store/stateless-state-store.ts
+++ b/packages/auth0-server-js/src/store/stateless-state-store.ts
@@ -19,7 +19,7 @@ export class StatelessStateStore<TStoreOptions> extends AbstractSessionStore<TSt
     removeIfExists?: boolean,
     options?: TStoreOptions | undefined
   ): Promise<void> {
-    const maxAge = this.calculateMaxAge(stateData.internal.createdAt);
+    const maxAge = this.calculateMaxAge(stateData.internal.createdAt, stateData.sessionExpiresAt);
     const cookieOpts = this.#getCookieOptions({
       maxAge,
     });

--- a/packages/auth0-server-js/src/types.ts
+++ b/packages/auth0-server-js/src/types.ts
@@ -115,6 +115,15 @@ export interface SessionData {
   tokenSets: TokenSet[];
   connectionTokenSets?: ConnectionTokenSet[];
   domain?: string;
+  /**
+   * IPSIE SL1 `session_expiry` ceiling for this session, as an absolute Unix timestamp in
+   * seconds. Present only when the user logged in through an enterprise connection configured
+   * with `id_token_session_expiry_supported: true`. When set, the SDK treats the session as
+   * expired once this time is reached (minus a small leeway) and forces re-authentication.
+   * Absent for database/social logins, connections without the option, and sessions created
+   * before this feature — those behave unchanged.
+   */
+  sessionExpiresAt?: number;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
Enforces the IPSIE SL1 `session_expiry` claim in `@auth0/auth0-server-js` as a hard ceiling on the local session. When an Okta/OIDC enterprise connection has `id_token_session_expiry_supported: true`, Auth0 emits a `session_expiry` claim (absolute Unix seconds) in the ID token; this SDK treats it as an upper bound the session — and any refresh renewal — must never outlive.

**The change is non-breaking** — all enforcement is gated on the claim being present. Sessions without it (database/social logins, the connection option disabled, or sessions created before this version) behave exactly as before.

## Architecture

The ceiling is **stamped once, at the login sites** — `completeInteractiveLogin`, `loginBackchannel`, and MFA `verify` — via `applySessionExpiryAtLogin()`, which extracts the claim, applies the born-expired lockout, and stamps a top-level `SessionData.sessionExpiresAt`. `updateStateData` is **preserve-only**: it never derives the ceiling, so it is carried forward unchanged across refreshes via the state spread. This makes it structurally impossible for a refresh-token grant to overwrite the ceiling — even when a Post-Login Action stamps `session_expiry` on the refreshed ID token. (Mirrors `auth0-server-python`.)

## What it does

- **Persists the ceiling** as a top-level `SessionData.sessionExpiresAt?: number` (Unix seconds) at login, so `getSession()` can read it back.
- **Lockout guard** at login: if `session_expiry <= iat` (falling back to now when `iat` is absent/implausible), throws `SessionExpiredError` and persists nothing rather than storing a born-dead session.
- **Reads (`getSession` / `getUser`)** — once the ceiling is reached, the current-domain session is deleted and the call returns `undefined` (silent), so the app's existing not-logged-in redirect path fires transparently.
- **`getAccessToken`** — once the ceiling is reached, the session is deleted and `SessionExpiredError` is thrown **before** any cached token is served or any `/oauth/token` refresh is attempted (never refresh past the ceiling).
- **`startLinkUser` / `startUnlinkUser`** — same throwing enforcement, since both require a live session and pass the session's ID token to build the account link/unlink URL.
- **`getAccessTokenForConnection` is intentionally NOT capped** — connection (Token Vault) tokens are the upstream IdP's own tokens, governed by that IdP's `expires_in`, not the Auth0 session ceiling. They keep working past the ceiling. (Per the closed Token Vault decision; matches `auth0-server-python`.)
- **Refresh preserves the ceiling** — write-once per authentication; never re-derived from a refresh response.
- **Cookie max-age** is capped at the ceiling as a defense-in-depth backstop. Idle/absolute timeouts stay independent.
- **Fail-open**: a missing or malformed claim means "no ceiling," never "already expired." A **millisecond-scale value is rejected** (`>= 1e10`) so an Action that forgets seconds can't silently disable enforcement.
- **~30s negative leeway** for clock skew; integer-seconds comparisons throughout.
- Adds `SessionExpiredError` (`code: 'session_expired'`), types `session_expiry?: number` on the ID-token claims (`IDTokenClaims` in `@auth0/auth0-auth-js`), and a "Session expiry from upstream IdP" guide in EXAMPLES.md.

## Behavior changes for consumers (opt-in, once the feature is enabled)

No API breakage, but two new runtime behaviors surface **only** after a connection enables the option and a user logs in through it:

- `getSession()` / `getUser()` can return `undefined` for a previously-logged-in user once the ceiling passes — apps that assumed these always return a value after login should add a null check.
- `getAccessToken()`, `startLinkUser()`, and `startUnlinkUser()` can throw `SessionExpiredError` past the ceiling. (`getAccessTokenForConnection()` does **not** throw on the ceiling.)

## Public API (all additive)

- New optional field `SessionData.sessionExpiresAt?: number`
- New exported error `SessionExpiredError` (`code: 'session_expired'`)
- New exported `IDTokenClaims` type (extends `IDToken` with `session_expiry?: number`); `TokenResponse.claims` widened to it
- New optional param on the `protected calculateMaxAge(createdAt, sessionExpiresAt?)`

Nothing removed, renamed, or behaviorally retyped.

## Test plan

- [x] `extractSessionExpiry` (valid/invalid shapes, millisecond rejection at the `1e10` bound), `isSessionExpiryReached`, `isSessionExpiryInPast` (leeway boundaries, ms-`iat` fallback)
- [x] `updateStateData` is preserve-only: does not stamp on fresh login; preserves the stored ceiling across refresh **even when the response carries `session_expiry`**
- [x] `applySessionExpiryAtLogin`: stamps; clears on a no-ceiling re-login; updates on re-login; throws when born-expired
- [x] `getSession` / `getUser`: expired → undefined + delete; future/absent → unchanged; resolver-mode foreign domain not deleted
- [x] `getAccessToken`: expired → throws `SessionExpiredError`, no `/oauth/token` call, session deleted; future → cached token served (regression)
- [x] `getAccessTokenForConnection`: NOT capped — serves past the ceiling, does not throw or delete
- [x] `startLinkUser` / `startUnlinkUser`: expired → throws, URL builder never called
- [x] MFA `verify`: stamps the ceiling; throws + persists nothing when born-expired
- [x] `completeInteractiveLogin`: born-expired → throws, persists nothing, transaction still deleted
- [x] Cookie max-age capped at the ceiling (rolling + non-rolling)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit  

## Release Notes  

* **New Features**
  * Enterprise OIDC sessions now honor the upstream `session_expiry` ceiling (`sessionExpiresAt`) and automatically stop using the session when the ceiling is reached (with clock leeway).
  * Session expiry is applied consistently during MFA verification as well.

* **Bug Fixes**
  * Expired session state is cleared across session accessors; access-token retrieval now throws `SessionExpiredError`.
  * Connection-token retrieval remains uncapped by the session ceiling.
  * Session cookie lifetime/max-age is capped to the ceiling.

* **Documentation**
  * Added examples and upgrade guidance for IPSIE `session_expiry` behavior.

* **Tests**
  * Added unit coverage for parsing, boundary/leeway logic, and lockout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->