### PR TITLE
feat(auth0-server-js): add passwordless authentication

### DIFF
--- a/packages/auth0-server-js/EXAMPLES.md
+++ b/packages/auth0-server-js/EXAMPLES.md
@@ -35,6 +35,7 @@
   - [Retrieving `appState`](#retrieving-appstate-1)
   - [Passing `StoreOptions`](#passing-storeoptions-3)
 - [Login using Client-Initiated Backchannel Authentication](#login-using-client-initiated-backchannel-authentication)
+- [Passwordless Authentication](#passwordless-authentication)
   - [Using Rich Authorization Requests](#using-rich-authorization-requests)
   - [Passing `StoreOptions`](#passing-storeoptions-4)
 - [Login and Signup using Passkeys](#login-and-signup-using-passkeys)
@@ -1094,6 +1095,104 @@ const tokenResponse = await serverClient.customTokenExchange({ subjectToken, sub
 ```
 
 Read more above in [Configuring the Store](#configuring-the-store)
+
+## Passwordless Authentication
+
+The server client exposes passwordless as session-aware wrappers around the Authentication API. Start methods are stateless passthroughs; login methods exchange the one-time code and persist the resulting session to the configured state store (no redirect, no PKCE).
+
+> [!IMPORTANT]
+> Your Auth0 application must have the **Passwordless OTP** grant enabled, with the Email and/or SMS connection configured. See the [Auth0 Passwordless documentation](https://auth0.com/docs/authenticate/passwordless).
+
+### Starting a Passwordless Login
+
+```ts
+// Email — one-time code (default)
+await serverClient.startPasswordlessEmail({ email: 'user@example.com', send: 'code' });
+
+// Email — magic link
+await serverClient.startPasswordlessEmail({
+  email: 'user@example.com',
+  send: 'link',
+  authParams: { redirect_uri: 'https://my-app.example.com/callback', scope: 'openid profile' },
+});
+
+// SMS — one-time code (E.164 phone)
+await serverClient.startPasswordlessSms({ phoneNumber: '+14155550100' });
+```
+
+### Completing a Passwordless Login
+
+`loginWithPasswordlessEmail` / `loginWithPasswordlessSms` exchange the code and establish a session. The `openid` scope is always ensured by the server layer.
+
+```ts
+await serverClient.loginWithPasswordlessEmail({
+  email: 'user@example.com',
+  code: '123456',
+  authorizationParams: { scope: 'openid profile' },
+});
+
+// The user is now logged in; getUser() / getAccessToken() work as usual.
+const accessToken = await serverClient.getAccessToken();
+```
+
+```ts
+await serverClient.loginWithPasswordlessSms({
+  phoneNumber: '+14155550100',
+  code: '123456',
+});
+```
+
+A `PasswordlessVerifyError` is thrown for an invalid/expired/rate-limited code; an `MfaRequiredError` is thrown (and propagated unchanged) when the connection requires MFA. Both are exported from `@auth0/auth0-auth-js`.
+
+> [!IMPORTANT]
+> If your deployment performs concurrent logins for the same session identifier, use a state store with atomic (compare-and-set) writes to avoid last-write-wins races.
+
+### Completing a Magic-Link Login
+
+A magic link is an authorization-code flow whose first leg is delivered by email instead of a browser redirect. Use `startPasswordlessMagicLink` to send the link and `completePasswordlessMagicLink` on the callback route. The SDK generates and persists an anti-forgery `state`, validates it on return, exchanges the code **without PKCE**, and writes the session. The interactive login path (`completeInteractiveLogin`) is not used.
+
+```ts
+// 1. Send the link. The SDK owns `state`; `client_id`, `response_type`, and `state` cannot be overridden.
+await serverClient.startPasswordlessMagicLink(
+  {
+    email: 'user@example.com',
+    redirectUri: 'https://app.example.com/auth/callback',
+    scope: 'openid profile',
+  },
+  storeOptions
+);
+
+// 2. On GET /auth/callback?code=...&state=..., complete the login.
+const result = await serverClient.completePasswordlessMagicLink(
+  new URL(req.url, 'https://app.example.com'),
+  storeOptions
+);
+
+// The user is now logged in; getUser() / getAccessToken() work as usual.
+```
+
+`completePasswordlessMagicLink` throws `MissingTransactionError` when no start transaction is found, and `PasswordlessVerifyError` when the returned `state` is missing or does not match the persisted `state`.
+
+> [!IMPORTANT]
+> Server-side completion requires the tenant setting `allow_magiclink_verify_without_session: true`. Without it, the click fails with "The link must be opened on the same device and browser." The callback URL passed as `redirectUri` must be registered on the application.
+>
+> This setting is nested under `universal_login.passwordless` (NOT a top-level `flags` entry; sending it under `flags` returns `400 Additional properties not allowed`):
+>
+> ```bash
+> auth0 api patch tenants/settings \
+>   --data '{"universal_login":{"passwordless":{"allow_magiclink_verify_without_session":true}}}'
+> ```
+
+### Passing `StoreOptions`
+
+Like other methods, all passwordless methods accept a second argument forwarded to the configured stores (and to the domain resolver in [Resolver Mode](#resolver-mode)):
+
+```ts
+const storeOptions = {
+  /* ... */
+};
+await serverClient.loginWithPasswordlessEmail({ email: 'user@example.com', code: '123456' }, storeOptions);
+```
 
 ## Retrieving the logged-in User
 

--- a/packages/auth0-server-js/EXAMPLES.md
+++ b/packages/auth0-server-js/EXAMPLES.md
@@ -1098,7 +1098,7 @@ Read more above in [Configuring the Store](#configuring-the-store)
 
 ## Passwordless Authentication
 
-The server client exposes passwordless as session-aware wrappers around the Authentication API. Start methods are stateless passthroughs; login methods exchange the one-time code and persist the resulting session to the configured state store (no redirect, no PKCE).
+The server client exposes passwordless as session-aware methods around the Authentication API. The surface mirrors `@auth0/nextjs-auth0` (`passwordless.start()` / `passwordless.verify()`): `startPasswordless` sends the code or link; `completePasswordless` exchanges the one-time code and persists the resulting session to the configured state store (no redirect, no PKCE). Both methods are discriminated on `connection` (`'email' | 'sms'`).
 
 > [!IMPORTANT]
 > Your Auth0 application must have the **Passwordless OTP** grant enabled, with the Email and/or SMS connection configured. See the [Auth0 Passwordless documentation](https://auth0.com/docs/authenticate/passwordless).
@@ -1107,27 +1107,32 @@ The server client exposes passwordless as session-aware wrappers around the Auth
 
 ```ts
 // Email — one-time code (default)
-await serverClient.startPasswordlessEmail({ email: 'user@example.com', send: 'code' });
+await serverClient.startPasswordless({ connection: 'email', email: 'user@example.com', send: 'code' });
 
-// Email — magic link
-await serverClient.startPasswordlessEmail({
+// Email — magic link (see "Completing a Magic-Link Login" below)
+await serverClient.startPasswordless({
+  connection: 'email',
   email: 'user@example.com',
   send: 'link',
-  authParams: { redirect_uri: 'https://my-app.example.com/callback', scope: 'openid profile' },
+  redirectUri: 'https://my-app.example.com/auth/callback',
+  scope: 'openid profile',
 });
 
 // SMS — one-time code (E.164 phone)
-await serverClient.startPasswordlessSms({ phoneNumber: '+14155550100' });
+await serverClient.startPasswordless({ connection: 'sms', phoneNumber: '+14155550100' });
 ```
+
+An optional `language` (BCP-47 tag, e.g. `'fr-CA'`) is forwarded as the `x-request-language` header to localize the email/SMS template.
 
 ### Completing a Passwordless Login
 
-`loginWithPasswordlessEmail` / `loginWithPasswordlessSms` exchange the code and establish a session. The `openid` scope is always ensured by the server layer.
+`completePasswordless` exchanges the `verificationCode` and establishes a session. The `openid` scope is always ensured by the server layer.
 
 ```ts
-await serverClient.loginWithPasswordlessEmail({
+await serverClient.completePasswordless({
+  connection: 'email',
   email: 'user@example.com',
-  code: '123456',
+  verificationCode: '123456',
   authorizationParams: { scope: 'openid profile' },
 });
 
@@ -1136,9 +1141,10 @@ const accessToken = await serverClient.getAccessToken();
 ```
 
 ```ts
-await serverClient.loginWithPasswordlessSms({
+await serverClient.completePasswordless({
+  connection: 'sms',
   phoneNumber: '+14155550100',
-  code: '123456',
+  verificationCode: '123456',
 });
 ```
 
@@ -1149,12 +1155,14 @@ A `PasswordlessVerifyError` is thrown for an invalid/expired/rate-limited code; 
 
 ### Completing a Magic-Link Login
 
-A magic link is an authorization-code flow whose first leg is delivered by email instead of a browser redirect. Use `startPasswordlessMagicLink` to send the link and `completePasswordlessMagicLink` on the callback route. The SDK generates and persists an anti-forgery `state`, validates it on return, exchanges the code **without PKCE**, and writes the session. The interactive login path (`completeInteractiveLogin`) is not used.
+A magic link is an authorization-code flow whose first leg is delivered by email instead of a browser redirect. Send the link with `startPasswordless({ connection: 'email', send: 'link', redirectUri })`, then call `completePasswordlessMagicLink` on the callback route. The SDK generates and persists an anti-forgery `state`, validates it on return, exchanges the code **without PKCE**, and writes the session. The interactive login path (`completeInteractiveLogin`) is not used.
 
 ```ts
 // 1. Send the link. The SDK owns `state`; `client_id`, `response_type`, and `state` cannot be overridden.
-await serverClient.startPasswordlessMagicLink(
+await serverClient.startPasswordless(
   {
+    connection: 'email',
+    send: 'link',
     email: 'user@example.com',
     redirectUri: 'https://app.example.com/auth/callback',
     scope: 'openid profile',
@@ -1191,7 +1199,10 @@ Like other methods, all passwordless methods accept a second argument forwarded 
 const storeOptions = {
   /* ... */
 };
-await serverClient.loginWithPasswordlessEmail({ email: 'user@example.com', code: '123456' }, storeOptions);
+await serverClient.completePasswordless(
+  { connection: 'email', email: 'user@example.com', verificationCode: '123456' },
+  storeOptions
+);
 ```
 
 ## Retrieving the logged-in User

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -5015,37 +5015,38 @@ describe('passwordless (session layer)', () => {
     startCount = 0;
   });
 
-  test('FT-1: startPasswordlessEmail delegates to token layer (stateless)', async () => {
+  test('FT-1: startPasswordless email delegates to token layer (stateless)', async () => {
     captureStart();
-    await newServerClient().startPasswordlessEmail({ email: 'user@example.com', send: 'code' });
+    await newServerClient().startPasswordless({ connection: 'email', email: 'user@example.com', send: 'code' });
 
     expect(startCount).toBe(1);
     expect(lastStartBody).toMatchObject({ email: 'user@example.com', send: 'code', connection: 'email' });
   });
 
-  test('FT-2: startPasswordlessEmail defaults to code when send omitted', async () => {
+  test('FT-2: startPasswordless email defaults to code when send omitted', async () => {
     captureStart();
-    await newServerClient().startPasswordlessEmail({ email: 'user@example.com' });
+    await newServerClient().startPasswordless({ connection: 'email', email: 'user@example.com' });
 
     expect(lastStartBody).toMatchObject({ email: 'user@example.com', send: 'code', connection: 'email' });
     expect(lastStartBody!).not.toHaveProperty('authParams');
   });
 
-  test('FT-3: startPasswordlessSms delegates; no delivery_method', async () => {
+  test('FT-3: startPasswordless sms delegates; no delivery_method', async () => {
     captureStart();
-    await newServerClient().startPasswordlessSms({ phoneNumber: '+14155550100' });
+    await newServerClient().startPasswordless({ connection: 'sms', phoneNumber: '+14155550100' });
 
     expect(lastStartBody).toMatchObject({ phone_number: '+14155550100', connection: 'sms' });
     expect(lastStartBody!).not.toHaveProperty('delivery_method');
   });
 
-  test('FT-4: loginWithPasswordlessEmail exchanges OTP and persists session', async () => {
+  test('FT-4: completePasswordless email exchanges OTP and persists session', async () => {
     captureOtp();
     const serverClient = newServerClient();
 
-    await serverClient.loginWithPasswordlessEmail({
+    await serverClient.completePasswordless({
+      connection: 'email',
       email: 'user@example.com',
-      code: '123456',
+      verificationCode: '123456',
       authorizationParams: { scope: 'openid profile' },
     });
 
@@ -5061,7 +5062,7 @@ describe('passwordless (session layer)', () => {
     captureOtp();
     const serverClient = newServerClient();
 
-    await serverClient.loginWithPasswordlessEmail({ email: 'user@example.com', code: '123456' });
+    await serverClient.completePasswordless({ connection: 'email', email: 'user@example.com', verificationCode: '123456' });
 
     expect(await serverClient.getUser()).toBeDefined();
     expect((await serverClient.getAccessToken()).accessToken).toBe(accessToken);
@@ -5069,9 +5070,10 @@ describe('passwordless (session layer)', () => {
 
   test('FT-6: ensureOpenId injects openid when caller scope omits it', async () => {
     captureOtp();
-    await newServerClient().loginWithPasswordlessEmail({
+    await newServerClient().completePasswordless({
+      connection: 'email',
       email: 'user@example.com',
-      code: '123456',
+      verificationCode: '123456',
       authorizationParams: { scope: 'profile email' },
     });
 
@@ -5088,7 +5090,7 @@ describe('passwordless (session layer)', () => {
     );
 
     const error = await newServerClient()
-      .loginWithPasswordlessEmail({ email: 'user@example.com', code: '123456' })
+      .completePasswordless({ connection: 'email', email: 'user@example.com', verificationCode: '123456' })
       .catch((e) => e);
 
     expect(error).toBeInstanceOf(Auth0AuthJs.PasswordlessVerifyError);
@@ -5104,19 +5106,37 @@ describe('passwordless (session layer)', () => {
     );
 
     await expect(
-      newServerClient().loginWithPasswordlessEmail({ email: 'user@example.com', code: 'wrong' })
+      newServerClient().completePasswordless({ connection: 'email', email: 'user@example.com', verificationCode: 'wrong' })
     ).rejects.toBeInstanceOf(Auth0AuthJs.PasswordlessVerifyError);
   });
 
-  test('FT-9: loginWithPasswordlessSms exchanges + persists (realm=sms)', async () => {
+  test('FT-9: completePasswordless sms exchanges + persists (realm=sms)', async () => {
     captureOtp();
     const serverClient = newServerClient();
 
-    await serverClient.loginWithPasswordlessSms({ phoneNumber: '+14155550100', code: '123456' });
+    await serverClient.completePasswordless({ connection: 'sms', phoneNumber: '+14155550100', verificationCode: '123456' });
 
     expect(lastOtpForm!.get('realm')).toBe('sms');
     expect(lastOtpForm!.get('username')).toBe('+14155550100');
     expect((await serverClient.getAccessToken()).accessToken).toBe(accessToken);
+  });
+
+  test('FT-9b: startPasswordless forwards language as x-request-language header (email + sms)', async () => {
+    let lastLang: string | null = null;
+    server.use(
+      http.post(startUrl, async ({ request }) => {
+        startCount += 1;
+        lastLang = request.headers.get('x-request-language');
+        lastStartBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({}, { status: 200 });
+      })
+    );
+
+    await newServerClient().startPasswordless({ connection: 'email', email: 'user@example.com', language: 'fr-CA' });
+    expect(lastLang).toBe('fr-CA');
+
+    await newServerClient().startPasswordless({ connection: 'sms', phoneNumber: '+14155550100', language: 'pt-BR' });
+    expect(lastLang).toBe('pt-BR');
   });
 
   test('FT-10: resolver mode routes to resolved domain for start + login', async () => {
@@ -5125,8 +5145,11 @@ describe('passwordless (session layer)', () => {
     const domainResolver = vi.fn().mockResolvedValue(domain);
     const serverClient = newServerClient({ domain: domainResolver });
 
-    await serverClient.startPasswordlessEmail({ email: 'user@example.com' }, { ctx: 1 } as never);
-    await serverClient.loginWithPasswordlessEmail({ email: 'user@example.com', code: '123456' }, { ctx: 1 } as never);
+    await serverClient.startPasswordless({ connection: 'email', email: 'user@example.com' }, { ctx: 1 } as never);
+    await serverClient.completePasswordless(
+      { connection: 'email', email: 'user@example.com', verificationCode: '123456' },
+      { ctx: 1 } as never
+    );
 
     expect(domainResolver).toHaveBeenCalled();
     expect(startCount).toBe(1);
@@ -5138,7 +5161,10 @@ describe('passwordless (session layer)', () => {
     const serverClient = newServerClient({ domain: domainResolver });
 
     await expect(
-      serverClient.loginWithPasswordlessEmail({ email: 'user@example.com', code: '123456' }, { ctx: 1 } as never)
+      serverClient.completePasswordless(
+        { connection: 'email', email: 'user@example.com', verificationCode: '123456' },
+        { ctx: 1 } as never
+      )
     ).rejects.toThrow('resolver boom');
   });
 
@@ -5169,12 +5195,14 @@ describe('passwordless (session layer)', () => {
     return { transactionStore, stateStore };
   };
 
-  test('FT-11: startPasswordlessMagicLink sends link + persists state, no codeVerifier', async () => {
+  test('FT-11: startPasswordless link sends link + persists state, no codeVerifier', async () => {
     captureStart();
     const { transactionStore, stateStore } = mockStores();
     const serverClient = newServerClient({ transactionStore, stateStore });
 
-    await serverClient.startPasswordlessMagicLink({
+    await serverClient.startPasswordless({
+      connection: 'email',
+      send: 'link',
       email: 'user@example.com',
       redirectUri: 'https://app.example.com/auth/callback',
       scope: 'profile',
@@ -5269,15 +5297,20 @@ describe('passwordless (session layer)', () => {
     expect(transactionStore.delete).not.toHaveBeenCalled();
   });
 
-  test('FT-15c: startPasswordlessMagicLink throws PasswordlessStartError on empty redirectUri', async () => {
+  test('FT-15c: startPasswordless link throws PasswordlessStartError on empty redirectUri', async () => {
     captureStart();
     await expect(
-      newServerClient().startPasswordlessMagicLink({ email: 'user@example.com', redirectUri: '' })
+      newServerClient().startPasswordless({
+        connection: 'email',
+        send: 'link',
+        email: 'user@example.com',
+        redirectUri: '',
+      })
     ).rejects.toBeInstanceOf(Auth0AuthJs.PasswordlessStartError);
     expect(startCount).toBe(0);
   });
 
-  test('FT-16: magic-link methods resolve domain in resolver mode', async () => {
+  test('FT-16: magic-link flows resolve domain in resolver mode', async () => {
     captureStart();
     captureCodeGrant();
     const domainResolver = vi.fn().mockResolvedValue(domain);
@@ -5285,8 +5318,8 @@ describe('passwordless (session layer)', () => {
     transactionStore.get.mockResolvedValue({ state: 's1', domain });
     const serverClient = newServerClient({ domain: domainResolver, transactionStore, stateStore });
 
-    await serverClient.startPasswordlessMagicLink(
-      { email: 'user@example.com', redirectUri: 'https://app/cb' },
+    await serverClient.startPasswordless(
+      { connection: 'email', send: 'link', email: 'user@example.com', redirectUri: 'https://app/cb' },
       { ctx: 1 } as never
     );
     await serverClient.completePasswordlessMagicLink(new URL(`https://${domain}/cb?code=123&state=s1`), {
@@ -5296,12 +5329,14 @@ describe('passwordless (session layer)', () => {
     expect(domainResolver).toHaveBeenCalled();
   });
 
-  test('FT-17: startPasswordlessMagicLink ensures openid even when scope omits it', async () => {
+  test('FT-17: startPasswordless link ensures openid even when scope omits it', async () => {
     captureStart();
     const { transactionStore, stateStore } = mockStores();
     const serverClient = newServerClient({ transactionStore, stateStore });
 
-    await serverClient.startPasswordlessMagicLink({
+    await serverClient.startPasswordless({
+      connection: 'email',
+      send: 'link',
       email: 'user@example.com',
       redirectUri: 'https://app/cb',
       scope: 'profile email',

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -5023,17 +5023,12 @@ describe('passwordless (session layer)', () => {
     expect(lastStartBody).toMatchObject({ email: 'user@example.com', send: 'code', connection: 'email' });
   });
 
-  test('FT-2: startPasswordlessEmail forwards link options incl authParams (camelCase)', async () => {
+  test('FT-2: startPasswordlessEmail defaults to code when send omitted', async () => {
     captureStart();
-    await newServerClient().startPasswordlessEmail({
-      email: 'user@example.com',
-      send: 'link',
-      authParams: { redirect_uri: 'https://app/cb', scope: 'openid' },
-    });
+    await newServerClient().startPasswordlessEmail({ email: 'user@example.com' });
 
-    expect(lastStartBody!.send).toBe('link');
-    expect(lastStartBody!.authParams).toMatchObject({ redirect_uri: 'https://app/cb' });
-    expect(lastStartBody!).not.toHaveProperty('auth_params');
+    expect(lastStartBody).toMatchObject({ email: 'user@example.com', send: 'code', connection: 'email' });
+    expect(lastStartBody!).not.toHaveProperty('authParams');
   });
 
   test('FT-3: startPasswordlessSms delegates; no delivery_method', async () => {
@@ -5252,6 +5247,34 @@ describe('passwordless (session layer)', () => {
     await expect(
       serverClient.completePasswordlessMagicLink(new URL(`https://${domain}/cb?code=123`))
     ).rejects.toBeInstanceOf(Auth0AuthJs.PasswordlessVerifyError);
+  });
+
+  test('FT-15b: non-string state in transaction throws PasswordlessVerifyError, no exchange', async () => {
+    let exchangeCalled = false;
+    server.use(
+      http.post(mockOpenIdConfiguration.token_endpoint, async () => {
+        exchangeCalled = true;
+        return HttpResponse.json({ access_token: accessToken, expires_in: 60, token_type: 'Bearer' });
+      })
+    );
+    const { transactionStore, stateStore } = mockStores();
+    // A custom store could persist a non-string state; the type guard must reject it.
+    transactionStore.get.mockResolvedValue({ state: 12345 as unknown as string, domain });
+    const serverClient = newServerClient({ transactionStore, stateStore });
+
+    await expect(
+      serverClient.completePasswordlessMagicLink(new URL(`https://${domain}/cb?code=123&state=12345`))
+    ).rejects.toBeInstanceOf(Auth0AuthJs.PasswordlessVerifyError);
+    expect(exchangeCalled).toBe(false);
+    expect(transactionStore.delete).not.toHaveBeenCalled();
+  });
+
+  test('FT-15c: startPasswordlessMagicLink throws PasswordlessStartError on empty redirectUri', async () => {
+    captureStart();
+    await expect(
+      newServerClient().startPasswordlessMagicLink({ email: 'user@example.com', redirectUri: '' })
+    ).rejects.toBeInstanceOf(Auth0AuthJs.PasswordlessStartError);
+    expect(startCount).toBe(0);
   });
 
   test('FT-16: magic-link methods resolve domain in resolver mode', async () => {

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -1,6 +1,6 @@
-import { expect, test, afterAll, afterEach, beforeAll, beforeEach, vi } from 'vitest';
+import { expect, test, afterAll, afterEach, beforeAll, beforeEach, vi, describe } from 'vitest';
 import { ServerClient } from './server-client.js';
-import { InvalidConfigurationError, MissingSessionError } from './errors.js';
+import { InvalidConfigurationError, MissingSessionError, MissingTransactionError } from './errors.js';
 import { AuthClient, TokenResponse, isMfaRequiredError } from '@auth0/auth0-auth-js';
 
 import * as Auth0AuthJs from '@auth0/auth0-auth-js';
@@ -4957,4 +4957,349 @@ test('passkeyGetToken - should forward audience and organization to the grant', 
 
   expect(capturedAudience).toBe('https://api.example.com');
   expect(capturedOrganization).toBe('org_123');
+});
+
+describe('passwordless (session layer)', () => {
+  const PASSWORDLESS_GRANT = 'http://auth0.com/oauth/grant-type/passwordless/otp';
+  const startUrl = `https://${domain}/passwordless/start`;
+
+  let lastStartBody: Record<string, unknown> | null;
+  let lastOtpForm: URLSearchParams | null;
+  let startCount: number;
+
+  const newServerClient = (extra?: Record<string, unknown>) =>
+    new ServerClient({
+      domain,
+      clientId: '<client_id>',
+      clientSecret: '<client_secret>',
+      stateStore: new DefaultStateStore({ secret: '<secret>' }),
+      transactionStore: new DefaultTransactionStore({ secret: '<secret>' }),
+      ...extra,
+    });
+
+  // Capture /passwordless/start request bodies.
+  const captureStart = (status = 200) =>
+    server.use(
+      http.post(startUrl, async ({ request }) => {
+        startCount += 1;
+        lastStartBody = (await request.json()) as Record<string, unknown>;
+        return status === 204 ? new HttpResponse(null, { status: 204 }) : HttpResponse.json({}, { status });
+      })
+    );
+
+  // Capture the OTP grant form posted to the token endpoint.
+  const captureOtp = (respond?: (form: URLSearchParams) => Response | Promise<Response>) =>
+    server.use(
+      http.post(mockOpenIdConfiguration.token_endpoint, async ({ request }) => {
+        const form = new URLSearchParams(await request.text());
+        if (form.get('grant_type') === PASSWORDLESS_GRANT) {
+          lastOtpForm = form;
+          if (respond) {
+            return respond(form);
+          }
+          return HttpResponse.json({
+            access_token: accessToken,
+            id_token: await generateToken(domain, 'user_123', '<client_id>'),
+            expires_in: 86400,
+            token_type: 'Bearer',
+            scope: form.get('scope') ?? '<scope>',
+          });
+        }
+        return HttpResponse.json({ access_token: accessToken, expires_in: 60, token_type: 'Bearer' });
+      })
+    );
+
+  beforeEach(() => {
+    lastStartBody = null;
+    lastOtpForm = null;
+    startCount = 0;
+  });
+
+  test('FT-1: startPasswordlessEmail delegates to token layer (stateless)', async () => {
+    captureStart();
+    await newServerClient().startPasswordlessEmail({ email: 'user@example.com', send: 'code' });
+
+    expect(startCount).toBe(1);
+    expect(lastStartBody).toMatchObject({ email: 'user@example.com', send: 'code', connection: 'email' });
+  });
+
+  test('FT-2: startPasswordlessEmail forwards link options incl authParams (camelCase)', async () => {
+    captureStart();
+    await newServerClient().startPasswordlessEmail({
+      email: 'user@example.com',
+      send: 'link',
+      authParams: { redirect_uri: 'https://app/cb', scope: 'openid' },
+    });
+
+    expect(lastStartBody!.send).toBe('link');
+    expect(lastStartBody!.authParams).toMatchObject({ redirect_uri: 'https://app/cb' });
+    expect(lastStartBody!).not.toHaveProperty('auth_params');
+  });
+
+  test('FT-3: startPasswordlessSms delegates; no delivery_method', async () => {
+    captureStart();
+    await newServerClient().startPasswordlessSms({ phoneNumber: '+14155550100' });
+
+    expect(lastStartBody).toMatchObject({ phone_number: '+14155550100', connection: 'sms' });
+    expect(lastStartBody!).not.toHaveProperty('delivery_method');
+  });
+
+  test('FT-4: loginWithPasswordlessEmail exchanges OTP and persists session', async () => {
+    captureOtp();
+    const serverClient = newServerClient();
+
+    await serverClient.loginWithPasswordlessEmail({
+      email: 'user@example.com',
+      code: '123456',
+      authorizationParams: { scope: 'openid profile' },
+    });
+
+    expect(lastOtpForm!.get('grant_type')).toBe(PASSWORDLESS_GRANT);
+    expect(lastOtpForm!.get('username')).toBe('user@example.com');
+    expect(lastOtpForm!.get('otp')).toBe('123456');
+    expect(lastOtpForm!.get('realm')).toBe('email');
+    expect(lastOtpForm!.get('scope')).toContain('openid');
+    expect((await serverClient.getAccessToken()).accessToken).toBe(accessToken);
+  });
+
+  test('FT-5: session retrievable after login', async () => {
+    captureOtp();
+    const serverClient = newServerClient();
+
+    await serverClient.loginWithPasswordlessEmail({ email: 'user@example.com', code: '123456' });
+
+    expect(await serverClient.getUser()).toBeDefined();
+    expect((await serverClient.getAccessToken()).accessToken).toBe(accessToken);
+  });
+
+  test('FT-6: ensureOpenId injects openid when caller scope omits it', async () => {
+    captureOtp();
+    await newServerClient().loginWithPasswordlessEmail({
+      email: 'user@example.com',
+      code: '123456',
+      authorizationParams: { scope: 'profile email' },
+    });
+
+    const scope = lastOtpForm!.get('scope')!;
+    expect(scope.split(' ')).toContain('openid');
+  });
+
+  test('FT-7: mfa_required propagates from token layer, narrowable via isMfaRequiredError', async () => {
+    captureOtp(() =>
+      HttpResponse.json(
+        { error: 'mfa_required', error_description: 'MFA required', mfa_token: 'mt' },
+        { status: 403 }
+      )
+    );
+
+    const error = await newServerClient()
+      .loginWithPasswordlessEmail({ email: 'user@example.com', code: '123456' })
+      .catch((e) => e);
+
+    expect(error).toBeInstanceOf(Auth0AuthJs.PasswordlessVerifyError);
+    expect(Auth0AuthJs.isMfaRequiredError(error)).toBe(true);
+    if (Auth0AuthJs.isMfaRequiredError(error)) {
+      expect(error.cause.mfa_token).toBe('mt');
+    }
+  });
+
+  test('FT-8: PasswordlessVerifyError propagates from token layer', async () => {
+    captureOtp(() =>
+      HttpResponse.json({ error: 'invalid_grant', error_description: 'Invalid code' }, { status: 403 })
+    );
+
+    await expect(
+      newServerClient().loginWithPasswordlessEmail({ email: 'user@example.com', code: 'wrong' })
+    ).rejects.toBeInstanceOf(Auth0AuthJs.PasswordlessVerifyError);
+  });
+
+  test('FT-9: loginWithPasswordlessSms exchanges + persists (realm=sms)', async () => {
+    captureOtp();
+    const serverClient = newServerClient();
+
+    await serverClient.loginWithPasswordlessSms({ phoneNumber: '+14155550100', code: '123456' });
+
+    expect(lastOtpForm!.get('realm')).toBe('sms');
+    expect(lastOtpForm!.get('username')).toBe('+14155550100');
+    expect((await serverClient.getAccessToken()).accessToken).toBe(accessToken);
+  });
+
+  test('FT-10: resolver mode routes to resolved domain for start + login', async () => {
+    captureStart();
+    captureOtp();
+    const domainResolver = vi.fn().mockResolvedValue(domain);
+    const serverClient = newServerClient({ domain: domainResolver });
+
+    await serverClient.startPasswordlessEmail({ email: 'user@example.com' }, { ctx: 1 } as never);
+    await serverClient.loginWithPasswordlessEmail({ email: 'user@example.com', code: '123456' }, { ctx: 1 } as never);
+
+    expect(domainResolver).toHaveBeenCalled();
+    expect(startCount).toBe(1);
+    expect(lastOtpForm!.get('realm')).toBe('email');
+  });
+
+  test('FT-10b: resolver throwing propagates (no silent session write)', async () => {
+    const domainResolver = vi.fn().mockRejectedValue(new Error('resolver boom'));
+    const serverClient = newServerClient({ domain: domainResolver });
+
+    await expect(
+      serverClient.loginWithPasswordlessEmail({ email: 'user@example.com', code: '123456' }, { ctx: 1 } as never)
+    ).rejects.toThrow('resolver boom');
+  });
+
+  // Capture the authorization_code grant posted to the token endpoint (magic-link completion).
+  let lastCodeForm: URLSearchParams | null = null;
+  const captureCodeGrant = (respond?: (form: URLSearchParams) => Response | Promise<Response>) =>
+    server.use(
+      http.post(mockOpenIdConfiguration.token_endpoint, async ({ request }) => {
+        const form = new URLSearchParams(await request.text());
+        lastCodeForm = form;
+        if (respond) {
+          return respond(form);
+        }
+        return HttpResponse.json({
+          access_token: accessToken,
+          id_token: await generateToken(domain, 'user_123', '<client_id>'),
+          expires_in: 86400,
+          token_type: 'Bearer',
+          scope: form.get('scope') ?? '<scope>',
+        });
+      })
+    );
+
+  const mockStores = () => {
+    const transactionStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn() };
+    const stateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
+    stateStore.get.mockResolvedValue(undefined);
+    return { transactionStore, stateStore };
+  };
+
+  test('FT-11: startPasswordlessMagicLink sends link + persists state, no codeVerifier', async () => {
+    captureStart();
+    const { transactionStore, stateStore } = mockStores();
+    const serverClient = newServerClient({ transactionStore, stateStore });
+
+    await serverClient.startPasswordlessMagicLink({
+      email: 'user@example.com',
+      redirectUri: 'https://app.example.com/auth/callback',
+      scope: 'profile',
+    });
+
+    expect(lastStartBody!.send).toBe('link');
+    const authParams = lastStartBody!.authParams as Record<string, unknown>;
+    expect(authParams.redirect_uri).toBe('https://app.example.com/auth/callback');
+    expect(authParams.response_type).toBe('code');
+    expect((authParams.scope as string).split(' ')).toContain('openid');
+    expect(authParams.state).toBeTruthy();
+
+    expect(transactionStore.set).toHaveBeenCalledTimes(1);
+    const persisted = transactionStore.set.mock.calls[0]![1];
+    expect(persisted.state).toBe(authParams.state);
+    expect(persisted).not.toHaveProperty('codeVerifier');
+  });
+
+  test('FT-12: completePasswordlessMagicLink validates state, exchanges (no PKCE), persists', async () => {
+    captureCodeGrant();
+    const { transactionStore, stateStore } = mockStores();
+    transactionStore.get.mockResolvedValue({ state: 's1', domain });
+    const serverClient = newServerClient({ transactionStore, stateStore });
+
+    const result = await serverClient.completePasswordlessMagicLink(
+      new URL(`https://${domain}/cb?code=123&state=s1`)
+    );
+
+    expect(lastCodeForm!.get('grant_type')).toBe('authorization_code');
+    expect(lastCodeForm!.has('code_verifier')).toBe(false);
+    expect(stateStore.set).toHaveBeenCalledTimes(1);
+    expect(transactionStore.delete).toHaveBeenCalledTimes(1);
+    expect(result).toBeDefined();
+  });
+
+  test('FT-13: completePasswordlessMagicLink throws MissingTransactionError when no transaction', async () => {
+    const { transactionStore, stateStore } = mockStores();
+    transactionStore.get.mockResolvedValue(undefined);
+    const serverClient = newServerClient({ transactionStore, stateStore });
+
+    await expect(
+      serverClient.completePasswordlessMagicLink(new URL(`https://${domain}/cb?code=123&state=s1`))
+    ).rejects.toBeInstanceOf(MissingTransactionError);
+  });
+
+  test('FT-14: state mismatch throws PasswordlessVerifyError, no exchange, no delete', async () => {
+    let exchangeCalled = false;
+    server.use(
+      http.post(mockOpenIdConfiguration.token_endpoint, async () => {
+        exchangeCalled = true;
+        return HttpResponse.json({ access_token: accessToken, expires_in: 60, token_type: 'Bearer' });
+      })
+    );
+    const { transactionStore, stateStore } = mockStores();
+    transactionStore.get.mockResolvedValue({ state: 's1', domain });
+    const serverClient = newServerClient({ transactionStore, stateStore });
+
+    await expect(
+      serverClient.completePasswordlessMagicLink(new URL(`https://${domain}/cb?code=123&state=tampered`))
+    ).rejects.toBeInstanceOf(Auth0AuthJs.PasswordlessVerifyError);
+    expect(exchangeCalled).toBe(false);
+    expect(transactionStore.delete).not.toHaveBeenCalled();
+  });
+
+  test('FT-15: absent state on callback throws PasswordlessVerifyError', async () => {
+    const { transactionStore, stateStore } = mockStores();
+    transactionStore.get.mockResolvedValue({ state: 's1', domain });
+    const serverClient = newServerClient({ transactionStore, stateStore });
+
+    await expect(
+      serverClient.completePasswordlessMagicLink(new URL(`https://${domain}/cb?code=123`))
+    ).rejects.toBeInstanceOf(Auth0AuthJs.PasswordlessVerifyError);
+  });
+
+  test('FT-16: magic-link methods resolve domain in resolver mode', async () => {
+    captureStart();
+    captureCodeGrant();
+    const domainResolver = vi.fn().mockResolvedValue(domain);
+    const { transactionStore, stateStore } = mockStores();
+    transactionStore.get.mockResolvedValue({ state: 's1', domain });
+    const serverClient = newServerClient({ domain: domainResolver, transactionStore, stateStore });
+
+    await serverClient.startPasswordlessMagicLink(
+      { email: 'user@example.com', redirectUri: 'https://app/cb' },
+      { ctx: 1 } as never
+    );
+    await serverClient.completePasswordlessMagicLink(new URL(`https://${domain}/cb?code=123&state=s1`), {
+      ctx: 1,
+    } as never);
+
+    expect(domainResolver).toHaveBeenCalled();
+  });
+
+  test('FT-17: startPasswordlessMagicLink ensures openid even when scope omits it', async () => {
+    captureStart();
+    const { transactionStore, stateStore } = mockStores();
+    const serverClient = newServerClient({ transactionStore, stateStore });
+
+    await serverClient.startPasswordlessMagicLink({
+      email: 'user@example.com',
+      redirectUri: 'https://app/cb',
+      scope: 'profile email',
+    });
+
+    const authParams = lastStartBody!.authParams as Record<string, unknown>;
+    expect((authParams.scope as string).split(' ')).toContain('openid');
+  });
+
+  test('FT-18: completeInteractiveLogin still completes a PKCE transaction (regression)', async () => {
+    captureCodeGrant();
+    const { transactionStore, stateStore } = mockStores();
+    // Interactive transaction: carries a codeVerifier (the field stayed required at runtime).
+    transactionStore.get.mockResolvedValue({ codeVerifier: '<code_verifier>', domain });
+    const serverClient = newServerClient({ transactionStore, stateStore });
+
+    await serverClient.completeInteractiveLogin(new URL(`https://${domain}?code=123`));
+
+    // PKCE path unchanged by the optional-codeVerifier widening: verifier sent on the wire.
+    expect(lastCodeForm!.get('code_verifier')).toBe('<code_verifier>');
+    expect(stateStore.set).toHaveBeenCalledTimes(1);
+    expect(transactionStore.delete).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/auth0-server-js/src/server-client.ts
+++ b/packages/auth0-server-js/src/server-client.ts
@@ -7,6 +7,8 @@ import {
   LoginBackchannelResult,
   LoginWithCustomTokenExchangeOptions,
   LoginWithCustomTokenExchangeResult,
+  CompletePasswordlessOptions,
+  CompletePasswordlessResult,
   LogoutOptions,
   PasskeyRegisterResponse,
   PasskeyRegisterOptions,
@@ -17,13 +19,8 @@ import {
   ServerClientOptions,
   SessionData,
   StartInteractiveLoginOptions,
-  StartPasswordlessEmailOptions,
-  StartPasswordlessSmsOptions,
-  StartPasswordlessMagicLinkOptions,
-  LoginWithPasswordlessEmailOptions,
-  LoginWithPasswordlessSmsOptions,
-  LoginWithPasswordlessResult,
   StartLinkUserOptions,
+  StartPasswordlessOptions,
   StartUnlinkUserOptions,
   StateData,
   StateStore,
@@ -612,172 +609,68 @@ export class ServerClient<TStoreOptions = unknown> {
   }
 
   /**
-   * Starts a passwordless email login by sending a one-time code (default) or a magic link.
+   * Starts a passwordless flow by sending a one-time code (OTP) or a magic link.
    *
-   * Stateless passthrough to the Authentication API; no session is created here.
-   * Complete a code flow with {@link ServerClient#loginWithPasswordlessEmail}.
+   * Discriminated on `connection` (and, for email, `send`) to mirror the
+   * `@auth0/nextjs-auth0` `passwordless.start()` surface:
+   * - `{ connection: 'email' }` / `{ connection: 'email', send: 'code' }` — email OTP
+   * - `{ connection: 'email', send: 'link', redirectUri }` — email magic link
+   * - `{ connection: 'sms' }` — SMS OTP
    *
-   * @param options Send options (email, optional `send`, optional `authParams` for a link).
+   * OTP modes are a stateless passthrough to the Authentication API (no session, no transaction);
+   * complete them with {@link ServerClient#completePasswordless}.
+   *
+   * Magic-link mode is stateful: the SDK generates an opaque anti-forgery `state`, sends the link
+   * with the OAuth parameters embedded (`redirect_uri`, `response_type=code`, `scope`, `state`),
+   * and persists a transaction carrying that `state`. NO PKCE challenge is registered, so the
+   * transaction holds no `codeVerifier`. Complete it with
+   * {@link ServerClient#completePasswordlessMagicLink}. Requires the tenant setting
+   * `allow_magiclink_verify_without_session: true` for server-side completion.
+   *
+   * @param options Discriminated start options.
    * @param storeOptions Optional options passed to the resolver / stores.
    *
-   * @throws {PasswordlessStartError} If the request fails.
-   */
-  public async startPasswordlessEmail(
-    options: StartPasswordlessEmailOptions,
-    storeOptions?: TStoreOptions
-  ): Promise<void> {
-    const domain = await this.#resolveDomain(storeOptions);
-    const authClient = this.#getAuthClient(domain);
-    await authClient.passwordless.sendEmail(options);
-  }
-
-  /**
-   * Starts a passwordless SMS login by sending a one-time code.
-   *
-   * Stateless passthrough to the Authentication API; no session is created here.
-   * Complete the flow with {@link ServerClient#loginWithPasswordlessSms}.
-   *
-   * @param options Send options (`phoneNumber` in E.164 format).
-   * @param storeOptions Optional options passed to the resolver / stores.
-   *
-   * @throws {PasswordlessStartError} If the phone number is invalid or the request fails.
-   */
-  public async startPasswordlessSms(
-    options: StartPasswordlessSmsOptions,
-    storeOptions?: TStoreOptions
-  ): Promise<void> {
-    const domain = await this.#resolveDomain(storeOptions);
-    const authClient = this.#getAuthClient(domain);
-    await authClient.passwordless.sendSms(options);
-  }
-
-  /**
-   * Completes a passwordless email OTP login and persists the resulting session.
-   *
-   * Non-redirect flow: no PKCE and no transaction store (mirrors {@link ServerClient#loginBackchannel}).
-   * The `openid` scope is always ensured by this layer.
-   *
-   * Note: the state store is read-then-written; if your deployment performs concurrent
-   * logins for the same session identifier, use a state store with atomic/serializable
-   * writes to avoid last-write-wins races.
-   *
-   * @param options Login options (email, code, optional `authorizationParams`).
-   * @param storeOptions Optional options passed to the resolver / stores.
-   *
-   * @throws {PasswordlessVerifyError} If the code is invalid, expired, or rate-limited. When the
-   *   connection requires MFA, the server responds with `mfa_required`; narrow the thrown error
-   *   with `isMfaRequiredError(error)` to read `cause.mfa_token`.
-   *
-   * @returns A promise resolving to the authorizationDetails (when RAR was used).
-   */
-  public async loginWithPasswordlessEmail(
-    options: LoginWithPasswordlessEmailOptions,
-    storeOptions?: TStoreOptions
-  ): Promise<LoginWithPasswordlessResult> {
-    const scope = ensureOpenIdScope(options.authorizationParams?.scope ?? this.#options.authorizationParams?.scope);
-    const audience = options.authorizationParams?.audience ?? this.#options.authorizationParams?.audience;
-    const domain = await this.#resolveDomain(storeOptions);
-    const authClient = this.#getAuthClient(domain);
-
-    const tokenEndpointResponse = await authClient.getTokenByPasswordlessEmail({
-      email: options.email,
-      code: options.code,
-      audience,
-      scope,
-    });
-
-    const existingStateData = await this.#stateStore.get(this.#stateStoreIdentifier, storeOptions);
-
-    const stateData = updateStateData(
-      this.#options.authorizationParams?.audience ?? 'default',
-      existingStateData,
-      tokenEndpointResponse,
-      { domain }
-    );
-
-    await this.#stateStore.set(this.#stateStoreIdentifier, stateData, true, storeOptions);
-
-    return {
-      authorizationDetails: tokenEndpointResponse.authorizationDetails,
-    };
-  }
-
-  /**
-   * Completes a passwordless SMS OTP login and persists the resulting session.
-   *
-   * Non-redirect flow: no PKCE and no transaction store. The `openid` scope is always
-   * ensured by this layer. See {@link ServerClient#loginWithPasswordlessEmail} for the
-   * concurrent-write note.
-   *
-   * @param options Login options (phoneNumber in E.164, code, optional `authorizationParams`).
-   * @param storeOptions Optional options passed to the resolver / stores.
-   *
-   * @throws {PasswordlessVerifyError} If the code is invalid, expired, or rate-limited. When the
-   *   connection requires MFA, the server responds with `mfa_required`; narrow the thrown error
-   *   with `isMfaRequiredError(error)` to read `cause.mfa_token`.
-   *
-   * @returns A promise resolving to the authorizationDetails (when RAR was used).
-   */
-  public async loginWithPasswordlessSms(
-    options: LoginWithPasswordlessSmsOptions,
-    storeOptions?: TStoreOptions
-  ): Promise<LoginWithPasswordlessResult> {
-    const scope = ensureOpenIdScope(options.authorizationParams?.scope ?? this.#options.authorizationParams?.scope);
-    const audience = options.authorizationParams?.audience ?? this.#options.authorizationParams?.audience;
-    const domain = await this.#resolveDomain(storeOptions);
-    const authClient = this.#getAuthClient(domain);
-
-    const tokenEndpointResponse = await authClient.getTokenByPasswordlessSms({
-      phoneNumber: options.phoneNumber,
-      code: options.code,
-      audience,
-      scope,
-    });
-
-    const existingStateData = await this.#stateStore.get(this.#stateStoreIdentifier, storeOptions);
-
-    const stateData = updateStateData(
-      this.#options.authorizationParams?.audience ?? 'default',
-      existingStateData,
-      tokenEndpointResponse,
-      { domain }
-    );
-
-    await this.#stateStore.set(this.#stateStoreIdentifier, stateData, true, storeOptions);
-
-    return {
-      authorizationDetails: tokenEndpointResponse.authorizationDetails,
-    };
-  }
-
-  /**
-   * Starts a passwordless magic-link login by emailing a link.
-   *
-   * The SDK generates an opaque anti-forgery `state`, sends the link with the OAuth parameters
-   * embedded (`redirect_uri`, `response_type=code`, `scope`, `state`), and persists a transaction
-   * carrying that `state`. Unlike interactive login, NO PKCE challenge is registered, so the
-   * transaction holds no `codeVerifier`. Complete the flow with
-   * {@link ServerClient#completePasswordlessMagicLink}.
-   *
-   * Requires the tenant setting `allow_magiclink_verify_without_session: true` for server-side
-   * completion (the start cookie is set on the server, not the browser).
-   *
-   * @param options Magic-link options (email, redirectUri, optional authParams/scope/audience/language).
-   * @param storeOptions Optional options passed to the resolver / stores.
-   *
-   * @throws {PasswordlessStartError} If the request fails.
+   * @throws {PasswordlessStartError} If the request fails, or if a magic link is requested without a `redirectUri`.
    *
    * @example
-   * await serverClient.startPasswordlessMagicLink({
+   * // Email OTP
+   * await serverClient.startPasswordless({ connection: 'email', email: 'user@example.com' });
+   * // SMS OTP
+   * await serverClient.startPasswordless({ connection: 'sms', phoneNumber: '+14155550100' });
+   * // Email magic link
+   * await serverClient.startPasswordless({
+   *   connection: 'email',
    *   email: 'user@example.com',
+   *   send: 'link',
    *   redirectUri: 'https://app.example.com/auth/callback',
-   *   scope: 'openid profile',
-   * }, storeOptions);
+   * });
    */
-  public async startPasswordlessMagicLink(
-    options: StartPasswordlessMagicLinkOptions,
+  public async startPasswordless(
+    options: StartPasswordlessOptions,
     storeOptions?: TStoreOptions
   ): Promise<void> {
+    const domain = await this.#resolveDomain(storeOptions);
+    const authClient = this.#getAuthClient(domain);
+
+    if (options.connection === 'sms') {
+      await authClient.passwordless.sendSms({
+        phoneNumber: options.phoneNumber,
+        language: options.language,
+      });
+      return;
+    }
+
+    // Email OTP
+    if (options.send !== 'link') {
+      await authClient.passwordless.sendEmail({
+        email: options.email,
+        send: 'code',
+        language: options.language,
+      });
+      return;
+    }
+
+    // Email magic link (stateful)
     if (!options.redirectUri || typeof options.redirectUri !== 'string') {
       throw new PasswordlessStartError('redirectUri is required to start a passwordless magic-link login.');
     }
@@ -785,8 +678,6 @@ export class ServerClient<TStoreOptions = unknown> {
     const state = crypto.randomUUID();
     const scope = ensureOpenIdScope(options.scope ?? this.#options.authorizationParams?.scope);
     const audience = options.audience ?? this.#options.authorizationParams?.audience;
-    const domain = await this.#resolveDomain(storeOptions);
-    const authClient = this.#getAuthClient(domain);
 
     await authClient.passwordless.sendEmail({
       email: options.email,
@@ -812,9 +703,69 @@ export class ServerClient<TStoreOptions = unknown> {
   }
 
   /**
+   * Completes a passwordless OTP login and persists the resulting session.
+   *
+   * Discriminated on `connection` to mirror the `@auth0/nextjs-auth0` `passwordless.verify()`
+   * surface. Non-redirect flow: no PKCE and no transaction store (mirrors
+   * {@link ServerClient#loginBackchannel}). The `openid` scope is always ensured by this layer.
+   *
+   * Note: the state store is read-then-written; if your deployment performs concurrent
+   * logins for the same session identifier, use a state store with atomic/serializable
+   * writes to avoid last-write-wins races.
+   *
+   * @param options Discriminated completion options (`connection`, identifier, `verificationCode`).
+   * @param storeOptions Optional options passed to the resolver / stores.
+   *
+   * @throws {PasswordlessVerifyError} If the code is invalid, expired, or rate-limited. When the
+   *   connection requires MFA, the server responds with `mfa_required`; narrow the thrown error
+   *   with `isMfaRequiredError(error)` to read `cause.mfa_token`.
+   *
+   * @returns A promise resolving to the authorizationDetails (when RAR was used).
+   */
+  public async completePasswordless(
+    options: CompletePasswordlessOptions,
+    storeOptions?: TStoreOptions
+  ): Promise<CompletePasswordlessResult> {
+    const scope = ensureOpenIdScope(options.authorizationParams?.scope ?? this.#options.authorizationParams?.scope);
+    const audience = options.authorizationParams?.audience ?? this.#options.authorizationParams?.audience;
+    const domain = await this.#resolveDomain(storeOptions);
+    const authClient = this.#getAuthClient(domain);
+
+    const tokenEndpointResponse =
+      options.connection === 'sms'
+        ? await authClient.getTokenByPasswordlessSms({
+            phoneNumber: options.phoneNumber,
+            code: options.verificationCode,
+            audience,
+            scope,
+          })
+        : await authClient.getTokenByPasswordlessEmail({
+            email: options.email,
+            code: options.verificationCode,
+            audience,
+            scope,
+          });
+
+    const existingStateData = await this.#stateStore.get(this.#stateStoreIdentifier, storeOptions);
+
+    const stateData = updateStateData(
+      this.#options.authorizationParams?.audience ?? 'default',
+      existingStateData,
+      tokenEndpointResponse,
+      { domain }
+    );
+
+    await this.#stateStore.set(this.#stateStoreIdentifier, stateData, true, storeOptions);
+
+    return {
+      authorizationDetails: tokenEndpointResponse.authorizationDetails,
+    };
+  }
+
+  /**
    * Completes a passwordless magic-link login and persists the resulting session.
    *
-   * Loads the transaction persisted by {@link ServerClient#startPasswordlessMagicLink}, validates the
+   * Loads the transaction persisted by {@link ServerClient#startPasswordless} (magic-link mode), validates the
    * `state` returned on the callback URL against the stored `state` (anti-forgery binding), exchanges
    * the authorization code WITHOUT PKCE, writes the session, and deletes the transaction. The existing
    * interactive login path ({@link ServerClient#completeInteractiveLogin}) is not used.
@@ -834,7 +785,7 @@ export class ServerClient<TStoreOptions = unknown> {
   public async completePasswordlessMagicLink(
     url: URL,
     storeOptions?: TStoreOptions
-  ): Promise<LoginWithPasswordlessResult> {
+  ): Promise<CompletePasswordlessResult> {
     const transactionData = await this.#transactionStore.get(this.#transactionStoreIdentifier, storeOptions);
 
     if (!transactionData) {

--- a/packages/auth0-server-js/src/server-client.ts
+++ b/packages/auth0-server-js/src/server-client.ts
@@ -17,6 +17,12 @@ import {
   ServerClientOptions,
   SessionData,
   StartInteractiveLoginOptions,
+  StartPasswordlessEmailOptions,
+  StartPasswordlessSmsOptions,
+  StartPasswordlessMagicLinkOptions,
+  LoginWithPasswordlessEmailOptions,
+  LoginWithPasswordlessSmsOptions,
+  LoginWithPasswordlessResult,
   StartLinkUserOptions,
   StartUnlinkUserOptions,
   StateData,
@@ -39,10 +45,11 @@ import {
   AuthorizationDetails,
   TokenByRefreshTokenError,
   TokenResponse,
+  PasswordlessVerifyError,
 } from '@auth0/auth0-auth-js';
 import { compareScopes } from './utils.js';
 import { decodeJwt } from 'jose';
-import type { AuthClientOptions } from '@auth0/auth0-auth-js';
+import type { AuthClientOptions, SendEmailOptions } from '@auth0/auth0-auth-js';
 import { getTelemetryConfig } from './telemetry.js';
 import { ServerMfaClient } from './mfa/server-mfa-client.js';
 
@@ -301,7 +308,8 @@ export class ServerClient<TStoreOptions = unknown> {
     const domain = transactionData.domain ?? (await this.#resolveDomain(storeOptions));
     const authClient = this.#getAuthClient(domain);
     const tokenEndpointResponse = await authClient.getTokenByCode(url, {
-      codeVerifier: transactionData.codeVerifier,
+      // TransactionData.codeVerifier is optional only to accommodate magic-link transactions.
+      codeVerifier: transactionData.codeVerifier!,
     });
 
     const existingStateData = await this.#stateStore.get(this.#stateStoreIdentifier, storeOptions);
@@ -596,6 +604,257 @@ export class ServerClient<TStoreOptions = unknown> {
     const stateData = updateStateData(audience ?? 'default', existingStateData, tokenEndpointResponse, { domain });
 
     await this.#stateStore.set(this.#stateStoreIdentifier, stateData, true, storeOptions);
+
+    return {
+      authorizationDetails: tokenEndpointResponse.authorizationDetails,
+    };
+  }
+
+  /**
+   * Starts a passwordless email login by sending a one-time code (default) or a magic link.
+   *
+   * Stateless passthrough to the Authentication API; no session is created here.
+   * Complete a code flow with {@link ServerClient#loginWithPasswordlessEmail}.
+   *
+   * @param options Send options (email, optional `send`, optional `authParams` for a link).
+   * @param storeOptions Optional options passed to the resolver / stores.
+   *
+   * @throws {PasswordlessStartError} If the request fails.
+   */
+  public async startPasswordlessEmail(
+    options: StartPasswordlessEmailOptions,
+    storeOptions?: TStoreOptions
+  ): Promise<void> {
+    const domain = await this.#resolveDomain(storeOptions);
+    const authClient = this.#getAuthClient(domain);
+    await authClient.passwordless.sendEmail(options as SendEmailOptions);
+  }
+
+  /**
+   * Starts a passwordless SMS login by sending a one-time code.
+   *
+   * Stateless passthrough to the Authentication API; no session is created here.
+   * Complete the flow with {@link ServerClient#loginWithPasswordlessSms}.
+   *
+   * @param options Send options (`phoneNumber` in E.164 format).
+   * @param storeOptions Optional options passed to the resolver / stores.
+   *
+   * @throws {PasswordlessStartError} If the phone number is invalid or the request fails.
+   */
+  public async startPasswordlessSms(
+    options: StartPasswordlessSmsOptions,
+    storeOptions?: TStoreOptions
+  ): Promise<void> {
+    const domain = await this.#resolveDomain(storeOptions);
+    const authClient = this.#getAuthClient(domain);
+    await authClient.passwordless.sendSms(options);
+  }
+
+  /**
+   * Completes a passwordless email OTP login and persists the resulting session.
+   *
+   * Non-redirect flow: no PKCE and no transaction store (mirrors {@link ServerClient#loginBackchannel}).
+   * The `openid` scope is always ensured by this layer.
+   *
+   * Note: the state store is read-then-written; if your deployment performs concurrent
+   * logins for the same session identifier, use a state store with atomic/serializable
+   * writes to avoid last-write-wins races.
+   *
+   * @param options Login options (email, code, optional `authorizationParams`).
+   * @param storeOptions Optional options passed to the resolver / stores.
+   *
+   * @throws {PasswordlessVerifyError} If the code is invalid, expired, or rate-limited. When the
+   *   connection requires MFA, the server responds with `mfa_required`; narrow the thrown error
+   *   with `isMfaRequiredError(error)` to read `cause.mfa_token`.
+   *
+   * @returns A promise resolving to the authorizationDetails (when RAR was used).
+   */
+  public async loginWithPasswordlessEmail(
+    options: LoginWithPasswordlessEmailOptions,
+    storeOptions?: TStoreOptions
+  ): Promise<LoginWithPasswordlessResult> {
+    const scope = ensureOpenIdScope(options.authorizationParams?.scope ?? this.#options.authorizationParams?.scope);
+    const audience = options.authorizationParams?.audience ?? this.#options.authorizationParams?.audience;
+    const domain = await this.#resolveDomain(storeOptions);
+    const authClient = this.#getAuthClient(domain);
+
+    const tokenEndpointResponse = await authClient.getTokenByPasswordlessEmail({
+      email: options.email,
+      code: options.code,
+      audience,
+      scope,
+    });
+
+    const existingStateData = await this.#stateStore.get(this.#stateStoreIdentifier, storeOptions);
+
+    const stateData = updateStateData(
+      this.#options.authorizationParams?.audience ?? 'default',
+      existingStateData,
+      tokenEndpointResponse,
+      { domain }
+    );
+
+    await this.#stateStore.set(this.#stateStoreIdentifier, stateData, true, storeOptions);
+
+    return {
+      authorizationDetails: tokenEndpointResponse.authorizationDetails,
+    };
+  }
+
+  /**
+   * Completes a passwordless SMS OTP login and persists the resulting session.
+   *
+   * Non-redirect flow: no PKCE and no transaction store. The `openid` scope is always
+   * ensured by this layer. See {@link ServerClient#loginWithPasswordlessEmail} for the
+   * concurrent-write note.
+   *
+   * @param options Login options (phoneNumber in E.164, code, optional `authorizationParams`).
+   * @param storeOptions Optional options passed to the resolver / stores.
+   *
+   * @throws {PasswordlessVerifyError} If the code is invalid, expired, or rate-limited. When the
+   *   connection requires MFA, the server responds with `mfa_required`; narrow the thrown error
+   *   with `isMfaRequiredError(error)` to read `cause.mfa_token`.
+   *
+   * @returns A promise resolving to the authorizationDetails (when RAR was used).
+   */
+  public async loginWithPasswordlessSms(
+    options: LoginWithPasswordlessSmsOptions,
+    storeOptions?: TStoreOptions
+  ): Promise<LoginWithPasswordlessResult> {
+    const scope = ensureOpenIdScope(options.authorizationParams?.scope ?? this.#options.authorizationParams?.scope);
+    const audience = options.authorizationParams?.audience ?? this.#options.authorizationParams?.audience;
+    const domain = await this.#resolveDomain(storeOptions);
+    const authClient = this.#getAuthClient(domain);
+
+    const tokenEndpointResponse = await authClient.getTokenByPasswordlessSms({
+      phoneNumber: options.phoneNumber,
+      code: options.code,
+      audience,
+      scope,
+    });
+
+    const existingStateData = await this.#stateStore.get(this.#stateStoreIdentifier, storeOptions);
+
+    const stateData = updateStateData(
+      this.#options.authorizationParams?.audience ?? 'default',
+      existingStateData,
+      tokenEndpointResponse,
+      { domain }
+    );
+
+    await this.#stateStore.set(this.#stateStoreIdentifier, stateData, true, storeOptions);
+
+    return {
+      authorizationDetails: tokenEndpointResponse.authorizationDetails,
+    };
+  }
+
+  /**
+   * Starts a passwordless magic-link login by emailing a link.
+   *
+   * The SDK generates an opaque anti-forgery `state`, sends the link with the OAuth parameters
+   * embedded (`redirect_uri`, `response_type=code`, `scope`, `state`), and persists a transaction
+   * carrying that `state`. Unlike interactive login, NO PKCE challenge is registered, so the
+   * transaction holds no `codeVerifier`. Complete the flow with
+   * {@link ServerClient#completePasswordlessMagicLink}.
+   *
+   * Requires the tenant setting `allow_magiclink_verify_without_session: true` for server-side
+   * completion (the start cookie is set on the server, not the browser).
+   *
+   * @param options Magic-link options (email, redirectUri, optional authParams/scope/audience/language).
+   * @param storeOptions Optional options passed to the resolver / stores.
+   *
+   * @throws {PasswordlessStartError} If the request fails.
+   *
+   * @example
+   * await serverClient.startPasswordlessMagicLink({
+   *   email: 'user@example.com',
+   *   redirectUri: 'https://app.example.com/auth/callback',
+   *   scope: 'openid profile',
+   * }, storeOptions);
+   */
+  public async startPasswordlessMagicLink(
+    options: StartPasswordlessMagicLinkOptions,
+    storeOptions?: TStoreOptions
+  ): Promise<void> {
+    const state = crypto.randomUUID();
+    const scope = ensureOpenIdScope(options.scope ?? this.#options.authorizationParams?.scope);
+    const audience = options.audience ?? this.#options.authorizationParams?.audience;
+    const domain = await this.#resolveDomain(storeOptions);
+    const authClient = this.#getAuthClient(domain);
+
+    await authClient.passwordless.sendEmail({
+      email: options.email,
+      send: 'link',
+      language: options.language,
+      authParams: {
+        ...options.authParams,
+        redirect_uri: options.redirectUri,
+        response_type: 'code',
+        scope,
+        ...(audience ? { audience } : {}),
+        state,
+      },
+    } as SendEmailOptions);
+
+    const transactionState: TransactionData = {
+      audience,
+      domain,
+      state,
+    };
+
+    await this.#transactionStore.set(this.#transactionStoreIdentifier, transactionState, false, storeOptions);
+  }
+
+  /**
+   * Completes a passwordless magic-link login and persists the resulting session.
+   *
+   * Loads the transaction persisted by {@link ServerClient#startPasswordlessMagicLink}, validates the
+   * `state` returned on the callback URL against the stored `state` (anti-forgery binding), exchanges
+   * the authorization code WITHOUT PKCE, writes the session, and deletes the transaction. The existing
+   * interactive login path ({@link ServerClient#completeInteractiveLogin}) is not used.
+   *
+   * @param url The callback URL containing the authorization `code` and `state`.
+   * @param storeOptions Optional options passed to the resolver / stores.
+   *
+   * @throws {MissingTransactionError} If no magic-link transaction was found.
+   * @throws {PasswordlessVerifyError} If the returned `state` is missing or does not match.
+   * @throws {TokenByCodeError} If the token exchange fails.
+   *
+   * @returns A promise resolving to the authorizationDetails (when RAR was used).
+   *
+   * @example
+   * const result = await serverClient.completePasswordlessMagicLink(callbackUrl, storeOptions);
+   */
+  public async completePasswordlessMagicLink(
+    url: URL,
+    storeOptions?: TStoreOptions
+  ): Promise<LoginWithPasswordlessResult> {
+    const transactionData = await this.#transactionStore.get(this.#transactionStoreIdentifier, storeOptions);
+
+    if (!transactionData) {
+      throw new MissingTransactionError();
+    }
+
+    const expectedState = transactionData.state as string | undefined;
+    const returnedState = url.searchParams.get('state');
+    if (!returnedState || !expectedState || returnedState !== expectedState) {
+      throw new PasswordlessVerifyError('State mismatch on magic-link callback');
+    }
+
+    const domain = transactionData.domain ?? (await this.#resolveDomain(storeOptions));
+    const authClient = this.#getAuthClient(domain);
+
+    const tokenEndpointResponse = await authClient.getTokenByMagicLinkCode(url, { expectedState });
+
+    const existingStateData = await this.#stateStore.get(this.#stateStoreIdentifier, storeOptions);
+
+    const stateData = updateStateData(transactionData.audience ?? 'default', existingStateData, tokenEndpointResponse, {
+      domain,
+    });
+
+    await this.#stateStore.set(this.#stateStoreIdentifier, stateData, true, storeOptions);
+    await this.#transactionStore.delete(this.#transactionStoreIdentifier, storeOptions);
 
     return {
       authorizationDetails: tokenEndpointResponse.authorizationDetails,

--- a/packages/auth0-server-js/src/server-client.ts
+++ b/packages/auth0-server-js/src/server-client.ts
@@ -43,13 +43,14 @@ import {
   TokenForConnectionError,
   AuthClient,
   AuthorizationDetails,
+  PasswordlessStartError,
+  PasswordlessVerifyError,
   TokenByRefreshTokenError,
   TokenResponse,
-  PasswordlessVerifyError,
 } from '@auth0/auth0-auth-js';
 import { compareScopes } from './utils.js';
 import { decodeJwt } from 'jose';
-import type { AuthClientOptions, SendEmailOptions } from '@auth0/auth0-auth-js';
+import type { AuthClientOptions } from '@auth0/auth0-auth-js';
 import { getTelemetryConfig } from './telemetry.js';
 import { ServerMfaClient } from './mfa/server-mfa-client.js';
 
@@ -627,7 +628,7 @@ export class ServerClient<TStoreOptions = unknown> {
   ): Promise<void> {
     const domain = await this.#resolveDomain(storeOptions);
     const authClient = this.#getAuthClient(domain);
-    await authClient.passwordless.sendEmail(options as SendEmailOptions);
+    await authClient.passwordless.sendEmail(options);
   }
 
   /**
@@ -777,6 +778,10 @@ export class ServerClient<TStoreOptions = unknown> {
     options: StartPasswordlessMagicLinkOptions,
     storeOptions?: TStoreOptions
   ): Promise<void> {
+    if (!options.redirectUri || typeof options.redirectUri !== 'string') {
+      throw new PasswordlessStartError('redirectUri is required to start a passwordless magic-link login.');
+    }
+
     const state = crypto.randomUUID();
     const scope = ensureOpenIdScope(options.scope ?? this.#options.authorizationParams?.scope);
     const audience = options.audience ?? this.#options.authorizationParams?.audience;
@@ -795,7 +800,7 @@ export class ServerClient<TStoreOptions = unknown> {
         ...(audience ? { audience } : {}),
         state,
       },
-    } as SendEmailOptions);
+    });
 
     const transactionState: TransactionData = {
       audience,
@@ -836,7 +841,10 @@ export class ServerClient<TStoreOptions = unknown> {
       throw new MissingTransactionError();
     }
 
-    const expectedState = transactionData.state as string | undefined;
+    // TransactionData.state is `unknown` ([key: string]: unknown); validate the type
+    // rather than assert it, so a non-string state (e.g. number from a custom store)
+    // falls through to the mismatch branch instead of comparing wrongly.
+    const expectedState = typeof transactionData.state === 'string' ? transactionData.state : undefined;
     const returnedState = url.searchParams.get('state');
     if (!returnedState || !expectedState || returnedState !== expectedState) {
       throw new PasswordlessVerifyError('State mismatch on magic-link callback');
@@ -845,6 +853,9 @@ export class ServerClient<TStoreOptions = unknown> {
     const domain = transactionData.domain ?? (await this.#resolveDomain(storeOptions));
     const authClient = this.#getAuthClient(domain);
 
+    // Belt-and-suspenders: `expectedState` is re-validated inside getTokenByMagicLinkCode
+    // (openid-client's anti-forgery binding). This is intentionally redundant with the
+    // manual check above — do not remove one without auditing the other.
     const tokenEndpointResponse = await authClient.getTokenByMagicLinkCode(url, { expectedState });
 
     const existingStateData = await this.#stateStore.get(this.#stateStoreIdentifier, storeOptions);

--- a/packages/auth0-server-js/src/types.ts
+++ b/packages/auth0-server-js/src/types.ts
@@ -120,7 +120,12 @@ export interface SessionData {
 
 export interface TransactionData {
   audience?: string;
-  codeVerifier: string;
+  /**
+   * PKCE code verifier for interactive (authorization-code) logins. Optional because
+   * magic-link transactions are bound by anti-forgery `state` only and register no PKCE
+   * challenge, so they persist no verifier.
+   */
+  codeVerifier?: string;
   domain?: string;
   [key: string]: unknown;
 }
@@ -178,6 +183,87 @@ export interface LoginBackchannelResult {
  *  Result of completing a passkey authentication flow (signup or login).
  */
 export interface PasskeyGetTokenResult {
+  authorizationDetails?: AuthorizationDetails[];
+}
+
+/**
+ * Options for starting a passwordless email login (code or magic link).
+ */
+export interface StartPasswordlessEmailOptions {
+  email: string;
+  /**
+   * Omit (or `'code'`) to send a one-time code; `'link'` to send a magic link.
+   */
+  send?: 'code' | 'link';
+  /**
+   * OAuth authorization parameters forwarded with a magic link (`send: 'link'`).
+   */
+  authParams?: Record<string, unknown>;
+}
+
+/**
+ * Options for starting a passwordless magic-link login. The SDK generates and persists an
+ * anti-forgery `state`, sends the link, and validates `state` on the callback. No PKCE is used.
+ */
+export interface StartPasswordlessMagicLinkOptions {
+  email: string;
+  /**
+   * The callback URL Auth0 redirects to after the magic link is clicked. Embedded in the link
+   * as `redirect_uri`; must be registered on the application.
+   */
+  redirectUri: string;
+  /**
+   * Additional OAuth authorization parameters merged into the link. `client_id`, `response_type`,
+   * and `state` are set by the SDK and cannot be overridden.
+   */
+  authParams?: Record<string, unknown>;
+  /**
+   * Scope for the resulting tokens. `openid` is ensured. Include `offline_access` for a refresh token.
+   */
+  scope?: string;
+  /**
+   * Audience for the resulting access token.
+   */
+  audience?: string;
+  /**
+   * BCP-47 language tag forwarded as `x-request-language` to localize the email template.
+   */
+  language?: string;
+}
+
+/**
+ * Options for starting a passwordless SMS login (code only).
+ */
+export interface StartPasswordlessSmsOptions {
+  /**
+   * Phone number in E.164 format, e.g. `+14155550100`.
+   */
+  phoneNumber: string;
+}
+
+/**
+ * Options for completing a passwordless email OTP login and establishing a session.
+ */
+export interface LoginWithPasswordlessEmailOptions {
+  email: string;
+  code: string;
+  authorizationParams?: AuthorizationParameters;
+}
+
+/**
+ * Options for completing a passwordless SMS OTP login and establishing a session.
+ */
+export interface LoginWithPasswordlessSmsOptions {
+  phoneNumber: string;
+  code: string;
+  authorizationParams?: AuthorizationParameters;
+}
+
+/**
+ * Result of a passwordless OTP login. The session is persisted to the state store;
+ * `authorizationDetails` is included when Rich Authorization Requests (RAR) were used.
+ */
+export interface LoginWithPasswordlessResult {
   authorizationDetails?: AuthorizationDetails[];
 }
 

--- a/packages/auth0-server-js/src/types.ts
+++ b/packages/auth0-server-js/src/types.ts
@@ -187,18 +187,22 @@ export interface PasskeyGetTokenResult {
 }
 
 /**
- * Options for starting a passwordless email login (code or magic link).
+ * Options for starting a passwordless email login by sending a one-time code (OTP).
+ *
+ * This is for the SDK-managed OTP flow only; complete it with
+ * {@link ServerClient#loginWithPasswordlessEmail}. To send a magic link, use
+ * {@link ServerClient#startPasswordlessMagicLink} — it generates and persists the
+ * anti-forgery `state` and stores the transaction that
+ * {@link ServerClient#completePasswordlessMagicLink} needs. Sending a link here
+ * would skip that bookkeeping and make completion impossible.
  */
 export interface StartPasswordlessEmailOptions {
   email: string;
   /**
-   * Omit (or `'code'`) to send a one-time code; `'link'` to send a magic link.
+   * Send a one-time code. Optional; this is the default. Magic links are NOT sent
+   * from here — use {@link ServerClient#startPasswordlessMagicLink} instead.
    */
-  send?: 'code' | 'link';
-  /**
-   * OAuth authorization parameters forwarded with a magic link (`send: 'link'`).
-   */
-  authParams?: Record<string, unknown>;
+  send?: 'code';
 }
 
 /**

--- a/packages/auth0-server-js/src/types.ts
+++ b/packages/auth0-server-js/src/types.ts
@@ -187,30 +187,37 @@ export interface PasskeyGetTokenResult {
 }
 
 /**
- * Options for starting a passwordless email login by sending a one-time code (OTP).
+ * Options for starting an email passwordless flow by sending a one-time code (OTP).
  *
- * This is for the SDK-managed OTP flow only; complete it with
- * {@link ServerClient#loginWithPasswordlessEmail}. To send a magic link, use
- * {@link ServerClient#startPasswordlessMagicLink} — it generates and persists the
- * anti-forgery `state` and stores the transaction that
- * {@link ServerClient#completePasswordlessMagicLink} needs. Sending a link here
- * would skip that bookkeeping and make completion impossible.
+ * Complete it with {@link ServerClient#loginWithPasswordless}.
  */
-export interface StartPasswordlessEmailOptions {
+export interface StartPasswordlessEmailCodeOptions {
+  /** Discriminator: email connection. */
+  connection: 'email';
+  /** The destination email address. */
   email: string;
-  /**
-   * Send a one-time code. Optional; this is the default. Magic links are NOT sent
-   * from here — use {@link ServerClient#startPasswordlessMagicLink} instead.
-   */
+  /** Send a one-time code. Optional; this is the default for the email connection. */
   send?: 'code';
+  /**
+   * BCP-47 language tag forwarded as `x-request-language` to localize the email template.
+   */
+  language?: string;
 }
 
 /**
- * Options for starting a passwordless magic-link login. The SDK generates and persists an
- * anti-forgery `state`, sends the link, and validates `state` on the callback. No PKCE is used.
+ * Options for starting an email passwordless magic-link flow.
+ *
+ * The SDK generates and persists an anti-forgery `state`, sends the link, and validates
+ * `state` on the callback. No PKCE is used. Complete it with
+ * {@link ServerClient#completePasswordlessMagicLink}.
  */
-export interface StartPasswordlessMagicLinkOptions {
+export interface StartPasswordlessEmailLinkOptions {
+  /** Discriminator: email connection. */
+  connection: 'email';
+  /** The destination email address. */
   email: string;
+  /** Send a magic link. Required literal to select link mode. */
+  send: 'link';
   /**
    * The callback URL Auth0 redirects to after the magic link is clicked. Embedded in the link
    * as `redirect_uri`; must be registered on the application.
@@ -236,38 +243,73 @@ export interface StartPasswordlessMagicLinkOptions {
 }
 
 /**
- * Options for starting a passwordless SMS login (code only).
+ * Options for starting an SMS passwordless flow (one-time code only; SMS has no magic link).
+ *
+ * Complete it with {@link ServerClient#loginWithPasswordless}.
  */
 export interface StartPasswordlessSmsOptions {
+  /** Discriminator: sms connection. */
+  connection: 'sms';
+  /** Phone number in E.164 format, e.g. `+14155550100`. */
+  phoneNumber: string;
   /**
-   * Phone number in E.164 format, e.g. `+14155550100`.
+   * BCP-47 language tag forwarded as `x-request-language` to localize the SMS template.
    */
-  phoneNumber: string;
+  language?: string;
 }
 
 /**
- * Options for completing a passwordless email OTP login and establishing a session.
+ * Options for starting a passwordless flow. Discriminated on `connection` (and, for email,
+ * on `send`) to mirror the `@auth0/nextjs-auth0` `passwordless.start()` surface.
+ *
+ * - `{ connection: 'email', send?: 'code' }` — email OTP (default)
+ * - `{ connection: 'email', send: 'link', redirectUri }` — email magic link
+ * - `{ connection: 'sms' }` — SMS OTP
  */
-export interface LoginWithPasswordlessEmailOptions {
+export type StartPasswordlessOptions =
+  | StartPasswordlessEmailCodeOptions
+  | StartPasswordlessEmailLinkOptions
+  | StartPasswordlessSmsOptions;
+
+/**
+ * Options for completing an email passwordless OTP login and establishing a session.
+ */
+export interface CompletePasswordlessEmailOptions {
+  /** Discriminator: email connection. */
+  connection: 'email';
+  /** The email address the code was sent to. */
   email: string;
-  code: string;
+  /** The one-time code entered by the user. */
+  verificationCode: string;
   authorizationParams?: AuthorizationParameters;
 }
 
 /**
- * Options for completing a passwordless SMS OTP login and establishing a session.
+ * Options for completing an SMS passwordless OTP login and establishing a session.
  */
-export interface LoginWithPasswordlessSmsOptions {
+export interface CompletePasswordlessSmsOptions {
+  /** Discriminator: sms connection. */
+  connection: 'sms';
+  /** The phone number the code was sent to, in E.164 format. */
   phoneNumber: string;
-  code: string;
+  /** The one-time code entered by the user. */
+  verificationCode: string;
   authorizationParams?: AuthorizationParameters;
 }
 
 /**
- * Result of a passwordless OTP login. The session is persisted to the state store;
- * `authorizationDetails` is included when Rich Authorization Requests (RAR) were used.
+ * Options for completing a passwordless OTP login. Discriminated on `connection` to mirror the
+ * `@auth0/nextjs-auth0` `passwordless.verify()` surface.
  */
-export interface LoginWithPasswordlessResult {
+export type CompletePasswordlessOptions =
+  | CompletePasswordlessEmailOptions
+  | CompletePasswordlessSmsOptions;
+
+/**
+ * Result of a passwordless login (OTP or magic link). The session is persisted to the state
+ * store; `authorizationDetails` is included when Rich Authorization Requests (RAR) were used.
+ */
+export interface CompletePasswordlessResult {
   authorizationDetails?: AuthorizationDetails[];
 }
 


### PR DESCRIPTION
Adds server-side passwordless session flows to `@auth0/auth0-server-js`, layered on the `auth0-auth-js` token grants.
Covers OTP (email/SMS) login and the full magic-link flow (start + completion) with session persistence.
Stacked on #197.

The public surface mirrors `@auth0/nextjs-auth0` (`passwordless.start()` / `passwordless.verify()`): a single `connection`-discriminated method per step instead of per-channel methods. This keeps server-js consistent with its own `start*`/`complete*` verb convention and makes the planned nextjs-auth0-on-server-js migration a near-passthrough (no per-channel fan-out wrapper).

## Public API
```ts
// Start — connection-discriminated (email OTP, email magic link, or SMS OTP)
await serverClient.startPasswordless({ connection: 'email', email, send: 'code' }, storeOptions);
await serverClient.startPasswordless({ connection: 'sms', phoneNumber }, storeOptions);
await serverClient.startPasswordless({ connection: 'email', send: 'link', email, redirectUri, scope: 'openid profile email' }, storeOptions);

// Complete OTP
await serverClient.completePasswordless({ connection: 'email', email, verificationCode }, storeOptions);
await serverClient.completePasswordless({ connection: 'sms', phoneNumber, verificationCode }, storeOptions);

// Complete magic link (on GET /callback?code&state)
await serverClient.completePasswordlessMagicLink(callbackUrl, storeOptions);
```

## Changes
- `startPasswordless(options)` — discriminated on `connection` (and, for email, `send`). OTP modes are stateless passthroughs; `send: 'link'` is stateful (SDK-owned `state`, persists a no-PKCE transaction with no `codeVerifier`). Optional `language` → `x-request-language` header.
- `completePasswordless(options)` — discriminated on `connection`; exchanges `verificationCode`, writes session (mirrors `loginBackchannel`). `openid` scope always ensured.
- `completePasswordlessMagicLink(url)` — kept as a dedicated method (no-PKCE state validation); nextjs likewise routes link-completion through its generic callback, not `verify`.
- `TransactionData.codeVerifier` optional (type-widening) for magic-link transactions; interactive path unchanged (non-null assert).
- `EXAMPLES.md`: passwordless section rewritten to the discriminated surface.

### Replaces (vs. previous revision of this PR)
- `startPasswordlessEmail` / `startPasswordlessSms` / `startPasswordlessMagicLink` → `startPasswordless({ connection, send? })`
- `loginWithPasswordlessEmail` / `loginWithPasswordlessSms` → `completePasswordless({ connection })` (field `code` → `verificationCode`)
- type renames: `LoginWithPasswordlessResult` → `CompletePasswordlessResult`

## nextjs-auth0 migration
1:1 adapter — `start(x)` → `startPasswordless(x)` (incl. `send: 'link'`); `verify(x)` → `completePasswordless(x)`.

## Testing
- Flow tests (vitest + MSW): FT-1..18 incl. SMS `x-request-language` (FT-9b), magic-link completion, state tamper, non-string state, missing transaction, empty-`redirectUri` guard, `completeInteractiveLogin` PKCE regression (FT-18)
- `npm test` server-js: 262 pass, 0 broken
- `npm run build` PASS (incl. DTS); `npm run lint` 0 violations