### PR TITLE
feat(auth0-auth-js): validate organization claim in returned ID token

### DIFF
--- a/packages/auth0-auth-js/EXAMPLES.md
+++ b/packages/auth0-auth-js/EXAMPLES.md
@@ -449,6 +449,17 @@ const url = 'http://localhost:3000/auth/callback?code=abc123';
 const tokenResponse = await authClient.getTokenByCode(url, { codeVerifier });
 ```
 
+If the login was initiated for a specific organization, pass `organization` to validate the returned ID token's organization claim. An organization ID (the `org_` prefix) is matched exactly against the `org_id` claim, while an organization name is matched case-insensitively against the `org_name` claim:
+
+```ts
+const tokenResponse = await authClient.getTokenByCode(url, {
+  codeVerifier,
+  organization: 'org_abc123',
+});
+```
+
+If the claim is missing or does not match, `getTokenByCode` throws an `OrganizationValidationError`.
+
 ## Retrieving a Token using a Refresh Token
 
 When a Refresh Token is available, the SDK's `getTokenByRefreshToken` can be used to retrieve a new Access Token by providing it said Refresh token:
@@ -1047,6 +1058,8 @@ const tokens = await authClient.passkey.getTokenByPasskey({
 });
 ```
 
+When `organization` is provided, the returned ID token's organization claim is validated against it (an `org_` prefix is matched exactly against `org_id`, otherwise the value is matched case-insensitively against `org_name`). A mismatch throws an `OrganizationValidationError`.
+
 ### Error Handling
 
 All passkey methods throw typed errors that can be caught and handled individually:
