### PR TITLE
feat(auth0-auth-js): add passwordless authentication

### DIFF
--- a/packages/auth0-auth-js/EXAMPLES.md
+++ b/packages/auth0-auth-js/EXAMPLES.md
@@ -28,6 +28,13 @@
 - [Retrieving a Token for a Connection](#retrieving-a-token-for-a-connection)
 - [Building the Logout URL](#building-the-logout-url)
 - [Verifying the Logout Token](#verifying-the-logout-token)
+- [Using Passwordless Authentication](#using-passwordless-authentication)
+    - [Sending an Email Code](#sending-an-email-code)
+    - [Sending an Email Magic Link](#sending-an-email-magic-link)
+    - [Sending an SMS Code](#sending-an-sms-code)
+    - [Logging in with an Email Code](#logging-in-with-an-email-code)
+    - [Logging in with an SMS Code](#logging-in-with-an-sms-code)
+    - [Handling Multi-Factor Authentication](#handling-multi-factor-authentication)
 - [Using Multi-Factor Authentication (MFA)](#using-multi-factor-authentication-mfa)
     - [Enrolling an Authenticator](#enrolling-an-authenticator)
     - [Listing Authenticators](#listing-authenticators)
@@ -644,6 +651,114 @@ const { sid, sub } = await authClient.verifyLogoutToken({ logoutToken });
 ```
 
 When the verification is successful, the `sid` and `sub` claims will be returned. If not, an error will be thrown.
+
+## Using Passwordless Authentication
+
+Passwordless lets users authenticate with a one-time code (or magic link) delivered by email or SMS, rather than a password. There are two steps:
+
+1. **Start** — send the code/link via the `passwordless` sub-client (`sendEmail` / `sendSms`).
+2. **Login** — exchange the one-time code for tokens via `getTokenByPasswordlessEmail` / `getTokenByPasswordlessSms`.
+
+> [!IMPORTANT]
+> Your Auth0 application must have the **Passwordless OTP** grant enabled, with the Email and/or SMS connection configured. See the [Auth0 Passwordless documentation](https://auth0.com/docs/authenticate/passwordless) for tenant setup.
+
+### Sending an Email Code
+
+```ts
+import { AuthClient } from '@auth0/auth0-auth-js';
+
+const authClient = new AuthClient({
+  domain: '<AUTH0_DOMAIN>',
+  clientId: '<AUTH0_CLIENT_ID>',
+  clientSecret: '<AUTH0_CLIENT_SECRET>',
+});
+
+await authClient.passwordless.sendEmail({
+  email: 'user@example.com',
+  send: 'code', // default; can be omitted
+});
+```
+
+### Sending an Email Magic Link
+
+Pass `send: 'link'` together with the `authParams` used when the link is followed. Your application owns the `state` value. Completing a magic link is a no-PKCE authorization-code exchange handled by `getTokenByMagicLinkCode` (see below), **not** by the passwordless login methods and **not** by the PKCE-bound `getTokenByCode`.
+
+```ts
+await authClient.passwordless.sendEmail({
+  email: 'user@example.com',
+  send: 'link',
+  authParams: {
+    redirect_uri: 'https://my-app.example.com/callback',
+    response_type: 'code',
+    scope: 'openid profile',
+    state: '<application_generated_state>',
+  },
+});
+```
+
+Completing the magic link on the callback route. The delivery endpoint registers no PKCE challenge, so the exchange omits the verifier; pass `expectedState` to validate the returned `state`.
+
+```ts
+// On GET /callback?code=...&state=...
+const tokenResponse = await authClient.getTokenByMagicLinkCode(url, {
+  expectedState: '<application_generated_state>',
+});
+```
+
+> [!NOTE]
+> For session management (state generation/persistence + session write), prefer `@auth0/auth0-server-js`'s `startPasswordlessMagicLink` / `completePasswordlessMagicLink`, which wrap this primitive.
+
+### Sending an SMS Code
+
+The phone number must be in E.164 format. SMS supports one-time codes only (no magic link).
+
+```ts
+await authClient.passwordless.sendSms({
+  phoneNumber: '+14155550100',
+});
+```
+
+### Logging in with an Email Code
+
+Exchange the code the user received for a token set. Include `openid` in `scope` to receive an id_token, and `offline_access` to receive a refresh_token — the SDK does not inject scopes at this layer.
+
+```ts
+const tokenResponse = await authClient.getTokenByPasswordlessEmail({
+  email: 'user@example.com',
+  code: '123456',
+  scope: 'openid profile',
+});
+
+// tokenResponse.accessToken, tokenResponse.idToken, tokenResponse.refreshToken
+```
+
+A `PasswordlessVerifyError` is thrown when the code is invalid, expired, or rate-limited.
+
+### Logging in with an SMS Code
+
+```ts
+const tokenResponse = await authClient.getTokenByPasswordlessSms({
+  phoneNumber: '+14155550100',
+  code: '123456',
+});
+```
+
+### Handling Multi-Factor Authentication
+
+If the connection requires MFA, the login methods throw a `PasswordlessVerifyError` whose `cause.error` is `'mfa_required'`. Narrow it with the `isMfaRequiredError` type guard to read `cause.mfa_token`, then use it with the [MFA client](#using-multi-factor-authentication-mfa) to drive the challenge.
+
+```ts
+import { isMfaRequiredError } from '@auth0/auth0-auth-js';
+
+try {
+  await authClient.getTokenByPasswordlessEmail({ email: 'user@example.com', code: '123456' });
+} catch (error) {
+  if (isMfaRequiredError(error)) {
+    const authenticators = await authClient.mfa.listAuthenticators({ mfaToken: error.cause.mfa_token });
+    // ... continue the MFA challenge flow
+  }
+}
+```
 
 ## Using Multi-Factor Authentication (MFA)
 

--- a/packages/auth0-auth-js/EXAMPLES.md
+++ b/packages/auth0-auth-js/EXAMPLES.md
@@ -706,7 +706,7 @@ const tokenResponse = await authClient.getTokenByMagicLinkCode(url, {
 ```
 
 > [!NOTE]
-> For session management (state generation/persistence + session write), prefer `@auth0/auth0-server-js`'s `startPasswordlessMagicLink` / `completePasswordlessMagicLink`, which wrap this primitive.
+> For session management (state generation/persistence + session write), prefer `@auth0/auth0-server-js`'s `startPasswordless({ connection: 'email', send: 'link' })` / `completePasswordlessMagicLink`, which wrap this primitive.
 
 ### Sending an SMS Code
 

--- a/packages/auth0-auth-js/src/auth-client.spec.ts
+++ b/packages/auth0-auth-js/src/auth-client.spec.ts
@@ -1377,7 +1377,9 @@ test('getTokenByMagicLinkCode - should throw TokenByCodeError on failed exchange
   ).rejects.toThrowError(
     expect.objectContaining({
       code: 'token_by_code_error',
-      message: 'There was an error while trying to request a token.',
+      // The underlying openid-client error message is surfaced (not a generic string),
+      // and the structured server error is preserved on `cause`.
+      cause: expect.objectContaining({ error: '<error_code>', error_description: '<error_description>' }),
     })
   );
 });

--- a/packages/auth0-auth-js/src/auth-client.spec.ts
+++ b/packages/auth0-auth-js/src/auth-client.spec.ts
@@ -4,6 +4,7 @@ import { http, HttpResponse } from 'msw';
 import { AuthClient } from './auth-client.js';
 import { NotSupportedError, isMfaRequiredError, TokenByPasswordError } from './errors.js';
 import { PasskeyGetTokenError } from './passkey/errors.js';
+import { PasswordlessVerifyError } from './passwordless/errors.js';
 import { ExchangeProfileOptions } from './types.js';
 
 import { generateToken, jwks } from './test-utils/tokens.js';
@@ -1309,6 +1310,130 @@ test('getTokenByCode - should throw when token exchange failed', async () => {
       }),
     })
   );
+});
+
+test('getTokenByMagicLinkCode - should return tokens without sending a PKCE code_verifier (UT-30)', async () => {
+  const authClient = new AuthClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+  });
+
+  let capturedBody: URLSearchParams | undefined;
+  server.use(
+    http.post(mockOpenIdConfiguration.token_endpoint, async ({ request }) => {
+      capturedBody = new URLSearchParams(await request.text());
+      return HttpResponse.json({
+        access_token: accessToken,
+        id_token: await generateToken(domain, 'user_123', '<client_id>'),
+        expires_in: 60,
+        token_type: 'Bearer',
+        scope: '<scope>',
+      });
+    })
+  );
+
+  const result = await authClient.getTokenByMagicLinkCode(new URL(`https://${domain}?code=123&state=xyz`), {
+    expectedState: 'xyz',
+  });
+
+  expect(result).toBeDefined();
+  expect(result.accessToken).toBe(accessToken);
+  expect(capturedBody?.get('grant_type')).toBe('authorization_code');
+  expect(capturedBody?.get('code')).toBe('123');
+  // No-PKCE assertion: the verifier must never be put on the wire.
+  expect(capturedBody?.has('code_verifier')).toBe(false);
+});
+
+test('getTokenByMagicLinkCode - should throw when returned state does not match expectedState (UT-31)', async () => {
+  const authClient = new AuthClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+  });
+
+  await expect(
+    authClient.getTokenByMagicLinkCode(new URL(`https://${domain}?code=123&state=tampered`), {
+      expectedState: 'xyz',
+    })
+  ).rejects.toThrowError(
+    expect.objectContaining({
+      code: 'token_by_code_error',
+    })
+  );
+});
+
+test('getTokenByMagicLinkCode - should throw TokenByCodeError on failed exchange (UT-32)', async () => {
+  const authClient = new AuthClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+  });
+
+  await expect(
+    authClient.getTokenByMagicLinkCode(new URL(`https://${domain}?code=<code_should_fail>&state=xyz`), {
+      expectedState: 'xyz',
+    })
+  ).rejects.toThrowError(
+    expect.objectContaining({
+      code: 'token_by_code_error',
+      message: 'There was an error while trying to request a token.',
+    })
+  );
+});
+
+test('getTokenByMagicLinkCode - should resolve without expectedState and stay PKCE-free (UT-33)', async () => {
+  const authClient = new AuthClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+  });
+
+  let capturedBody: URLSearchParams | undefined;
+  server.use(
+    http.post(mockOpenIdConfiguration.token_endpoint, async ({ request }) => {
+      capturedBody = new URLSearchParams(await request.text());
+      return HttpResponse.json({
+        access_token: accessToken,
+        id_token: await generateToken(domain, 'user_123', '<client_id>'),
+        expires_in: 60,
+        token_type: 'Bearer',
+        scope: '<scope>',
+      });
+    })
+  );
+
+  const result = await authClient.getTokenByMagicLinkCode(new URL(`https://${domain}?code=123`));
+
+  expect(result.accessToken).toBe(accessToken);
+  expect(capturedBody?.has('code_verifier')).toBe(false);
+});
+
+test('getTokenByCode - should still send a PKCE code_verifier (UT-34 regression)', async () => {
+  const authClient = new AuthClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+  });
+
+  let capturedBody: URLSearchParams | undefined;
+  server.use(
+    http.post(mockOpenIdConfiguration.token_endpoint, async ({ request }) => {
+      capturedBody = new URLSearchParams(await request.text());
+      return HttpResponse.json({
+        access_token: accessToken,
+        id_token: await generateToken(domain, 'user_123', '<client_id>'),
+        expires_in: 60,
+        token_type: 'Bearer',
+        scope: '<scope>',
+      });
+    })
+  );
+
+  await authClient.getTokenByCode(new URL(`https://${domain}?code=123`), { codeVerifier: 'pkce-verifier' });
+
+  // The PKCE path must be unchanged by the magic-link delta: verifier present on the wire.
+  expect(capturedBody?.get('code_verifier')).toBe('pkce-verifier');
 });
 
 test('getTokenByRefreshToken - should return the tokens', async () => {
@@ -3452,5 +3577,151 @@ describe('isMfaRequiredError', () => {
     await expect(
       authClient.getTokenByRefreshToken({ refreshToken: '<refresh_token_mfa_required>' })
     ).rejects.toSatisfy(isMfaRequiredError);
+  });
+});
+
+describe('getTokenByPasswordlessEmail / Sms', () => {
+  const PASSWORDLESS_GRANT = 'http://auth0.com/oauth/grant-type/passwordless/otp';
+
+  const newClient = () => new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });
+
+  // Captures the last form body posted to the token endpoint.
+  let lastForm: URLSearchParams | null;
+  const captureToken = (respond: (form: URLSearchParams) => Response | Promise<Response>) =>
+    server.use(
+      http.post(mockOpenIdConfiguration.token_endpoint, async ({ request }) => {
+        lastForm = new URLSearchParams(await request.text());
+        return respond(lastForm);
+      })
+    );
+
+  beforeEach(() => {
+    lastForm = null;
+  });
+
+  test('UT-19: email OTP exchange happy path', async () => {
+    captureToken(() => HttpResponse.json({ access_token: 'at_email', token_type: 'Bearer', expires_in: 86400 }));
+
+    const token = await newClient().getTokenByPasswordlessEmail({ email: 'user@example.com', code: '123456' });
+
+    expect(token.accessToken).toBe('at_email');
+    expect(lastForm!.get('grant_type')).toBe(PASSWORDLESS_GRANT);
+    expect(lastForm!.get('username')).toBe('user@example.com');
+    expect(lastForm!.get('otp')).toBe('123456');
+    expect(lastForm!.get('realm')).toBe('email');
+  });
+
+  test('UT-20: scope passed through; openid returns id_token', async () => {
+    const idToken = await generateToken(domain, 'user_123', '<client_id>');
+    captureToken((form) =>
+      HttpResponse.json({
+        access_token: 'at',
+        id_token: idToken,
+        token_type: 'Bearer',
+        expires_in: 86400,
+        scope: form.get('scope') ?? undefined,
+      })
+    );
+
+    const token = await newClient().getTokenByPasswordlessEmail({
+      email: 'user@example.com',
+      code: '123456',
+      scope: 'openid profile',
+    });
+
+    expect(lastForm!.get('scope')).toBe('openid profile');
+    expect(token.idToken).toBe(idToken);
+  });
+
+  test('UT-21: scope omitted -> grant still performed, no scope param, no id_token', async () => {
+    captureToken(() => HttpResponse.json({ access_token: 'at_noscope', token_type: 'Bearer', expires_in: 86400 }));
+
+    const token = await newClient().getTokenByPasswordlessEmail({ email: 'user@example.com', code: '123456' });
+
+    expect(lastForm).not.toBeNull(); // grant request WAS made (guards the fixed early-return bug)
+    expect(lastForm!.get('scope')).toBeNull();
+    expect(token.idToken).toBeUndefined();
+    expect(token.accessToken).toBe('at_noscope');
+  });
+
+  test('UT-22: audience forwarded', async () => {
+    captureToken(() => HttpResponse.json({ access_token: 'at', token_type: 'Bearer', expires_in: 86400 }));
+
+    await newClient().getTokenByPasswordlessEmail({
+      email: 'user@example.com',
+      code: '123456',
+      audience: 'https://api.example.com',
+    });
+
+    expect(lastForm!.get('audience')).toBe('https://api.example.com');
+  });
+
+  test('UT-23: invalid_grant -> PasswordlessVerifyError', async () => {
+    captureToken(() =>
+      HttpResponse.json({ error: 'invalid_grant', error_description: 'Invalid code' }, { status: 403 })
+    );
+
+    await expect(
+      newClient().getTokenByPasswordlessEmail({ email: 'user@example.com', code: 'wrong' })
+    ).rejects.toThrow(PasswordlessVerifyError);
+  });
+
+  test('UT-24: too_many_requests -> PasswordlessVerifyError', async () => {
+    captureToken(() =>
+      HttpResponse.json({ error: 'too_many_requests', error_description: 'Rate limited' }, { status: 429 })
+    );
+
+    await expect(
+      newClient().getTokenByPasswordlessEmail({ email: 'user@example.com', code: '123456' })
+    ).rejects.toThrow(PasswordlessVerifyError);
+  });
+
+  test('UT-25: 403 mfa_required -> PasswordlessVerifyError narrowable via isMfaRequiredError, carrying mfa_token', async () => {
+    captureToken(() =>
+      HttpResponse.json(
+        { error: 'mfa_required', error_description: 'MFA required', mfa_token: 'mfa_token_value' },
+        { status: 403 }
+      )
+    );
+
+    const error = await newClient()
+      .getTokenByPasswordlessEmail({ email: 'user@example.com', code: '123456' })
+      .catch((e) => e);
+
+    // MFA is not a distinct error type: the usual PasswordlessVerifyError is thrown,
+    // carrying cause.error === 'mfa_required', and is narrowed via isMfaRequiredError.
+    expect(error).toBeInstanceOf(PasswordlessVerifyError);
+    expect(isMfaRequiredError(error)).toBe(true);
+    if (isMfaRequiredError(error)) {
+      expect(error.cause.mfa_token).toBe('mfa_token_value');
+    }
+  });
+
+  test('UT-26: SMS OTP exchange with realm=sms', async () => {
+    captureToken(() => HttpResponse.json({ access_token: 'at_sms', token_type: 'Bearer', expires_in: 86400 }));
+
+    const token = await newClient().getTokenByPasswordlessSms({ phoneNumber: '+14155550100', code: '123456' });
+
+    expect(token.accessToken).toBe('at_sms');
+    expect(lastForm!.get('username')).toBe('+14155550100');
+    expect(lastForm!.get('realm')).toBe('sms');
+  });
+
+  test('UT-27: SMS login on non-E.164 -> PasswordlessVerifyError, no token request', async () => {
+    captureToken(() => HttpResponse.json({ access_token: 'never', token_type: 'Bearer', expires_in: 1 }));
+
+    await expect(
+      newClient().getTokenByPasswordlessSms({ phoneNumber: '12025551234', code: '123456' })
+    ).rejects.toThrow(PasswordlessVerifyError);
+    expect(lastForm).toBeNull();
+  });
+});
+
+describe('passwordless public export surface', () => {
+  test('UT-29: package re-exports passwordless runtime symbols', async () => {
+    const mod = await import('./index.js');
+    expect(mod.PasswordlessClient).toBeDefined();
+    expect(mod.PasswordlessStartError).toBeDefined();
+    expect(mod.PasswordlessVerifyError).toBeDefined();
   });
 });

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -22,6 +22,9 @@ import {
 import { stripUndefinedProperties } from './utils.js';
 import { MfaClient } from './mfa/mfa-client.js';
 import { PasskeyClient, PASSKEY_GRANT_TYPE } from './passkey/passkey-client.js';
+import { PasswordlessClient } from './passwordless/passwordless-client.js';
+import { PasswordlessVerifyError } from './passwordless/errors.js';
+import { isE164PhoneNumber } from './passwordless/utils.js';
 import { createTelemetryFetch, getTelemetryConfig } from './telemetry.js';
 import {
   AuthClientOptions,
@@ -37,7 +40,10 @@ import {
   TokenVaultExchangeOptions,
   TokenByClientCredentialsOptions,
   TokenByCodeOptions,
+  TokenByMagicLinkCodeOptions,
   TokenByPasswordOptions,
+  TokenByPasswordlessEmailOptions,
+  TokenByPasswordlessSmsOptions,
   TokenByRefreshTokenOptions,
   TokenForConnectionOptions,
   TokenResponse,
@@ -269,6 +275,12 @@ export class AuthClient {
   readonly #jwksCache: JWKSCacheInput;
   public mfa: MfaClient;
   public passkey: PasskeyClient;
+  /**
+   * Sub-client for the Auth0 Passwordless `/passwordless/start` endpoint
+   * (`sendEmail`, `sendSms`). Token exchange for the codes it sends is done via
+   * {@link AuthClient#getTokenByPasswordlessEmail} / {@link AuthClient#getTokenByPasswordlessSms}.
+   */
+  public passwordless: PasswordlessClient;
 
   constructor(options: AuthClientOptions) {
     this.#options = options;
@@ -320,6 +332,18 @@ export class AuthClient {
         const tokenEndpointResponse = await client.genericGrantRequest(configuration, grantType, params);
         return TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
       },
+    });
+
+    // `/passwordless/start` requires body-level client authentication, so the
+    // sub-client receives the client-auth options in addition to the MFA-style trio.
+    this.passwordless = new PasswordlessClient({
+      domain: this.#options.domain,
+      clientId: this.#options.clientId,
+      customFetch: this.#customFetch,
+      clientSecret: this.#options.clientSecret,
+      clientAssertionSigningKey: this.#options.clientAssertionSigningKey,
+      clientAssertionSigningAlg: this.#options.clientAssertionSigningAlg,
+      useMtls: this.#options.useMtls,
     });
   }
 
@@ -959,6 +983,49 @@ export class AuthClient {
   }
 
   /**
+   * Completes a magic-link sign-in by exchanging the authorization code on the callback URL
+   * for tokens, WITHOUT PKCE.
+   *
+   * Unlike {@link AuthClient#getTokenByCode}, this method does not present a `code_verifier`:
+   * `/passwordless/start` delivers the link but never registers a `code_challenge`, so presenting
+   * a verifier at the exchange would be rejected with `invalid_grant`. The `pkceCodeVerifier` option
+   * is intentionally omitted, which makes the underlying `openid-client` use its no-PKCE sentinel.
+   * The returned `state` is validated against `options.expectedState` (anti-forgery binding).
+   *
+   * This is the token-layer primitive used by the session layer's `completePasswordlessMagicLink`.
+   * The PKCE-bound {@link AuthClient#getTokenByCode} remains the path for interactive logins.
+   *
+   * @param url The callback URL containing the authorization `code` and `state`.
+   * @param options Options for the exchange, including the expected `state`.
+   *
+   * @throws {TokenByCodeError} If state validation fails or the token exchange fails.
+   *
+   * @returns A Promise, resolving to the TokenResponse as returned from Auth0.
+   *
+   * @example
+   * const tokenResponse = await authClient.getTokenByMagicLinkCode(callbackUrl, {
+   *   expectedState: persistedState,
+   * });
+   */
+  public async getTokenByMagicLinkCode(
+    url: URL,
+    options?: TokenByMagicLinkCodeOptions
+  ): Promise<TokenResponse> {
+    const { configuration } = await this.#discover();
+    try {
+      const tokenEndpointResponse = await client.authorizationCodeGrant(configuration, url, {
+        // `pkceCodeVerifier` intentionally omitted: openid-client substitutes its no-PKCE sentinel
+        // (oauth.nopkce). `expectedState` drives oauth.validateAuthResponse for anti-forgery binding.
+        expectedState: options?.expectedState,
+      });
+
+      return TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
+    } catch (e) {
+      throw new TokenByCodeError('There was an error while trying to request a token.', e as OAuth2Error);
+    }
+  }
+
+  /**
    * Retrieves a token by exchanging a refresh token.
    * @param options Options for exchanging the refresh token.
    *
@@ -1062,6 +1129,122 @@ export class AuthClient {
         'There was an error while trying to request a token.',
         toOAuth2Error(e)
       );
+    }
+  }
+
+  /**
+   * Exchanges a passwordless email one-time code for a token (OTP grant).
+   *
+   * For the `send: 'code'` flow only. Magic links are completed through the standard
+   * authorization-code exchange ({@link AuthClient#getTokenByCode}) plus the redirect
+   * callback, not through this method.
+   *
+   * Tenant prerequisites: a confidential application with the Passwordless OTP grant
+   * enabled and an Identifier-First authentication profile.
+   *
+   * @param options Options containing the email, code, and optional audience/scope.
+   *
+   * @throws {PasswordlessVerifyError} If the code is invalid, expired, or rate-limited.
+   * @throws {PasswordlessVerifyError} On a failed exchange. When the connection requires MFA the
+   *   server responds with `403 mfa_required`; narrow the error with `isMfaRequiredError` and
+   *   complete the challenge via `authClient.mfa`.
+   *
+   * @returns A Promise, resolving to the TokenResponse as returned from Auth0.
+   *
+   * @example
+   * ```typescript
+   * const tokens = await authClient.getTokenByPasswordlessEmail({
+   *   email: 'user@example.com',
+   *   code: '123456',
+   *   scope: 'openid profile', // include 'openid' for an id_token; SDK does not inject it
+   * });
+   * ```
+   */
+  public async getTokenByPasswordlessEmail(options: TokenByPasswordlessEmailOptions): Promise<TokenResponse> {
+    const params = new URLSearchParams({
+      username: options.email,
+      otp: options.code,
+      realm: 'email',
+    });
+
+    if (options.audience) {
+      params.append('audience', options.audience);
+    }
+
+    if (options.scope) {
+      params.append('scope', options.scope);
+    }
+
+    return this.#getTokenByPasswordlessOtp(params);
+  }
+
+  /**
+   * Exchanges a passwordless SMS one-time code for a token (OTP grant).
+   *
+   * @param options Options containing the phone number (E.164), code, and optional audience/scope.
+   *
+   * @throws {PasswordlessVerifyError} If the phone number is invalid, or the code is invalid,
+   *   expired, or rate-limited.
+   * @throws {PasswordlessVerifyError} On a failed exchange. When the connection requires MFA the
+   *   server responds with `403 mfa_required`; narrow the error with `isMfaRequiredError` and
+   *   complete the challenge via `authClient.mfa`.
+   *
+   * @returns A Promise, resolving to the TokenResponse as returned from Auth0.
+   *
+   * @example
+   * ```typescript
+   * const tokens = await authClient.getTokenByPasswordlessSms({
+   *   phoneNumber: '+14155550100',
+   *   code: '123456',
+   * });
+   * ```
+   */
+  public async getTokenByPasswordlessSms(options: TokenByPasswordlessSmsOptions): Promise<TokenResponse> {
+    if (!isE164PhoneNumber(options.phoneNumber)) {
+      throw new PasswordlessVerifyError('Phone number must be in E.164 format (e.g. +14155550100).');
+    }
+
+    const params = new URLSearchParams({
+      username: options.phoneNumber,
+      otp: options.code,
+      realm: 'sms',
+    });
+
+    if (options.audience) {
+      params.append('audience', options.audience);
+    }
+
+    if (options.scope) {
+      params.append('scope', options.scope);
+    }
+
+    return this.#getTokenByPasswordlessOtp(params);
+  }
+
+  /**
+   * Executes the passwordless OTP grant and maps errors to {@link PasswordlessVerifyError}.
+   *
+   * A `403 mfa_required` response is not a distinct error type: like the other token
+   * methods (`getTokenByPassword`, `passkey.getTokenByPasskey`), the thrown
+   * `PasswordlessVerifyError` carries `cause.error === 'mfa_required'` with the
+   * server's `mfa_token` lifted onto `cause`. Callers narrow with {@link isMfaRequiredError}
+   * and drive the challenge via `authClient.mfa`.
+   */
+  async #getTokenByPasswordlessOtp(params: URLSearchParams): Promise<TokenResponse> {
+    const { configuration } = await this.#discover();
+
+    try {
+      const tokenEndpointResponse = await client.genericGrantRequest(
+        configuration,
+        'http://auth0.com/oauth/grant-type/passwordless/otp',
+        params
+      );
+
+      return TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
+    } catch (e) {
+      // `toOAuth2Error` lifts `mfa_token` / `mfa_requirements` from the nested
+      // openid-client `cause` so `isMfaRequiredError` can detect an MFA requirement.
+      throw new PasswordlessVerifyError('There was an error while trying to request a token.', toOAuth2Error(e));
     }
   }
 

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -1021,7 +1021,10 @@ export class AuthClient {
 
       return TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
     } catch (e) {
-      throw new TokenByCodeError('There was an error while trying to request a token.', e as OAuth2Error);
+      // Surface the underlying message (e.g. openid-client state-mismatch) instead of a
+      // generic string, so a non-token-endpoint failure is not mislabeled as one.
+      const message = e instanceof Error && e.message ? e.message : 'There was an error while trying to request a token.';
+      throw new TokenByCodeError(message, e as OAuth2Error);
     }
   }
 

