### PR TITLE
feat(auth0-server-js): export TokenExchangeError from public surface

### DIFF
--- a/packages/auth0-server-js/src/index.ts
+++ b/packages/auth0-server-js/src/index.ts
@@ -2,7 +2,7 @@ export { ServerClient } from './server-client.js';
 export { AbstractStateStore } from './store/abstract-state-store.js';
 export { AbstractTransactionStore } from './store/abstract-transaction-store.js';
 export type { TokenResponse, ActClaim } from '@auth0/auth0-auth-js';
-export { TokenExchangeError } from '@auth0/auth0-auth-js';
+export { TokenExchangeError, MissingClientAuthError } from '@auth0/auth0-auth-js';
 
 export type { CookieHandler, CookieSerializeOptions } from './store/cookie-handler.js';
 export { CookieTransactionStore } from './store/cookie-transaction-store.js';

--- a/packages/auth0-server-js/src/index.ts
+++ b/packages/auth0-server-js/src/index.ts
@@ -2,6 +2,7 @@ export { ServerClient } from './server-client.js';
 export { AbstractStateStore } from './store/abstract-state-store.js';
 export { AbstractTransactionStore } from './store/abstract-transaction-store.js';
 export type { TokenResponse, ActClaim } from '@auth0/auth0-auth-js';
+export { TokenExchangeError } from '@auth0/auth0-auth-js';
 
 export type { CookieHandler, CookieSerializeOptions } from './store/cookie-handler.js';
 export { CookieTransactionStore } from './store/cookie-transaction-store.js';


### PR DESCRIPTION
## Summary

- Re-exports `TokenExchangeError` and `MissingClientAuthError` from `@auth0/auth0-auth-js` in the `auth0-server-js` public surface
- Both `loginWithCustomTokenExchange()` and `customTokenExchange()` are documented as throwing these errors, but consumers had no way to import them from `@auth0/auth0-server-js` — they were forced to reach into `@auth0/auth0-auth-js` directly (a transitive dependency) or fall back to matching on `error.name`
- `TokenExchangeError`: thrown when the exchange fails (bad subject token, Auth0 rejects the request, validation errors)
- `MissingClientAuthError`: thrown when the client is not configured with a `clientSecret` or `clientAssertionSigningKey` — CTE requires a confidential client
- Framework SDKs built on top of `auth0-server-js` (e.g. `auth0-fastify`) can now re-export both errors cleanly without adding `auth0-auth-js` as a direct dependency
- Follows the same pattern as `TokenResponse` and `ActClaim` added in #194