@@ -1143,6 +1156,18 @@ const tokens = await authClient.exchangeToken({
 console.log(tokens.accessToken);
 ```
 
+When `organization` is provided and the exchange returns an ID token, its organization claim is validated against the requested value (an `org_` prefix is matched exactly against `org_id`, otherwise the value is matched case-insensitively against `org_name`). A missing or mismatched claim throws an `OrganizationValidationError`.
+
+```ts
+const tokens = await authClient.exchangeToken({
+  subjectToken: externalToken,
+  subjectTokenType: 'urn:acme:legacy-token',
+  audience: 'https://api.example.com',
+  scope: 'openid profile read:data',
+  organization: 'org_abc123',
+});
+```
+
 ### Delegation Exchange with Actor Token
 
 When an intermediate service acts on behalf of a user, pass the service's own token as `actorToken`. Both `actorToken` and `actorTokenType` must be provided together.
@@ -1198,16 +1223,21 @@ console.log(tokens.act?.sub);
 ### Error Handling
 
 ```ts
-import { AuthClient, TokenExchangeError } from '@auth0/auth0-auth-js';
+import { AuthClient, TokenExchangeError, OrganizationValidationError } from '@auth0/auth0-auth-js';
 
 try {
   const tokens = await authClient.exchangeToken({
     subjectToken: externalToken,
     subjectTokenType: 'urn:acme:legacy-token',
     audience: 'https://api.example.com',
+    organization: 'org_abc123',
   });
 } catch (error) {
-  if (error instanceof TokenExchangeError) {
+  if (error instanceof OrganizationValidationError) {
+    // The ID token's organization claim did not match the requested organization.
+    console.error(error.message);
+    console.error(error.code);          // 'organization_validation_error'
+  } else if (error instanceof TokenExchangeError) {
     console.error(error.message);       // Human-readable error message
     console.error(error.code);          // 'token_exchange_error'
     console.error(error.cause?.error);  // e.g., 'invalid_grant', 'access_denied'

--- a/packages/auth0-auth-js/src/auth-client.spec.ts
+++ b/packages/auth0-auth-js/src/auth-client.spec.ts
@@ -1402,6 +1402,25 @@ describe('getTokenByCode - organization validation', () => {
     expect(res.accessToken).toBe(accessToken);
   });
 
+  test('skips validation when org is requested but no ID token is returned', async () => {
+    server.use(
+      http.post(mockOpenIdConfiguration.token_endpoint, async () => {
+        return HttpResponse.json({
+          access_token: accessToken,
+          expires_in: 60,
+          token_type: 'Bearer',
+          scope: '<scope>',
+        });
+      })
+    );
+    const authClient = newClient();
+    const res = await authClient.getTokenByCode(new URL(`https://${domain}?code=123`), {
+      codeVerifier: '123',
+      organization: 'org_abc123',
+    });
+    expect(res.accessToken).toBe(accessToken);
+  });
+
   test('throws a clear error when organization is only whitespace', async () => {
     useOrgTokenHandler({ org_name: 'acme-corp' });
     const authClient = newClient();

--- a/packages/auth0-auth-js/src/auth-client.spec.ts
+++ b/packages/auth0-auth-js/src/auth-client.spec.ts
@@ -2,7 +2,7 @@ import { expect, test, afterAll, beforeAll, beforeEach, vi, afterEach, describe 
 import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
 import { AuthClient } from './auth-client.js';
-import { NotSupportedError, isMfaRequiredError, TokenByPasswordError } from './errors.js';
+import { NotSupportedError, isMfaRequiredError, TokenByPasswordError, OrganizationValidationError } from './errors.js';
 import { PasskeyGetTokenError } from './passkey/errors.js';
 import { ExchangeProfileOptions } from './types.js';
 
@@ -1309,6 +1309,119 @@ test('getTokenByCode - should throw when token exchange failed', async () => {
       }),
     })
   );
+});
+
+describe('getTokenByCode - organization validation', () => {
+  // Helper: override the token endpoint to return an id_token carrying the given org claims.
+  const useOrgTokenHandler = (orgClaims: Record<string, unknown>) => {
+    server.use(
+      http.post(mockOpenIdConfiguration.token_endpoint, async () => {
+        return HttpResponse.json({
+          access_token: accessToken,
+          id_token: await generateToken(domain, 'user_123', '<client_id>', undefined, undefined, undefined, orgClaims),
+          expires_in: 60,
+          token_type: 'Bearer',
+          scope: '<scope>',
+        });
+      })
+    );
+  };
+
+  const newClient = () => new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });
+
+  test('passes when org_id matches exactly', async () => {
+    useOrgTokenHandler({ org_id: 'org_abc123' });
+    const authClient = newClient();
+    const res = await authClient.getTokenByCode(new URL(`https://${domain}?code=123`), {
+      codeVerifier: '123',
+      organization: 'org_abc123',
+    });
+    expect(res.claims?.org_id).toBe('org_abc123');
+  });
+
+  test('throws when org_id mismatches', async () => {
+    useOrgTokenHandler({ org_id: 'org_other' });
+    const authClient = newClient();
+    await expect(
+      authClient.getTokenByCode(new URL(`https://${domain}?code=123`), {
+        codeVerifier: '123',
+        organization: 'org_abc123',
+      })
+    ).rejects.toMatchObject({ name: 'OrganizationValidationError', code: 'organization_validation_error' });
+  });
+
+  test('throws when org_id claim is missing', async () => {
+    useOrgTokenHandler({});
+    const authClient = newClient();
+    await expect(
+      authClient.getTokenByCode(new URL(`https://${domain}?code=123`), {
+        codeVerifier: '123',
+        organization: 'org_abc123',
+      })
+    ).rejects.toThrow(OrganizationValidationError);
+  });
+
+  test('passes when org_name matches case-insensitively', async () => {
+    useOrgTokenHandler({ org_name: 'acme-corp' });
+    const authClient = newClient();
+    const res = await authClient.getTokenByCode(new URL(`https://${domain}?code=123`), {
+      codeVerifier: '123',
+      organization: 'ACME-Corp',
+    });
+    expect(res.claims?.org_name).toBe('acme-corp');
+  });
+
+  test('throws when org_name mismatches', async () => {
+    useOrgTokenHandler({ org_name: 'other-corp' });
+    const authClient = newClient();
+    await expect(
+      authClient.getTokenByCode(new URL(`https://${domain}?code=123`), {
+        codeVerifier: '123',
+        organization: 'acme-corp',
+      })
+    ).rejects.toThrow(OrganizationValidationError);
+  });
+
+  test('throws when org_name claim is missing', async () => {
+    useOrgTokenHandler({});
+    const authClient = newClient();
+    await expect(
+      authClient.getTokenByCode(new URL(`https://${domain}?code=123`), {
+        codeVerifier: '123',
+        organization: 'acme-corp',
+      })
+    ).rejects.toThrow(OrganizationValidationError);
+  });
+
+  test('no validation when organization is not set', async () => {
+    useOrgTokenHandler({ org_id: 'org_abc123' });
+    const authClient = newClient();
+    const res = await authClient.getTokenByCode(new URL(`https://${domain}?code=123`), {
+      codeVerifier: '123',
+    });
+    expect(res.accessToken).toBe(accessToken);
+  });
+
+  test('throws a clear error when organization is only whitespace', async () => {
+    useOrgTokenHandler({ org_name: 'acme-corp' });
+    const authClient = newClient();
+    await expect(
+      authClient.getTokenByCode(new URL(`https://${domain}?code=123`), {
+        codeVerifier: '123',
+        organization: '   ',
+      })
+    ).rejects.toThrow('organization must not be blank');
+  });
+
+  test('uses org_id when both org_id and org_name are present and org_ prefix is used', async () => {
+    useOrgTokenHandler({ org_id: 'org_abc123', org_name: 'ignored-name' });
+    const authClient = newClient();
+    const res = await authClient.getTokenByCode(new URL(`https://${domain}?code=123`), {
+      codeVerifier: '123',
+      organization: 'org_abc123',
+    });
+    expect(res.claims?.org_id).toBe('org_abc123');
+  });
 });
 
 test('getTokenByRefreshToken - should return the tokens', async () => {
@@ -2674,6 +2787,75 @@ describe('exchangeToken', () => {
     // Verify that allowed custom params are still forwarded (denylist is selective)
     expect(capturedCustomParam).toBe('allowed');
   });
+
+  describe('organization validation', () => {
+    const useOrgTokenHandler = (orgClaims: Record<string, unknown>) => {
+      server.use(
+        http.post(mockOpenIdConfiguration.token_endpoint, async () => {
+          return HttpResponse.json({
+            access_token: accessToken,
+            id_token: await generateToken(domain, 'user_cte', '<client_id>', undefined, undefined, undefined, orgClaims),
+            expires_in: 3600,
+            token_type: 'Bearer',
+            scope: 'read:default',
+          });
+        })
+      );
+    };
+
+    test('passes when org_id matches', async () => {
+      useOrgTokenHandler({ org_id: 'org_abc123' });
+      const authClient = new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });
+      const result = await authClient.exchangeToken({ ...baseOptions, organization: 'org_abc123' });
+      expect(result.claims?.org_id).toBe('org_abc123');
+    });
+
+    test('throws OrganizationValidationError when org_id mismatches', async () => {
+      useOrgTokenHandler({ org_id: 'org_other' });
+      const authClient = new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });
+      await expect(
+        authClient.exchangeToken({ ...baseOptions, organization: 'org_abc123' })
+      ).rejects.toMatchObject({ name: 'OrganizationValidationError', code: 'organization_validation_error' });
+    });
+
+    test('passes when org_name matches case-insensitively', async () => {
+      useOrgTokenHandler({ org_name: 'acme-corp' });
+      const authClient = new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });
+      const result = await authClient.exchangeToken({ ...baseOptions, organization: 'ACME-Corp' });
+      expect(result.claims?.org_name).toBe('acme-corp');
+    });
+
+    test('throws when org claim is missing', async () => {
+      useOrgTokenHandler({});
+      const authClient = new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });
+      await expect(
+        authClient.exchangeToken({ ...baseOptions, organization: 'org_abc123' })
+      ).rejects.toThrow(OrganizationValidationError);
+    });
+
+    test('skips validation when org is requested but no ID token is returned (access-token-only exchange)', async () => {
+      server.use(
+        http.post(mockOpenIdConfiguration.token_endpoint, async () => {
+          return HttpResponse.json({
+            access_token: accessToken,
+            expires_in: 3600,
+            token_type: 'Bearer',
+            scope: 'read:default',
+          });
+        })
+      );
+      const authClient = new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });
+      const result = await authClient.exchangeToken({ ...baseOptions, organization: 'org_abc123' });
+      expect(result.accessToken).toBe(accessToken);
+    });
+
+    test('no validation when organization is not set', async () => {
+      useOrgTokenHandler({ org_id: 'org_abc123' });
+      const authClient = new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });
+      const result = await authClient.exchangeToken(baseOptions);
+      expect(result.accessToken).toBe(accessToken);
+    });
+  });
 });
 
 describe('Client Authentication for Token Exchange', () => {
@@ -2858,7 +3040,9 @@ describe('exchangeToken with Token Exchange Profile', () => {
         capturedOrganization = info.get('organization') as string;
         return HttpResponse.json({
           access_token: accessToken,
-          id_token: await generateToken(domain, 'user_cte', '<client_id>'),
+          id_token: await generateToken(domain, 'user_cte', '<client_id>', undefined, undefined, undefined, {
+            org_id: 'org_abc123',
+          }),
           expires_in: 3600,
           token_type: 'Bearer',
           scope: 'read:default',

--- a/packages/auth0-auth-js/src/auth-client.spec.ts
+++ b/packages/auth0-auth-js/src/auth-client.spec.ts
@@ -1432,6 +1432,17 @@ describe('getTokenByCode - organization validation', () => {
     ).rejects.toThrow('organization must not be blank');
   });
 
+  test('throws a clear error when organization is an empty string', async () => {
+    useOrgTokenHandler({ org_name: 'acme-corp' });
+    const authClient = newClient();
+    await expect(
+      authClient.getTokenByCode(new URL(`https://${domain}?code=123`), {
+        codeVerifier: '123',
+        organization: '',
+      })
+    ).rejects.toThrow('organization must not be blank');
+  });
+
   test('uses org_id when both org_id and org_name are present and org_ prefix is used', async () => {
     useOrgTokenHandler({ org_id: 'org_abc123', org_name: 'ignored-name' });
     const authClient = newClient();
@@ -2844,12 +2855,34 @@ describe('exchangeToken', () => {
       expect(result.claims?.org_name).toBe('acme-corp');
     });
 
+    test('throws OrganizationValidationError when org_name mismatches', async () => {
+      useOrgTokenHandler({ org_name: 'other-corp' });
+      const authClient = new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });
+      await expect(
+        authClient.exchangeToken({ ...baseOptions, organization: 'acme-corp' })
+      ).rejects.toMatchObject({ name: 'OrganizationValidationError', code: 'organization_validation_error' });
+    });
+
     test('throws when org claim is missing', async () => {
       useOrgTokenHandler({});
       const authClient = new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });
       await expect(
         authClient.exchangeToken({ ...baseOptions, organization: 'org_abc123' })
       ).rejects.toThrow(OrganizationValidationError);
+    });
+
+    test('throws a clear error when organization is only whitespace', async () => {
+      const authClient = new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });
+      await expect(authClient.exchangeToken({ ...baseOptions, organization: '   ' })).rejects.toThrow(
+        'organization must not be blank'
+      );
+    });
+
+    test('throws a clear error when organization is an empty string', async () => {
+      const authClient = new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });
+      await expect(authClient.exchangeToken({ ...baseOptions, organization: '' })).rejects.toThrow(
+        'organization must not be blank'
+      );
     });
 
     test('skips validation when org is requested but no ID token is returned (access-token-only exchange)', async () => {

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -876,9 +876,9 @@ export class AuthClient {
    *
    * @param options Token Exchange Profile configuration (without `connection` parameter)
    * @returns Promise resolving to TokenResponse with Auth0 tokens
-   * @throws {TokenExchangeError} When exchange fails or validation errors occur
+   * @throws {TokenExchangeError} When the token exchange or non-organization option validation fails
    * @throws {MissingClientAuthError} When client authentication is not configured
-   * @throws {OrganizationValidationError} When `organization` is provided and the ID token's organization claim does not match
+   * @throws {OrganizationValidationError} When `organization` is blank, or when an ID token is returned whose organization claim is missing or does not match
    *
    * @example
    * ```typescript
@@ -959,7 +959,7 @@ export class AuthClient {
    * @param options Options for exchanging the authorization code, containing the expected code verifier.
    *
    * @throws {TokenByCodeError} If there was an issue requesting the access token.
-   * @throws {OrganizationValidationError} If the organization claim in the ID token does not match the requested organization.
+   * @throws {OrganizationValidationError} If `organization` is blank, or if an ID token is returned whose organization claim is missing or does not match.
    *
    * @returns A Promise, resolving to the TokenResponse as returned from Auth0.
    */

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -18,9 +18,8 @@ import {
   TokenByRefreshTokenError,
   TokenForConnectionError,
   VerifyLogoutTokenError,
-  OrganizationValidationError,
 } from './errors.js';
-import { stripUndefinedProperties, validateOrganization } from './utils.js';
+import { stripUndefinedProperties, assertValidOrganization, validateOrganizationClaim } from './utils.js';
 import { MfaClient } from './mfa/mfa-client.js';
 import { PasskeyClient, PASSKEY_GRANT_TYPE } from './passkey/passkey-client.js';
 import { createTelemetryFetch, getTelemetryConfig } from './telemetry.js';
@@ -792,6 +791,10 @@ export class AuthClient {
 
     validateSubjectToken(options.subjectToken);
 
+    if (options.organization !== undefined) {
+      assertValidOrganization(options.organization);
+    }
+
     if (options.actorToken !== undefined && options.actorTokenType === undefined) {
       throw new TokenExchangeError('actorTokenType is required when actorToken is provided');
     }
@@ -822,40 +825,40 @@ export class AuthClient {
 
     appendExtraParams(tokenRequestParams, options.extra);
 
+    let tokenResponse: TokenResponse;
+    let tokenEndpointResponse: Awaited<ReturnType<typeof client.genericGrantRequest>>;
     try {
-      const tokenEndpointResponse = await client.genericGrantRequest(
+      tokenEndpointResponse = await client.genericGrantRequest(
         configuration,
         TOKEN_EXCHANGE_GRANT_TYPE,
         tokenRequestParams
       );
 
-      const tokenResponse = TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
-
-      if (options.organization) {
-        validateOrganization(tokenResponse.claims, options.organization);
-      }
-
-      if (options.actorToken) {
-        if (tokenResponse.claims?.act) {
-          tokenResponse.act = tokenResponse.claims.act as ActClaim;
-        } else {
-          try {
-            tokenResponse.act = decodeJwt(tokenEndpointResponse.access_token).act as ActClaim | undefined;
-          } catch {
-            // opaque access token — act claim not available
-          }
-        }
-      }
-      return tokenResponse;
+      tokenResponse = TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
     } catch (e) {
-      if (e instanceof OrganizationValidationError) {
-        throw e;
-      }
       throw new TokenExchangeError(
         `Failed to exchange token of type '${options.subjectTokenType}'${options.audience ? ` for audience '${options.audience}'` : ''}.`,
         toOAuth2Error(e)
       );
     }
+
+    if (options.organization) {
+      validateOrganizationClaim(tokenResponse.claims, options.organization);
+    }
+
+    if (options.actorToken) {
+      if (tokenResponse.claims?.act) {
+        tokenResponse.act = tokenResponse.claims.act as ActClaim;
+      } else {
+        try {
+          tokenResponse.act = decodeJwt(tokenEndpointResponse.access_token).act as ActClaim | undefined;
+        } catch {
+          // opaque access token — act claim not available
+        }
+      }
+    }
+
+    return tokenResponse;
   }
 
   /**
@@ -962,24 +965,27 @@ export class AuthClient {
    */
   public async getTokenByCode(url: URL, options: TokenByCodeOptions): Promise<TokenResponse> {
     const { configuration } = await this.#discover();
+
+    if (options.organization !== undefined) {
+      assertValidOrganization(options.organization);
+    }
+
+    let tokenResponse: TokenResponse;
     try {
       const tokenEndpointResponse = await client.authorizationCodeGrant(configuration, url, {
         pkceCodeVerifier: options.codeVerifier,
       });
 
-      const tokenResponse = TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
-
-      if (options.organization) {
-        validateOrganization(tokenResponse.claims, options.organization);
-      }
-
-      return tokenResponse;
+      tokenResponse = TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
     } catch (e) {
-      if (e instanceof OrganizationValidationError) {
-        throw e;
-      }
       throw new TokenByCodeError('There was an error while trying to request a token.', toOAuth2Error(e));
     }
+
+    if (options.organization) {
+      validateOrganizationClaim(tokenResponse.claims, options.organization);
+    }
+
+    return tokenResponse;
   }
 
   /**

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -18,8 +18,9 @@ import {
   TokenByRefreshTokenError,
   TokenForConnectionError,
   VerifyLogoutTokenError,
+  OrganizationValidationError,
 } from './errors.js';
-import { stripUndefinedProperties } from './utils.js';
+import { stripUndefinedProperties, validateOrganization } from './utils.js';
 import { MfaClient } from './mfa/mfa-client.js';
 import { PasskeyClient, PASSKEY_GRANT_TYPE } from './passkey/passkey-client.js';
 import { createTelemetryFetch, getTelemetryConfig } from './telemetry.js';
@@ -829,6 +830,11 @@ export class AuthClient {
       );
 
       const tokenResponse = TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
+
+      if (options.organization) {
+        validateOrganization(tokenResponse.claims, options.organization);
+      }
+
       if (options.actorToken) {
         if (tokenResponse.claims?.act) {
           tokenResponse.act = tokenResponse.claims.act as ActClaim;
@@ -842,6 +848,9 @@ export class AuthClient {
       }
       return tokenResponse;
     } catch (e) {
+      if (e instanceof OrganizationValidationError) {
+        throw e;
+      }
       throw new TokenExchangeError(
         `Failed to exchange token of type '${options.subjectTokenType}'${options.audience ? ` for audience '${options.audience}'` : ''}.`,
         toOAuth2Error(e)
@@ -858,10 +867,15 @@ export class AuthClient {
    * services) for Auth0 tokens targeting a specific API audience. Requires a Token
    * Exchange Profile configured in Auth0.
    *
+   * When `organization` is provided, the returned ID token's organization claim is
+   * validated against it (an `org_` prefix is matched exactly against `org_id`,
+   * otherwise the value is matched case-insensitively against `org_name`).
+   *
    * @param options Token Exchange Profile configuration (without `connection` parameter)
    * @returns Promise resolving to TokenResponse with Auth0 tokens
    * @throws {TokenExchangeError} When exchange fails or validation errors occur
    * @throws {MissingClientAuthError} When client authentication is not configured
+   * @throws {OrganizationValidationError} When `organization` is provided and the ID token's organization claim does not match
    *
    * @example
    * ```typescript
@@ -942,6 +956,7 @@ export class AuthClient {
    * @param options Options for exchanging the authorization code, containing the expected code verifier.
    *
    * @throws {TokenByCodeError} If there was an issue requesting the access token.
+   * @throws {OrganizationValidationError} If the organization claim in the ID token does not match the requested organization.
    *
    * @returns A Promise, resolving to the TokenResponse as returned from Auth0.
    */
@@ -952,8 +967,17 @@ export class AuthClient {
         pkceCodeVerifier: options.codeVerifier,
       });
 
-      return TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
+      const tokenResponse = TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
+
+      if (options.organization) {
+        validateOrganization(tokenResponse.claims, options.organization);
+      }
+
+      return tokenResponse;
     } catch (e) {
+      if (e instanceof OrganizationValidationError) {
+        throw e;
+      }
       throw new TokenByCodeError('There was an error while trying to request a token.', toOAuth2Error(e));
     }
   }

--- a/packages/auth0-auth-js/src/errors.ts
+++ b/packages/auth0-auth-js/src/errors.ts
@@ -287,3 +287,20 @@ export class MissingClientAuthError extends Error {
     this.name = 'MissingClientAuthError';
   }
 }