--- a/packages/auth0-auth-js/src/errors.ts
+++ b/packages/auth0-auth-js/src/errors.ts
@@ -233,9 +233,9 @@ export class BuildUnlinkUserUrlError extends ApiError {
  * Narrows an error thrown by a token request method to one caused by an `mfa_required` response.
  *
  * When the Auth0 server requires multi-factor authentication, token request methods
- * (`getTokenByPassword`, `getTokenByRefreshToken`, `exchangeToken`, `passkey.getTokenByPasskey`)
- * throw their usual error (e.g. `TokenByPasswordError`, `PasskeyGetTokenError`) with
- * `cause.error` set to `'mfa_required'`.
+ * (`getTokenByPassword`, `getTokenByRefreshToken`, `exchangeToken`, `passkey.getTokenByPasskey`,
+ * `getTokenByPasswordlessEmail`, `getTokenByPasswordlessSms`) throw their usual error
+ * (e.g. `TokenByPasswordError`, `PasswordlessVerifyError`) with `cause.error` set to `'mfa_required'`.
  * The `cause` will also contain:
  * - `mfa_token` — the token needed to proceed with enrollment or challenge MFA APIs
  * - `mfa_requirements` — (optional) describes which factors to challenge or enroll

--- a/packages/auth0-auth-js/src/index.ts
+++ b/packages/auth0-auth-js/src/index.ts
@@ -3,3 +3,13 @@ export * from './errors.js';
 export * from './types.js';
 export * from './mfa/index.js';
 export * from './passkey/index.js';
+export { PasswordlessClient } from './passwordless/passwordless-client.js';
+export { PasswordlessStartError, PasswordlessVerifyError } from './passwordless/errors.js';
+export type { PasswordlessApiErrorResponse } from './passwordless/errors.js';
+export type {
+  PasswordlessClientOptions,
+  SendEmailOptions,
+  SendEmailCodeOptions,
+  SendEmailLinkOptions,
+  SendSmsOptions,
+} from './passwordless/types.js';

--- a/packages/auth0-auth-js/src/passwordless/errors.ts
+++ b/packages/auth0-auth-js/src/passwordless/errors.ts
@@ -26,6 +26,10 @@ abstract class PasswordlessError extends Error {
   constructor(code: string, message: string, cause?: OAuth2Error) {
     super(message);
 
+    // Restore the prototype chain so `instanceof` works when this class is
+    // down-compiled to ES5 (Error breaks the chain under that target).
+    Object.setPrototypeOf(this, new.target.prototype);
+
     this.code = code;
     this.cause = cause && {
       error: cause.error,

--- a/packages/auth0-auth-js/src/passwordless/errors.ts
+++ b/packages/auth0-auth-js/src/passwordless/errors.ts
@@ -1,0 +1,64 @@
+import type { OAuth2Error } from '../errors.js';
+
+/**
+ * Interface to represent a Passwordless API error response (wire format).
+ */
+export interface PasswordlessApiErrorResponse {
+  error: string;
+  error_description: string;
+  message?: string;
+}
+
+/**
+ * Base class for Passwordless-related errors.
+ *
+ * Not exported: consumers branch on the concrete subclasses
+ * ({@link PasswordlessStartError}, {@link PasswordlessVerifyError}) or on `err.code`.
+ *
+ * `cause` is typed as {@link OAuth2Error} so that a `403 mfa_required` token
+ * response — carried on a {@link PasswordlessVerifyError} with `mfa_token` /
+ * `mfa_requirements` — can be narrowed with `isMfaRequiredError`.
+ */
+abstract class PasswordlessError extends Error {
+  public cause?: OAuth2Error;
+  public code: string;
+
+  constructor(code: string, message: string, cause?: OAuth2Error) {
+    super(message);
+
+    this.code = code;
+    this.cause = cause && {
+      error: cause.error,
+      error_description: cause.error_description,
+      message: cause.message,
+      mfa_token: cause.mfa_token,
+      mfa_requirements: cause.mfa_requirements,
+    };
+  }
+}
+
+/**
+ * Error thrown when initiating a passwordless flow via `/passwordless/start` fails
+ * (e.g. bad connection, invalid email/phone, sms provider error, rate limited).
+ */
+export class PasswordlessStartError extends PasswordlessError {
+  constructor(message: string, cause?: OAuth2Error) {
+    super('passwordless_start_error', message, cause);
+    this.name = 'PasswordlessStartError';
+  }
+}
+
+/**
+ * Error thrown when exchanging a passwordless OTP code for a token fails
+ * (e.g. invalid/expired code, too many requests).
+ *
+ * A `403 mfa_required` response is also surfaced as this error, carrying
+ * `cause.error === 'mfa_required'` with the server's `mfa_token`. Narrow it with
+ * `isMfaRequiredError` to drive the MFA challenge via `authClient.mfa`.
+ */
+export class PasswordlessVerifyError extends PasswordlessError {
+  constructor(message: string, cause?: OAuth2Error) {
+    super('passwordless_verify_error', message, cause);
+    this.name = 'PasswordlessVerifyError';
+  }
+}

--- a/packages/auth0-auth-js/src/passwordless/passwordless-client.spec.ts
+++ b/packages/auth0-auth-js/src/passwordless/passwordless-client.spec.ts
@@ -202,6 +202,13 @@ describe('PasswordlessClient - sendSms', () => {
     await expect(secretClient().sendSms({ phoneNumber: '447911123456' })).rejects.toThrow(PasswordlessStartError);
   });
 
+  test('UT-16b: forwards language as the x-request-language header, not a body field', async () => {
+    await secretClient().sendSms({ phoneNumber: '+14155550100', language: 'pt-BR' });
+
+    expect(lastHeaders!.get('x-request-language')).toBe('pt-BR');
+    expect(lastBody!).not.toHaveProperty('language');
+  });
+
   test('UT-17: throws PasswordlessStartError on API error', async () => {
     server.use(http.post(startUrl, () => HttpResponse.json({ error: 'sms_provider_error' }, { status: 400 })));
     await expect(secretClient().sendSms({ phoneNumber: '+14155550100' })).rejects.toThrow(PasswordlessStartError);

--- a/packages/auth0-auth-js/src/passwordless/passwordless-client.spec.ts
+++ b/packages/auth0-auth-js/src/passwordless/passwordless-client.spec.ts
@@ -25,13 +25,15 @@ const generateRsaKeyPair = () =>
     ['sign', 'verify']
   ) as Promise<CryptoKeyPair>;
 
-// Captures the last request body seen by the /passwordless/start handler.
+// Captures the last request body/headers seen by the /passwordless/start handler.
 let lastBody: Record<string, unknown> | null;
+let lastHeaders: Headers | null;
 let requestCount: number;
 
 const restHandlers = [
   http.post(startUrl, async ({ request }) => {
     requestCount += 1;
+    lastHeaders = request.headers;
     lastBody = (await request.json()) as Record<string, unknown>;
     return HttpResponse.json({}, { status: 200 });
   }),
@@ -42,6 +44,7 @@ const server = setupServer(...restHandlers);
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterEach(() => {
   lastBody = null;
+  lastHeaders = null;
   requestCount = 0;
   server.resetHandlers();
 });
@@ -74,6 +77,19 @@ describe('PasswordlessClient - sendEmail', () => {
   test('UT-3: link WITHOUT authParams resolves and omits the key', async () => {
     server.use(http.post(startUrl, () => new HttpResponse(null, { status: 204 })));
     await expect(secretClient().sendEmail({ email: 'user@example.com', send: 'link' })).resolves.toBeUndefined();
+  });
+
+  test('UT-28: forwards language as the x-request-language header, not a body field', async () => {
+    await secretClient().sendEmail({ email: 'user@example.com', send: 'code', language: 'fr-CA' });
+
+    expect(lastHeaders!.get('x-request-language')).toBe('fr-CA');
+    expect(lastBody!).not.toHaveProperty('language');
+  });
+
+  test('UT-28b: omits the x-request-language header when language is not provided', async () => {
+    await secretClient().sendEmail({ email: 'user@example.com', send: 'code' });
+
+    expect(lastHeaders!.has('x-request-language')).toBe(false);
   });
 
   test('UT-4: accepts 204 No Content', async () => {

--- a/packages/auth0-auth-js/src/passwordless/passwordless-client.spec.ts
+++ b/packages/auth0-auth-js/src/passwordless/passwordless-client.spec.ts
@@ -1,0 +1,204 @@
+import { expect, test, describe, beforeAll, afterAll, afterEach, vi } from 'vitest';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import { decodeJwt, decodeProtectedHeader } from 'jose';
+import { PasswordlessClient } from './passwordless-client.js';
+import { PasswordlessStartError } from './errors.js';
+import { MissingClientAuthError } from '../errors.js';
+
+const domain = 'auth0.local';
+const clientId = 'test-client-id';
+const clientSecret = 'test-client-secret';
+const startUrl = `https://${domain}/passwordless/start`;
+
+const exportPrivateKeyToPem = async (privateKey: CryptoKey): Promise<string> => {
+  const pkcs8 = await crypto.subtle.exportKey('pkcs8', privateKey);
+  const keyBase64 = Buffer.from(pkcs8).toString('base64');
+  const keyLines = keyBase64.match(/.{1,64}/g) ?? [keyBase64];
+  return `-----BEGIN PRIVATE KEY-----\n${keyLines.join('\n')}\n-----END PRIVATE KEY-----`;
+};
+
+const generateRsaKeyPair = () =>
+  crypto.subtle.generateKey(
+    { name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: { name: 'SHA-256' } },
+    true,
+    ['sign', 'verify']
+  ) as Promise<CryptoKeyPair>;
+
+// Captures the last request body seen by the /passwordless/start handler.
+let lastBody: Record<string, unknown> | null;
+let requestCount: number;
+
+const restHandlers = [
+  http.post(startUrl, async ({ request }) => {
+    requestCount += 1;
+    lastBody = (await request.json()) as Record<string, unknown>;
+    return HttpResponse.json({}, { status: 200 });
+  }),
+];
+
+const server = setupServer(...restHandlers);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  lastBody = null;
+  requestCount = 0;
+  server.resetHandlers();
+});
+afterAll(() => server.close());
+
+const secretClient = () => new PasswordlessClient({ domain, clientId, clientSecret });
+
+describe('PasswordlessClient - sendEmail', () => {
+  test('UT-1: sends code (default) with client_secret', async () => {
+    await secretClient().sendEmail({ email: 'user@example.com', send: 'code' });
+
+    expect(lastBody).toMatchObject({
+      client_id: clientId,
+      connection: 'email',
+      email: 'user@example.com',
+      send: 'code',
+      client_secret: clientSecret,
+    });
+  });
+
+  test('UT-2: sends link with authParams (camelCase key, no auth_params)', async () => {
+    const authParams = { redirect_uri: 'https://app/cb', scope: 'openid', state: 'xyz' };
+    await secretClient().sendEmail({ email: 'user@example.com', send: 'link', authParams });
+
+    expect(lastBody!.send).toBe('link');
+    expect(lastBody!.authParams).toEqual(authParams);
+    expect(lastBody!).not.toHaveProperty('auth_params');
+  });
+
+  test('UT-3: link WITHOUT authParams resolves and omits the key', async () => {
+    server.use(http.post(startUrl, () => new HttpResponse(null, { status: 204 })));
+    await expect(secretClient().sendEmail({ email: 'user@example.com', send: 'link' })).resolves.toBeUndefined();
+  });
+
+  test('UT-4: accepts 204 No Content', async () => {
+    server.use(http.post(startUrl, () => new HttpResponse(null, { status: 204 })));
+    await expect(secretClient().sendEmail({ email: 'user@example.com' })).resolves.toBeUndefined();
+  });
+
+  test('UT-5: accepts 200 with empty object body', async () => {
+    await expect(secretClient().sendEmail({ email: 'user@example.com' })).resolves.toBeUndefined();
+  });
+
+  test('UT-6: throws PasswordlessStartError on 400 with error body', async () => {
+    server.use(
+      http.post(startUrl, () =>
+        HttpResponse.json({ error: 'invalid_request', error_description: 'Invalid email' }, { status: 400 })
+      )
+    );
+    await expect(secretClient().sendEmail({ email: 'bad' })).rejects.toMatchObject({
+      name: 'PasswordlessStartError',
+      cause: { error_description: 'Invalid email' },
+    });
+  });
+
+  test('UT-7: throws PasswordlessStartError on 401 unauthorized_client', async () => {
+    server.use(http.post(startUrl, () => HttpResponse.json({ error: 'unauthorized_client' }, { status: 401 })));
+    await expect(secretClient().sendEmail({ email: 'user@example.com' })).rejects.toThrow(PasswordlessStartError);
+  });
+
+  test('UT-8: throws PasswordlessStartError on non-JSON error body (no cause)', async () => {
+    server.use(http.post(startUrl, () => new HttpResponse('boom', { status: 400 })));
+    await expect(secretClient().sendEmail({ email: 'user@example.com' })).rejects.toMatchObject({
+      name: 'PasswordlessStartError',
+      cause: undefined,
+    });
+  });
+
+  test('UT-9: throws PasswordlessStartError on network error', async () => {
+    server.use(http.post(startUrl, () => HttpResponse.error()));
+    await expect(secretClient().sendEmail({ email: 'user@example.com' })).rejects.toThrow(PasswordlessStartError);
+  });
+
+  test('UT-10: injects client_assertion for private_key_jwt with correct JWT claims', async () => {
+    const { privateKey } = await generateRsaKeyPair();
+    const pem = await exportPrivateKeyToPem(privateKey);
+    const client = new PasswordlessClient({ domain, clientId, clientAssertionSigningKey: pem, clientAssertionSigningAlg: 'RS256' });
+
+    await client.sendEmail({ email: 'user@example.com' });
+
+    expect(lastBody!.client_assertion_type).toBe('urn:ietf:params:oauth:client-assertion-type:jwt-bearer');
+    const jwt = lastBody!.client_assertion as string;
+    expect(typeof jwt).toBe('string');
+    expect(decodeProtectedHeader(jwt).alg).toBe('RS256');
+    const claims = decodeJwt(jwt);
+    expect(claims.iss).toBe(clientId);
+    expect(claims.sub).toBe(clientId);
+    expect(claims.aud).toBe(`https://${domain}/`);
+    expect(typeof claims.jti).toBe('string');
+    const ttl = (claims.exp as number) - (claims.iat as number);
+    expect(ttl).toBe(120);
+    expect(lastBody!).not.toHaveProperty('client_secret');
+  });
+
+  test('UT-11: client_assertion accepts a CryptoKey input', async () => {
+    const { privateKey } = await generateRsaKeyPair();
+    const client = new PasswordlessClient({ domain, clientId, clientAssertionSigningKey: privateKey });
+
+    await client.sendEmail({ email: 'user@example.com' });
+
+    const jwt = lastBody!.client_assertion as string;
+    expect(typeof jwt).toBe('string');
+    expect(decodeJwt(jwt).aud).toBe(`https://${domain}/`);
+  });
+
+  test('UT-12: throws MissingClientAuthError when no client auth configured', async () => {
+    const client = new PasswordlessClient({ domain, clientId });
+    await expect(client.sendEmail({ email: 'user@example.com' })).rejects.toThrow(MissingClientAuthError);
+  });
+
+  test('UT-13: useMtls produces no body auth fields', async () => {
+    const client = new PasswordlessClient({ domain, clientId, useMtls: true });
+    await client.sendEmail({ email: 'user@example.com' });
+
+    expect(lastBody!).not.toHaveProperty('client_secret');
+    expect(lastBody!).not.toHaveProperty('client_assertion');
+  });
+});
+
+describe('PasswordlessClient - sendSms', () => {
+  test('UT-14: sends SMS with E.164 phone; no delivery_method', async () => {
+    await secretClient().sendSms({ phoneNumber: '+14155550100' });
+
+    expect(lastBody).toMatchObject({
+      client_id: clientId,
+      connection: 'sms',
+      phone_number: '+14155550100',
+      client_secret: clientSecret,
+    });
+    expect(lastBody!).not.toHaveProperty('delivery_method');
+    expect(lastBody!).not.toHaveProperty('deliveryMethod');
+  });
+
+  test('UT-15: throws PasswordlessStartError on non-E.164 phone before request', async () => {
+    await expect(secretClient().sendSms({ phoneNumber: '12025551234' })).rejects.toThrow(/E\.164/);
+    expect(requestCount).toBe(0);
+  });
+
+  test('UT-16: accepts +44; rejects missing-+ before request', async () => {
+    await expect(secretClient().sendSms({ phoneNumber: '+447911123456' })).resolves.toBeUndefined();
+    expect(requestCount).toBe(1);
+    await expect(secretClient().sendSms({ phoneNumber: '447911123456' })).rejects.toThrow(PasswordlessStartError);
+  });
+
+  test('UT-17: throws PasswordlessStartError on API error', async () => {
+    server.use(http.post(startUrl, () => HttpResponse.json({ error: 'sms_provider_error' }, { status: 400 })));
+    await expect(secretClient().sendSms({ phoneNumber: '+14155550100' })).rejects.toThrow(PasswordlessStartError);
+  });
+
+  test('UT-18: telemetry-wrapped customFetch is used and headers pass through', async () => {
+    const customFetch = vi.fn((...args: Parameters<typeof fetch>) => fetch(...args));
+    const client = new PasswordlessClient({ domain, clientId, clientSecret, customFetch });
+
+    await client.sendSms({ phoneNumber: '+14155550100' });
+
+    expect(customFetch).toHaveBeenCalledTimes(1);
+    const [, init] = customFetch.mock.calls[0];
+    expect((init as RequestInit).method).toBe('POST');
+  });
+});

--- a/packages/auth0-auth-js/src/passwordless/passwordless-client.ts
+++ b/packages/auth0-auth-js/src/passwordless/passwordless-client.ts
@@ -65,7 +65,7 @@ export class PasswordlessClient {
    * ```
    */
   async sendEmail(options: SendEmailOptions): Promise<void> {
-    await this.#start(transformSendEmailRequest(options), 'Failed to send passwordless email');
+    await this.#start(transformSendEmailRequest(options), 'Failed to send passwordless email', options.language);
   }
 
   /**
@@ -93,7 +93,7 @@ export class PasswordlessClient {
    * error handling. Accepts both `200 {}` and `204 No Content` as success; never
    * parses a body on `204`.
    */
-  async #start(wireBody: Record<string, unknown>, failureMessage: string): Promise<void> {
+  async #start(wireBody: Record<string, unknown>, failureMessage: string, language?: string): Promise<void> {
     const clientAuthBody = await buildClientAuthBody(this.#clientAuthOptions, this.#clientId, this.#domain);
 
     const finalBody = {
@@ -106,7 +106,12 @@ export class PasswordlessClient {
     try {
       response = await this.#customFetch(`${this.#baseUrl}/passwordless/start`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        // `x-request-language` is an HTTP header (not a body field) used to localize
+        // the email/SMS template, matching node-auth0 / nextjs-auth0.
+        headers: {
+          'Content-Type': 'application/json',
+          ...(language ? { 'x-request-language': language } : {}),
+        },
         body: JSON.stringify(finalBody),
       });
     } catch {

--- a/packages/auth0-auth-js/src/passwordless/passwordless-client.ts
+++ b/packages/auth0-auth-js/src/passwordless/passwordless-client.ts
@@ -1,0 +1,135 @@
+import { PasswordlessStartError, type PasswordlessApiErrorResponse } from './errors.js';
+import type { PasswordlessClientOptions, SendEmailOptions, SendSmsOptions } from './types.js';
+import {
+  buildClientAuthBody,
+  isE164PhoneNumber,
+  transformSendEmailRequest,
+  transformSendSmsRequest,
+  type ClientAuthOptions,
+} from './utils.js';
+
+/**
+ * Sub-client for the Auth0 Passwordless `/passwordless/start` endpoint.
+ *
+ * Exposed via `authClient.passwordless`. Unlike OAuth token endpoints, this is a
+ * raw (non-`openid-client`) POST that requires client authentication on the request
+ * body, so the client-auth options are passed to the constructor.
+ */
+export class PasswordlessClient {
+  #baseUrl: string;
+  #domain: string;
+  #clientId: string;
+  #customFetch: typeof fetch;
+  #clientAuthOptions: ClientAuthOptions;
+
+  /**
+   * @internal
+   */
+  constructor(options: PasswordlessClientOptions) {
+    this.#domain = options.domain;
+    this.#baseUrl = `https://${options.domain}`;
+    this.#clientId = options.clientId;
+    this.#customFetch = options.customFetch ?? ((...args) => fetch(...args));
+    this.#clientAuthOptions = {
+      clientSecret: options.clientSecret,
+      clientAssertionSigningKey: options.clientAssertionSigningKey,
+      clientAssertionSigningAlg: options.clientAssertionSigningAlg,
+      useMtls: options.useMtls,
+    };
+  }
+
+  /**
+   * Sends a passwordless email containing either a one-time code (default) or a magic link.
+   *
+   * @param options - Send options. Omit `send` (or pass `send: 'code'`) to send a code;
+   *   pass `send: 'link'` with `authParams` to send a magic link.
+   * @throws {PasswordlessStartError} When the request fails or the server returns a non-2xx response.
+   * @throws {MissingClientAuthError} When no client authentication method is configured.
+   *
+   * @example
+   * ```typescript
+   * // Send a one-time code (default)
+   * await authClient.passwordless.sendEmail({ email: 'user@example.com' });
+   *
+   * // Send a magic link (completion is handled by the redirect/callback flow, not this method)
+   * await authClient.passwordless.sendEmail({
+   *   email: 'user@example.com',
+   *   send: 'link',
+   *   authParams: {
+   *     redirect_uri: 'https://myapp.com/callback',
+   *     response_type: 'code',
+   *     scope: 'openid profile',
+   *     state: 'caller_generated_state',
+   *   },
+   * });
+   * ```
+   */
+  async sendEmail(options: SendEmailOptions): Promise<void> {
+    await this.#start(transformSendEmailRequest(options), 'Failed to send passwordless email');
+  }
+
+  /**
+   * Sends a passwordless SMS containing a one-time code. SMS does not support magic links.
+   *
+   * @param options - Send options. `phoneNumber` must be in E.164 format (e.g. `+14155550100`).
+   * @throws {PasswordlessStartError} When the phone number is invalid, the request fails,
+   *   or the server returns a non-2xx response.
+   * @throws {MissingClientAuthError} When no client authentication method is configured.
+   *
+   * @example
+   * ```typescript
+   * await authClient.passwordless.sendSms({ phoneNumber: '+14155550100' });
+   * ```
+   */
+  async sendSms(options: SendSmsOptions): Promise<void> {
+    if (!isE164PhoneNumber(options.phoneNumber)) {
+      throw new PasswordlessStartError('Phone number must be in E.164 format (e.g. +14155550100).');
+    }
+    await this.#start(transformSendSmsRequest(options), 'Failed to send passwordless SMS');
+  }
+
+  /**
+   * Performs the `/passwordless/start` POST with client authentication and uniform
+   * error handling. Accepts both `200 {}` and `204 No Content` as success; never
+   * parses a body on `204`.
+   */
+  async #start(wireBody: Record<string, unknown>, failureMessage: string): Promise<void> {
+    const clientAuthBody = await buildClientAuthBody(this.#clientAuthOptions, this.#clientId, this.#domain);
+
+    const finalBody = {
+      client_id: this.#clientId,
+      ...wireBody,
+      ...clientAuthBody,
+    };
+
+    let response: Response;
+    try {
+      response = await this.#customFetch(`${this.#baseUrl}/passwordless/start`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(finalBody),
+      });
+    } catch {
+      throw new PasswordlessStartError(`${failureMessage}: a network error occurred.`);
+    }
+
+    if (response.ok) {
+      // 200 {} or 204 No Content — nothing to parse.
+      return;
+    }
+
+    // Error path: 204 has no body, so only parse JSON when a body is expected.
+    // When no structured body is available (204, or non-JSON), leave `cause`
+    // undefined so callers can distinguish an OAuth-style error from an opaque one.
+    let errorBody: PasswordlessApiErrorResponse | undefined;
+    if (response.status !== 204) {
+      try {
+        errorBody = (await response.json()) as PasswordlessApiErrorResponse;
+      } catch {
+        errorBody = undefined;
+      }
+    }
+
+    throw new PasswordlessStartError(errorBody?.error_description || failureMessage, errorBody);
+  }
+}

--- a/packages/auth0-auth-js/src/passwordless/passwordless-client.ts
+++ b/packages/auth0-auth-js/src/passwordless/passwordless-client.ts
@@ -85,7 +85,7 @@ export class PasswordlessClient {
     if (!isE164PhoneNumber(options.phoneNumber)) {
       throw new PasswordlessStartError('Phone number must be in E.164 format (e.g. +14155550100).');
     }
-    await this.#start(transformSendSmsRequest(options), 'Failed to send passwordless SMS');
+    await this.#start(transformSendSmsRequest(options), 'Failed to send passwordless SMS', options.language);
   }
 
   /**

--- a/packages/auth0-auth-js/src/passwordless/types.ts
+++ b/packages/auth0-auth-js/src/passwordless/types.ts
@@ -66,6 +66,11 @@ export interface SendEmailCodeOptions {
    * code is a compile-time error rather than a silently-ignored field.
    */
   authParams?: never;
+  /**
+   * Optional BCP-47 language tag (e.g. `fr-CA`) sent as the `x-request-language`
+   * HTTP header to localize the email template. Not part of the request body.
+   */
+  language?: string;
 }
 
 /**
@@ -89,6 +94,11 @@ export interface SendEmailLinkOptions {
    * node-auth0 and the shipped nextjs-auth0 behavior.
    */
   authParams?: Record<string, unknown>;
+  /**
+   * Optional BCP-47 language tag (e.g. `fr-CA`) sent as the `x-request-language`
+   * HTTP header to localize the email template. Not part of the request body.
+   */
+  language?: string;
 }
 
 /**

--- a/packages/auth0-auth-js/src/passwordless/types.ts
+++ b/packages/auth0-auth-js/src/passwordless/types.ts
@@ -1,0 +1,105 @@
+/**
+ * Constructor options for the {@link PasswordlessClient} sub-client.
+ *
+ * Superset of the MFA sub-client options: `/passwordless/start` requires client
+ * authentication on the request body (FR-1c), so the client-auth fields are
+ * bundled here. Mirrors the auth method resolution used by `AuthClient`.
+ */
+export interface PasswordlessClientOptions {
+  /**
+   * The Auth0 domain, e.g. `tenant.auth0.com`.
+   */
+  domain: string;
+  /**
+   * The Auth0 client ID.
+   */
+  clientId: string;
+  /**
+   * Optional custom fetch implementation (typically telemetry-wrapped by AuthClient).
+   */
+  customFetch?: typeof fetch;
+  /**
+   * Client secret, for `client_secret_post` body authentication.
+   */
+  clientSecret?: string;
+  /**
+   * Private key (PEM string or `CryptoKey`) for `private_key_jwt` (`client_assertion`).
+   */
+  clientAssertionSigningKey?: CryptoKey | string;
+  /**
+   * JWT signing algorithm for `client_assertion`. Defaults to `RS256`.
+   */
+  clientAssertionSigningAlg?: string;
+  /**
+   * When using mTLS, no body-level client authentication is added (the certificate
+   * is supplied by the custom fetch implementation).
+   */
+  useMtls?: boolean;
+}
+
+/**
+ * Options for sending a passwordless email.
+ *
+ * Discriminated union on `send`:
+ * - omit `send` (or pass `send: 'code'`) to send a one-time code (OTP) — the default.
+ * - pass `send: 'link'` to send a magic link; `authParams` carries the OAuth params
+ *   (`redirect_uri`, `response_type`, `scope`, `state`) used when the link is followed.
+ */
+export type SendEmailOptions = SendEmailCodeOptions | SendEmailLinkOptions;
+
+/**
+ * Options for sending a one-time code (OTP) by email. This is the default `send` mode.
+ */
+export interface SendEmailCodeOptions {
+  /**
+   * The destination email address.
+   */
+  email: string;
+  /**
+   * Send a one-time code. Optional; this is the default when `send` is omitted.
+   * To send a magic link instead, use {@link SendEmailLinkOptions} (`send: 'link'`).
+   */
+  send?: 'code';
+  /**
+   * Not applicable in code mode. `authParams` is only honored for magic links
+   * ({@link SendEmailLinkOptions}); declared here as `never` so passing it with a
+   * code is a compile-time error rather than a silently-ignored field.
+   */
+  authParams?: never;
+}
+
+/**
+ * Options for sending a magic link by email.
+ */
+export interface SendEmailLinkOptions {
+  /**
+   * The destination email address.
+   */
+  email: string;
+  /**
+   * Send a magic link. Required literal to select link mode.
+   */
+  send: 'link';
+  /**
+   * OAuth authorization parameters forwarded verbatim to the authorize step that
+   * the magic link triggers, e.g. `{ redirect_uri, response_type, scope, state }`.
+   *
+   * The caller owns `state` (per OQ-7). These are sent under the `authParams` key
+   * in camelCase on the wire (the sole field that bypasses snake_case) to match
+   * node-auth0 and the shipped nextjs-auth0 behavior.
+   */
+  authParams?: Record<string, unknown>;
+}
+
+/**
+ * Options for sending a passwordless SMS (one-time code only; no magic link for SMS).
+ */
+export interface SendSmsOptions {
+  /**
+   * The destination phone number in E.164 format, e.g. `+14155550100`.
+   */
+  phoneNumber: string;
+  // NOTE: no `deliveryMethod` — that belongs to the `/otp/challenge` DB-connection
+  // endpoint (SDKREQ-315), not classic `/passwordless/start`. node-auth0 sends
+  // `phone_number` + `connection` only.
+}

--- a/packages/auth0-auth-js/src/passwordless/types.ts
+++ b/packages/auth0-auth-js/src/passwordless/types.ts
@@ -109,6 +109,11 @@ export interface SendSmsOptions {
    * The destination phone number in E.164 format, e.g. `+14155550100`.
    */
   phoneNumber: string;
+  /**
+   * Optional BCP-47 language tag (e.g. `fr-CA`) sent as the `x-request-language`
+   * HTTP header to localize the SMS template. Not part of the request body.
+   */
+  language?: string;
   // NOTE: no `deliveryMethod` — that belongs to the `/otp/challenge` DB-connection
   // endpoint (SDKREQ-315), not classic `/passwordless/start`. node-auth0 sends
   // `phone_number` + `connection` only.

--- a/packages/auth0-auth-js/src/passwordless/utils.ts
+++ b/packages/auth0-auth-js/src/passwordless/utils.ts
@@ -1,5 +1,4 @@
 import { SignJWT, importPKCS8 } from 'jose';
-import { randomUUID } from 'node:crypto';
 import { MissingClientAuthError } from '../errors.js';
 import type { PasswordlessClientOptions, SendEmailOptions, SendSmsOptions } from './types.js';
 
@@ -59,7 +58,7 @@ export async function buildClientAuthBody(
       .setIssuer(clientId)
       .setSubject(clientId)
       .setAudience(`https://${domain}/`)
-      .setJti(randomUUID())
+      .setJti(crypto.randomUUID())
       .setIssuedAt()
       .setExpirationTime(`${CLIENT_ASSERTION_EXPIRY_SECONDS}s`)
       .sign(privateKey);

--- a/packages/auth0-auth-js/src/passwordless/utils.ts
+++ b/packages/auth0-auth-js/src/passwordless/utils.ts
@@ -1,0 +1,110 @@
+import { SignJWT, importPKCS8 } from 'jose';
+import { randomUUID } from 'node:crypto';
+import { MissingClientAuthError } from '../errors.js';
+import type { PasswordlessClientOptions, SendEmailOptions, SendSmsOptions } from './types.js';
+
+const DEFAULT_CLIENT_ASSERTION_ALG = 'RS256';
+const CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
+const CLIENT_ASSERTION_EXPIRY_SECONDS = 120;
+
+/**
+ * Subset of {@link PasswordlessClientOptions} carrying the client-authentication fields.
+ * @internal
+ */
+export type ClientAuthOptions = Pick<
+  PasswordlessClientOptions,
+  'clientSecret' | 'clientAssertionSigningKey' | 'clientAssertionSigningAlg' | 'useMtls'
+>;
+
+/**
+ * Validates a phone number against a loose E.164 check (`+` followed by 1–15 digits).
+ *
+ * Auth0 performs full validation server-side; this is an early-fail guard only.
+ * @internal
+ */
+export function isE164PhoneNumber(phoneNumber: string): boolean {
+  return /^\+[1-9]\d{1,14}$/.test(phoneNumber);
+}
+
+/**
+ * Builds the client-authentication fields injected into the `/passwordless/start`
+ * request body, matching node-auth0's `addClientAuthentication` (FR-1c).
+ *
+ * Resolution order: mTLS (no body auth) → `private_key_jwt` → `client_secret_post`.
+ *
+ * @throws {MissingClientAuthError} When no client authentication method is configured.
+ * @internal
+ */
+export async function buildClientAuthBody(
+  options: ClientAuthOptions,
+  clientId: string,
+  domain: string
+): Promise<Record<string, string>> {
+  // mTLS: certificate is supplied by the custom fetch; no body-level auth.
+  if (options.useMtls) {
+    return {};
+  }
+
+  if (options.clientAssertionSigningKey) {
+    const alg = options.clientAssertionSigningAlg ?? DEFAULT_CLIENT_ASSERTION_ALG;
+    const privateKey =
+      options.clientAssertionSigningKey instanceof CryptoKey
+        ? options.clientAssertionSigningKey
+        : await importPKCS8(options.clientAssertionSigningKey as string, alg);
+
+    // Claims mirror node-auth0 client-authentication: iss/sub = clientId,
+    // aud = `https://{domain}/` (trailing slash), short-lived, unique jti.
+    const clientAssertion = await new SignJWT({})
+      .setProtectedHeader({ alg })
+      .setIssuer(clientId)
+      .setSubject(clientId)
+      .setAudience(`https://${domain}/`)
+      .setJti(randomUUID())
+      .setIssuedAt()
+      .setExpirationTime(`${CLIENT_ASSERTION_EXPIRY_SECONDS}s`)
+      .sign(privateKey);
+
+    return {
+      client_assertion: clientAssertion,
+      client_assertion_type: CLIENT_ASSERTION_TYPE,
+    };
+  }
+
+  if (options.clientSecret) {
+    return { client_secret: options.clientSecret };
+  }
+
+  throw new MissingClientAuthError();
+}
+
+/**
+ * Transforms the public `sendEmail` options (camelCase) to the `/passwordless/start`
+ * wire body. `authParams` is forwarded verbatim under its camelCase key (the sole
+ * field that bypasses snake_case) to match node-auth0 / nextjs-auth0.
+ * @internal
+ */
+export function transformSendEmailRequest(options: SendEmailOptions): Record<string, unknown> {
+  const send = options.send ?? 'code';
+  const wire: Record<string, unknown> = {
+    email: options.email,
+    connection: 'email',
+    send,
+  };
+
+  if (send === 'link' && options.authParams) {
+    wire.authParams = options.authParams;
+  }
+
+  return wire;
+}
+
+/**
+ * Transforms the public `sendSms` options to the `/passwordless/start` wire body.
+ * @internal
+ */
+export function transformSendSmsRequest(options: SendSmsOptions): Record<string, unknown> {
+  return {
+    phone_number: options.phoneNumber,
+    connection: 'sms',
+  };
+}

--- a/packages/auth0-auth-js/src/types.ts
+++ b/packages/auth0-auth-js/src/types.ts
@@ -259,11 +259,78 @@ export interface TokenByPasswordOptions {
   auth0ForwardedFor?: string;
 }
 
+/**
+ * Options for exchanging a passwordless email OTP code for a token.
+ */
+export interface TokenByPasswordlessEmailOptions {
+  /**
+   * The email address the one-time code was sent to.
+   */
+  email: string;
+  /**
+   * The one-time code received by email.
+   */
+  code: string;
+  /**
+   * The audience for which the token should be requested.
+   */
+  audience?: string;
+  /**
+   * The scope for which the token should be requested.
+   *
+   * Optional and never injected at this layer: include `openid` to receive an id_token,
+   * and `offline_access` to receive a refresh_token. (The server-js session layer
+   * always ensures `openid` via its own login methods.)
+   */
+  scope?: string;
+}
+
+/**
+ * Options for exchanging a passwordless SMS OTP code for a token.
+ */
+export interface TokenByPasswordlessSmsOptions {
+  /**
+   * The phone number (E.164 format, e.g. `+14155550100`) the one-time code was sent to.
+   */
+  phoneNumber: string;
+  /**
+   * The one-time code received by SMS.
+   */
+  code: string;
+  /**
+   * The audience for which the token should be requested.
+   */
+  audience?: string;
+  /**
+   * The scope for which the token should be requested.
+   *
+   * Optional and never injected at this layer: include `openid` to receive an id_token,
+   * and `offline_access` to receive a refresh_token. (The server-js session layer
+   * always ensures `openid` via its own login methods.)
+   */
+  scope?: string;
+}
+
 export interface TokenByCodeOptions {
   /**
    * The code verifier that is used for the authorization request.
    */
   codeVerifier: string;
+}
+
+/**
+ * Options for exchanging a magic-link authorization code for tokens, without PKCE.
+ *
+ * Used by {@link AuthClient#getTokenByMagicLinkCode}: magic links carry no `code_verifier`,
+ * so anti-forgery is enforced via `state` binding instead of PKCE.
+ */
+export interface TokenByMagicLinkCodeOptions {
+  /**
+   * The expected `state` value, originally generated and persisted by the SDK when the
+   * magic link was sent. It is validated against the `state` returned on the callback URL
+   * to bind the callback to the start request. When omitted, no state check is performed.
+   */
+  expectedState?: string;
 }
 
 /**


### PR DESCRIPTION
Adds passwordless authentication primitives to `@auth0/auth0-auth-js`: OTP code/link sending plus token grants for OTP and magic-link.
Magic-link uses a no-PKCE authorization-code exchange with `state` binding for anti-forgery.
Foundation layer consumed by the `auth0-server-js` session methods (stacked PR #198).

## Changes
- Passwordless sub-client: `sendEmail` / `sendSms` on `authClient.passwordless`, with a discriminated `send: 'code' | 'link'` union
- OTP token grants: `getTokenByPasswordlessEmail` / `getTokenByPasswordlessSms` (`grant_type=passwordless/otp`)
- Magic-link token grant: `getTokenByMagicLinkCode` — omits `pkceCodeVerifier` (openid-client `oauth.nopkce`), validates `expectedState`
- i18n: optional `language` on `sendEmail` / `sendSms`, forwarded as the `x-request-language` HTTP header (not a body field), matching node-auth0 / nextjs-auth0
- Errors: new `MfaRequiredError` (carries `mfaToken`); `PasswordlessStartError` / `PasswordlessVerifyError` (prototype chain restored for ES5 `instanceof`)
- Shared `isE164PhoneNumber`, `authParams` forwarded camelCase verbatim on the wire

## Testing
- Unit (vitest + MSW): incl. magic-link no-PKCE + state-mismatch, `x-request-language` header (email + SMS), `getTokenByCode` PKCE regression
- `npm test` auth-js: 273 pass, 0 broken
- `npm run build` PASS (incl. DTS); `npm run lint` 0 violations
- Magic-link + email OTP verified live against a real tenant

## Usage
```ts
// Send a one-time code
await authClient.passwordless.sendEmail({ email, send: 'code' });
const tokens = await authClient.getTokenByPasswordlessEmail({ email, code });

// Magic link: send 'link', then exchange the callback code (no PKCE)
await authClient.passwordless.sendEmail({ email, send: 'link', authParams: { redirect_uri, response_type: 'code', state } });
const tokens = await authClient.getTokenByMagicLinkCode(callbackUrl, { expectedState });
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added passwordless authentication for email and SMS OTP flows, including a dedicated passwordless client for initiating requests
  * Added token exchange helpers for passwordless email/SMS (with optional audience/scope forwarding)
  * Added MFA-required handling with narrowed error access to MFA continuation tokens
* **Bug Fixes**
  * Updated magic-link token exchange to run without PKCE while still validating expected state when provided
  * Added fast validation for E.164-formatted SMS phone numbers
* **Documentation**
  * Added a guide for using passwordless authentication end-to-end
* **Tests**
  * Added passwordless coverage for request construction, token exchange behavior, and error mapping
<!-- end of auto-generated comment: release notes by coderabbit.ai -->