### PR TITLE
chore: fix failing tests

### DIFF
--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -4932,7 +4932,7 @@ test('passkeyGetToken - should forward audience and organization to the grant', 
       capturedOrganization = info.get('organization')?.toString() ?? null;
       return HttpResponse.json({
         access_token: accessToken,
-        id_token: await generateToken(domain, 'user_123', '<client_id>'),
+        id_token: await generateToken(domain, 'user_123', '<client_id>', undefined, { org_id: 'org_123' }),
         expires_in: 60,
         token_type: 'Bearer',
         scope: '<scope>',

--- a/packages/auth0-server-js/src/test-utils/tokens.ts
+++ b/packages/auth0-server-js/src/test-utils/tokens.ts
@@ -25,11 +25,12 @@ export const generateToken = async (
   domain: string,
   userId: string,
   audience?: string,
-  issuer?: string | false
+  issuer?: string | false,
+  claims?: Record<string, unknown>
 ) => {
   const privateKey = await jose.importJWK(jwk, alg);
 
-  let jwtBuilder = new jose.SignJWT({ 'urn:example:claim': true }).setProtectedHeader({ alg }).setIssuedAt();
+  let jwtBuilder = new jose.SignJWT({ 'urn:example:claim': true, ...claims }).setProtectedHeader({ alg }).setIssuedAt();
 
   if (issuer !== false) {
     jwtBuilder = jwtBuilder.setIssuer(issuer ?? `https://${domain}/`);


### PR DESCRIPTION
## Description

Fixes the `auth0-server-js` test suite, which broke after #200 added organization claim validation to `auth0-auth-js`. `ServerClient.passkeyGetToken` delegates to core's `getTokenByPasskey`, which now validates the returned ID token's org claim when `organization` is provided. The test `passkeyGetToken - should forward audience and organization to the grant` passed `organization: 'org_123'` but its mocked ID token carried no `org_id` claim, so validation threw `OrganizationValidationError`.

## Changes
- `test-utils/tokens.ts`: add an optional `claims` argument to `generateToken` so tests can mint ID tokens with specific claims (mirrors the core test helper).
- `server-client.spec.ts`: the passkey forward test now returns an ID token with a matching `org_id: 'org_123'`, so it still asserts forwarding and passes validation.

Test-only change; no SDK/runtime behavior is affected.

## Testing
- [x] `auth0-server-js` suite green (249 tests); full workspace green; build + lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced token generation utility to support configurable custom claims, enabling more flexible and comprehensive test scenarios.
  * Updated token generation tests to properly reflect organization context handling for improved coverage accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->