+
+/**
+ * Error thrown when the organization claim (`org_id` or `org_name`) in the
+ * returned ID token does not match the organization requested at login.
+ *
+ * This is a post-exchange claim-validation failure — the token request itself
+ * succeeded. It therefore extends plain `Error` and does not carry an OAuth2
+ * error cause.
+ */
+export class OrganizationValidationError extends Error {
+  public code: string = 'organization_validation_error';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'OrganizationValidationError';
+  }
+}

--- a/packages/auth0-auth-js/src/passkey/passkey-client.spec.ts
+++ b/packages/auth0-auth-js/src/passkey/passkey-client.spec.ts
@@ -1179,6 +1179,17 @@ describe('PasskeyClient', () => {
         expect(result.claims?.org_name).toBe('acme-corp');
       });
 
+      test('throws OrganizationValidationError when org_name mismatches', async () => {
+        const client = createClient({ grantRequest: grantRequestWithClaims({ org_name: 'other-corp' }) });
+        await expect(
+          client.getTokenByPasskey({
+            authSession: 'eyJ_session',
+            credential: mockCredentialCreation,
+            organization: 'acme-corp',
+          })
+        ).rejects.toMatchObject({ name: 'OrganizationValidationError', code: 'organization_validation_error' });
+      });
+
       test('throws when org claim is missing', async () => {
         const client = createClient({ grantRequest: grantRequestWithClaims({}) });
         await expect(
@@ -1188,6 +1199,28 @@ describe('PasskeyClient', () => {
             organization: 'org_abc123',
           })
         ).rejects.toThrow(OrganizationValidationError);
+      });
+
+      test('throws a clear error when organization is only whitespace', async () => {
+        const client = createClient({ grantRequest: grantRequestWithClaims({ org_name: 'acme-corp' }) });
+        await expect(
+          client.getTokenByPasskey({
+            authSession: 'eyJ_session',
+            credential: mockCredentialCreation,
+            organization: '   ',
+          })
+        ).rejects.toThrow('organization must not be blank');
+      });
+
+      test('throws a clear error when organization is an empty string', async () => {
+        const client = createClient({ grantRequest: grantRequestWithClaims({ org_name: 'acme-corp' }) });
+        await expect(
+          client.getTokenByPasskey({
+            authSession: 'eyJ_session',
+            credential: mockCredentialCreation,
+            organization: '',
+          })
+        ).rejects.toThrow('organization must not be blank');
       });
 
       test('no validation when organization is not set', async () => {

--- a/packages/auth0-auth-js/src/passkey/passkey-client.spec.ts
+++ b/packages/auth0-auth-js/src/passkey/passkey-client.spec.ts
@@ -1198,6 +1198,22 @@ describe('PasskeyClient', () => {
         });
         expect(result.accessToken).toBe('eyJ_access_token');
       });
+
+      test('skips validation when org is requested but no ID token is returned', async () => {
+        // grantRequest returns a TokenResponse with no ID-token claims.
+        const grantRequest: GrantRequestFn = async () => {
+          const response = new TokenResponse('eyJ_access_token', Math.floor(Date.now() / 1000) + 86400);
+          response.tokenType = 'Bearer';
+          return response;
+        };
+        const client = createClient({ grantRequest });
+        const result = await client.getTokenByPasskey({
+          authSession: 'eyJ_session',
+          credential: mockCredentialCreation,
+          organization: 'org_abc123',
+        });
+        expect(result.accessToken).toBe('eyJ_access_token');
+      });
     });
   });
 

--- a/packages/auth0-auth-js/src/passkey/passkey-client.spec.ts
+++ b/packages/auth0-auth-js/src/passkey/passkey-client.spec.ts
@@ -9,7 +9,7 @@ import {
 } from './errors.js';
 import type { GrantRequestFn } from './types.js';
 import { TokenResponse } from '../types.js';
-import { isMfaRequiredError } from '../errors.js';
+import { isMfaRequiredError, OrganizationValidationError } from '../errors.js';
 
 const domain = 'auth0.local';
 const clientId = 'test-client-id';
@@ -917,7 +917,18 @@ describe('PasskeyClient', () => {
     });
 
     test('includes organization param when provided', async () => {
-      const grantRequest = vi.fn(createMockGrantRequest());
+      const grantRequest = vi.fn(async () => {
+        const response = new TokenResponse(
+          'eyJ_access_token',
+          Math.floor(Date.now() / 1000) + 86400,
+          'eyJ_id_token',
+          'eyJ_refresh_token',
+          undefined,
+          { org_id: 'org_abc123' } as unknown as TokenResponse['claims']
+        );
+        response.tokenType = 'Bearer';
+        return response;
+      });
       const client = createClient({ grantRequest });
 
       await client.getTokenByPasskey({
@@ -1118,6 +1129,75 @@ describe('PasskeyClient', () => {
         expect(error.cause?.error).toBe('mfa_required');
         expect(error.cause?.mfa_token).toBeUndefined();
       }
+    });
+
+    describe('organization validation', () => {
+      // grantRequest returning a TokenResponse whose ID-token claims are the given object.
+      const grantRequestWithClaims = (claims: Record<string, unknown>): GrantRequestFn => {
+        return async () => {
+          const response = new TokenResponse(
+            'eyJ_access_token',
+            Math.floor(Date.now() / 1000) + 86400,
+            'eyJ_id_token',
+            'eyJ_refresh_token',
+            undefined,
+            claims as unknown as TokenResponse['claims']
+          );
+          response.tokenType = 'Bearer';
+          return response;
+        };
+      };
+
+      test('passes when org_id matches', async () => {
+        const client = createClient({ grantRequest: grantRequestWithClaims({ org_id: 'org_abc123' }) });
+        const result = await client.getTokenByPasskey({
+          authSession: 'eyJ_session',
+          credential: mockCredentialCreation,
+          organization: 'org_abc123',
+        });
+        expect(result.claims?.org_id).toBe('org_abc123');
+      });
+
+      test('throws OrganizationValidationError when org_id mismatches', async () => {
+        const client = createClient({ grantRequest: grantRequestWithClaims({ org_id: 'org_other' }) });
+        await expect(
+          client.getTokenByPasskey({
+            authSession: 'eyJ_session',
+            credential: mockCredentialCreation,
+            organization: 'org_abc123',
+          })
+        ).rejects.toMatchObject({ name: 'OrganizationValidationError', code: 'organization_validation_error' });
+      });
+
+      test('passes when org_name matches case-insensitively', async () => {
+        const client = createClient({ grantRequest: grantRequestWithClaims({ org_name: 'acme-corp' }) });
+        const result = await client.getTokenByPasskey({
+          authSession: 'eyJ_session',
+          credential: mockCredentialCreation,
+          organization: 'ACME-Corp',
+        });
+        expect(result.claims?.org_name).toBe('acme-corp');
+      });
+
+      test('throws when org claim is missing', async () => {
+        const client = createClient({ grantRequest: grantRequestWithClaims({}) });
+        await expect(
+          client.getTokenByPasskey({
+            authSession: 'eyJ_session',
+            credential: mockCredentialCreation,
+            organization: 'org_abc123',
+          })
+        ).rejects.toThrow(OrganizationValidationError);
+      });
+
+      test('no validation when organization is not set', async () => {
+        const client = createClient({ grantRequest: grantRequestWithClaims({ org_id: 'org_abc123' }) });
+        const result = await client.getTokenByPasskey({
+          authSession: 'eyJ_session',
+          credential: mockCredentialCreation,
+        });
+        expect(result.accessToken).toBe('eyJ_access_token');
+      });
     });
   });
 

--- a/packages/auth0-auth-js/src/passkey/passkey-client.ts
+++ b/packages/auth0-auth-js/src/passkey/passkey-client.ts
@@ -179,7 +179,7 @@ export class PasskeyClient {
    * @param options - The auth session and serialized credential response
    * @returns Promise resolving to a TokenResponse with access token, ID token, and optional refresh token
    * @throws {PasskeyGetTokenError} When the token exchange fails, or when no client credentials are configured
-   * @throws {OrganizationValidationError} When `organization` is provided and the ID token's organization claim does not match
+   * @throws {OrganizationValidationError} When `organization` is blank, or when an ID token is returned whose organization claim is missing or does not match
    *
    * @example
    * ```typescript

--- a/packages/auth0-auth-js/src/passkey/passkey-client.ts
+++ b/packages/auth0-auth-js/src/passkey/passkey-client.ts
@@ -11,7 +11,7 @@ import type {
 } from './types.js';
 import type { TokenResponse } from '../types.js';
 import { toOAuth2Error } from '../errors.js';
-import { validateOrganization } from '../utils.js';
+import { assertValidOrganization, validateOrganizationClaim } from '../utils.js';
 import {
   PasskeyRegisterError,
   PasskeyChallengeError,
@@ -195,6 +195,10 @@ export class PasskeyClient {
    * ```
    */
   async getTokenByPasskey(options: GetTokenByPasskeyOptions): Promise<TokenResponse> {
+    if (options.organization !== undefined) {
+      assertValidOrganization(options.organization);
+    }
+
     const params = new URLSearchParams({
       auth_session: options.authSession,
       authn_response: JSON.stringify(options.credential),
@@ -217,7 +221,7 @@ export class PasskeyClient {
     }
 
     if (options.organization) {
-      validateOrganization(tokenResponse.claims, options.organization);
+      validateOrganizationClaim(tokenResponse.claims, options.organization);
     }
 
     return tokenResponse;

--- a/packages/auth0-auth-js/src/passkey/passkey-client.ts
+++ b/packages/auth0-auth-js/src/passkey/passkey-client.ts
@@ -11,6 +11,7 @@ import type {
 } from './types.js';
 import type { TokenResponse } from '../types.js';
 import { toOAuth2Error } from '../errors.js';
+import { validateOrganization } from '../utils.js';
 import {
   PasskeyRegisterError,
   PasskeyChallengeError,
@@ -171,9 +172,14 @@ export class PasskeyClient {
    * client credentials it throws a `PasskeyGetTokenError` whose `cause` reports
    * that a client secret or client assertion signing key is required.
    *
+   * When `organization` is provided, the returned ID token's organization claim is
+   * validated against it (an `org_` prefix is matched exactly against `org_id`,
+   * otherwise the value is matched case-insensitively against `org_name`).
+   *
    * @param options - The auth session and serialized credential response
    * @returns Promise resolving to a TokenResponse with access token, ID token, and optional refresh token
    * @throws {PasskeyGetTokenError} When the token exchange fails, or when no client credentials are configured
+   * @throws {OrganizationValidationError} When `organization` is provided and the ID token's organization claim does not match
    *
    * @example
    * ```typescript
@@ -199,8 +205,9 @@ export class PasskeyClient {
     if (options.audience) params.append('audience', options.audience);
     if (options.organization) params.append('organization', options.organization);
 
+    let tokenResponse: TokenResponse;
     try {
-      return await this.#grantRequest(PASSKEY_GRANT_TYPE, params);
+      tokenResponse = await this.#grantRequest(PASSKEY_GRANT_TYPE, params);
     } catch (e) {
       const apiError = toOAuth2Error(e);
       throw new PasskeyGetTokenError(
@@ -208,5 +215,11 @@ export class PasskeyClient {
         apiError,
       );
     }
+
+    if (options.organization) {
+      validateOrganization(tokenResponse.claims, options.organization);
+    }
+
+    return tokenResponse;
   }
 }

--- a/packages/auth0-auth-js/src/types.ts
+++ b/packages/auth0-auth-js/src/types.ts
@@ -264,6 +264,15 @@ export interface TokenByCodeOptions {
    * The code verifier that is used for the authorization request.
    */
   codeVerifier: string;
+  /**
+   * The organization that was requested at login, if any.
+   * When set, {@link AuthClient#getTokenByCode} validates the returned ID token's
+   * organization claim against it:
+   * - a value with the `org_` prefix is matched exactly (case-sensitive) against `org_id`;
+   * - any other value is matched case-insensitively against `org_name`.
+   * A mismatch (or a missing claim) throws {@link OrganizationValidationError}.
+   */
+  organization?: string;
 }
 
 /**

--- a/packages/auth0-auth-js/src/utils.ts
+++ b/packages/auth0-auth-js/src/utils.ts
@@ -12,6 +12,21 @@ export function stripUndefinedProperties<T extends object>(value: T): Partial<T>
 }
 
 /**
+ * Asserts that a requested organization is a usable (non-blank) value.
+ *
+ * This is an input-shape check, intended to run before the token request so that
+ * malformed input fails fast — consistent with the other up-front option checks
+ * (e.g. subject-token validation) rather than only after a network round-trip.
+ *
+ * @throws {OrganizationValidationError} when `organization` is blank or whitespace-only.
+ */
+export function assertValidOrganization(organization: string): void {
+  if (!organization.trim()) {
+    throw new OrganizationValidationError('organization must not be blank');
+  }
+}
+
+/**
  * Validates the organization claim in an ID token against the requested organization.
  * - an `org_`-prefixed value is matched exactly (case-sensitive) against `org_id`;
  * - any other value is matched case-insensitively against `org_name`.
@@ -21,19 +36,17 @@ export function stripUndefinedProperties<T extends object>(value: T): Partial<T>
  * for example, token-exchange flows that return only an access token. When an ID token
  * is present, a missing or mismatched organization claim throws.
  *
- * @throws {OrganizationValidationError} when `organization` is blank, or when an ID
- * token is present and its organization claim is missing or does not match.
+ * Assumes `organization` has already passed {@link assertValidOrganization}.
+ *
+ * @throws {OrganizationValidationError} when an ID token is present and its
+ * organization claim is missing or does not match.
  */
-export function validateOrganization(claims: IDToken | undefined, organization: string): void {
-  const org = organization.trim();
-
-  if (!org) {
-    throw new OrganizationValidationError('organization must not be blank');
-  }
-
+export function validateOrganizationClaim(claims: IDToken | undefined, organization: string): void {
   if (!claims) {
     return;
   }
+
+  const org = organization.trim();
 
   if (org.startsWith('org_')) {
     const actual = claims.org_id;

--- a/packages/auth0-auth-js/src/utils.ts
+++ b/packages/auth0-auth-js/src/utils.ts
@@ -36,7 +36,7 @@ export function validateOrganization(claims: IDToken | undefined, organization: 
   }
 
   if (org.startsWith('org_')) {
-    const actual = claims?.org_id;
+    const actual = claims.org_id;
     if (typeof actual !== 'string') {
       throw new OrganizationValidationError('Organization Id (org_id) claim must be a string present in the ID token');
     }
@@ -46,7 +46,7 @@ export function validateOrganization(claims: IDToken | undefined, organization: 
       );
     }
   } else {
-    const actual = claims?.org_name;
+    const actual = claims.org_name;
     if (typeof actual !== 'string') {
       throw new OrganizationValidationError(
         'Organization Name (org_name) claim must be a string present in the ID token'

--- a/packages/auth0-auth-js/src/utils.ts
+++ b/packages/auth0-auth-js/src/utils.ts
@@ -1,3 +1,6 @@
+import type { IDToken } from 'openid-client';
+import { OrganizationValidationError } from './errors.js';
+
 /**
  * Helper function that removes properties from an object when the value is undefined.
  * @returns The object, without the properties whose values are undefined.
@@ -6,4 +9,53 @@ export function stripUndefinedProperties<T extends object>(value: T): Partial<T>
   return Object.entries(value)
     .filter(([, value]) => typeof value !== 'undefined')
     .reduce((acc, curr) => ({ ...acc, [curr[0]]: curr[1] }), {});
+}
+
+/**
+ * Validates the organization claim in an ID token against the requested organization.
+ * - an `org_`-prefixed value is matched exactly (case-sensitive) against `org_id`;
+ * - any other value is matched case-insensitively against `org_name`.
+ *
+ * Validation only applies when an ID token was returned. If no ID token is present
+ * (`claims` is undefined) there is nothing to validate and the function is a no-op —
+ * for example, token-exchange flows that return only an access token. When an ID token
+ * is present, a missing or mismatched organization claim throws.
+ *
+ * @throws {OrganizationValidationError} when `organization` is blank, or when an ID
+ * token is present and its organization claim is missing or does not match.
+ */
+export function validateOrganization(claims: IDToken | undefined, organization: string): void {
+  const org = organization.trim();
+
+  if (!org) {
+    throw new OrganizationValidationError('organization must not be blank');
+  }
+
+  if (!claims) {
+    return;
+  }
+
+  if (org.startsWith('org_')) {
+    const actual = claims?.org_id;
+    if (typeof actual !== 'string') {
+      throw new OrganizationValidationError('Organization Id (org_id) claim must be a string present in the ID token');
+    }
+    if (actual !== org) {
+      throw new OrganizationValidationError(
+        `Organization Id (org_id) claim value mismatch in the ID token; expected "${org}", found "${actual}"`
+      );
+    }
+  } else {
+    const actual = claims?.org_name;
+    if (typeof actual !== 'string') {
+      throw new OrganizationValidationError(
+        'Organization Name (org_name) claim must be a string present in the ID token'
+      );
+    }
+    if (actual.toLowerCase() !== org.toLowerCase()) {
+      throw new OrganizationValidationError(
+        `Organization Name (org_name) claim value mismatch in the ID token; expected "${org}", found "${actual}"`
+      );
+    }
+  }
 }


### PR DESCRIPTION
### Description

Adds organization claim validation to the `auth0-auth-js` token methods that support organizations and return a user ID token. When `organization` is provided, the returned ID token's organization claim is validated against it:
- an organization ID (the `org_` prefix) is matched **exactly** (case-sensitive) against the `org_id` claim;
- an organization name (no `org_` prefix) is matched **case-insensitively** against the `org_name` claim.

A missing or mismatched claim throws a new `OrganizationValidationError`. Validation is **opt-in** (it only runs when `organization` is provided) and only applies **when an ID token is present** — exchanges that return only an access token (e.g. M2M token exchange) are a no-op, since there is no ID-token claim to validate.
Validation is applied to the three methods the platform supports `organization` on with a user ID token:
- `AuthClient.getTokenByCode`
- `AuthClient.exchangeToken` (custom token exchange profile path)
- `PasskeyClient.getTokenByPasskey`

The validation messaging follows the SDK Organizations validation guidance.

### Changes

- Add `OrganizationValidationError` (code `organization_validation_error`, extends `Error`) — a post-exchange claim-validation failure, distinct from the OAuth token-request errors. Not rewrapped as `TokenByCodeError` / `TokenExchangeError`.
- Add a shared `validateOrganization()` helper (internal to the package) used by all three call sites.
- Add optional `organization` to `TokenByCodeOptions` (already present on the passkey and exchange option types).
- Document the behavior and `OrganizationValidationError` in `EXAMPLES.md` for all three methods.

 ### Behavior change (note for existing callers)
`exchangeToken` (custom token exchange profile path) and `PasskeyClient.getTokenByPasskey` already accepted and forwarded the `organization` parameter but the returned ID token's organization claim was **not** validated. As of this change, when `organization` is provided **and** the response includes an ID token, a missing or mismatched `org_id`/`org_name` claim now throws `OrganizationValidationError`.

- This only affects callers who **already pass `organization`** to these methods. Callers who don't pass it are unaffected.
- Exchanges that return only an access token (no ID token, e.g. M2M) are unchanged — there is no ID-token claim to validate, so validation is a no-op.
- `getTokenByCode` is new behavior in the same release (it now validates the claim when `organization` is provided).

### Testing
- [x] Unit tests for each method covering `org_id` exact match / mismatch / missing, `org_name` case-insensitive match / mismatch / missing, blank input, no-ID-token (no-op) and the no-op path when `organization` is unset.
- [x] Full `auth0-auth-js` suite green; `auth0-api-js` consumer suite green; build and lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added organization claim validation for token exchange methods (`getTokenByCode`, `exchangeToken`, `getTokenByPasskey`) with optional `organization` parameter
  * New `OrganizationValidationError` thrown when organization claims mismatch

* **Tests**
  * Added comprehensive test coverage for organization validation scenarios

* **Documentation**
  * Updated examples documenting organization claim validation behavior and matching rules
<!-- end of auto-generated comment: release notes by coderabbit.ai -->