### PR TITLE
feat(auth0-server-js): export TokenResponse and ActClaim types

### DIFF
--- a/packages/auth0-server-js/src/index.ts
+++ b/packages/auth0-server-js/src/index.ts
@@ -1,6 +1,7 @@
 export { ServerClient } from './server-client.js';
 export { AbstractStateStore } from './store/abstract-state-store.js';
 export { AbstractTransactionStore } from './store/abstract-transaction-store.js';
+export type { TokenResponse, ActClaim } from '@auth0/auth0-auth-js';
 
 export type { CookieHandler, CookieSerializeOptions } from './store/cookie-handler.js';
 export { CookieTransactionStore } from './store/cookie-transaction-store.js';


### PR DESCRIPTION
### Description

`customTokenExchange()` returns a `TokenResponse` which carries an `act?: ActClaim` field for delegation flows. Neither type was re-exported from `auth0-server-js`, meaning framework adapters (e.g. `auth0-fastify`) and their consumers could not explicitly name the return type without reaching into `@auth0/auth0-auth-js` directly.

This change re-exports both types from `auth0-server-js/src/index.ts` so that consumers can write explicitly typed code:

```ts
import type { TokenResponse, ActClaim } from '@auth0/auth0-server-js';

const tokenResponse: TokenResponse = await fastify.auth0Client.customTokenExchange({ ... });
const actor: ActClaim = tokenResponse.act!;
```

Without this, TypeScript inference still works for inline usage — but the types are not importable, which is a leaky abstraction for framework adapters that re-export the SDK's public surface.

### Changes

- `packages/auth0-server-js/src/index.ts` — added `export type { TokenResponse, ActClaim } from '@auth0/auth0-auth-js'`

### Testing

- All 240 existing tests pass
- Build verified: both types appear in `dist/index.d.ts`

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch