### PR TITLE
refactor: Moved passkeys API to a new passkey client

### DIFF
--- a/packages/auth0-server-js/EXAMPLES.md
+++ b/packages/auth0-server-js/EXAMPLES.md
@@ -349,7 +349,7 @@ const authorizationUrl = await serverClient.startInteractiveLogin();
 - **Custom Fetch Required**: You must provide a `customFetch` implementation that includes the client certificate in the TLS handshake.
 - **Store Configuration**: mTLS works with both stateless and stateful store configurations.
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > mTLS requires proper certificate management and Auth0 tenant configuration. Make sure your Auth0 tenant supports mTLS endpoints and that your client certificates are properly configured in the Auth0 Dashboard. Learn how to configure mTLS in your Auth0 tenant by reading the [mTLS configuration documentation](https://auth0.com/docs/get-started/applications/configure-mtls).
 
 ### Configuring the `authorizationParams` globally
@@ -429,7 +429,7 @@ Resolver mode is intended for the custom domains of a single `Auth0` tenant. It 
 ### Dynamic Domain Resolver
 
 Provide a resolver function to select the domain at runtime. The resolver should return the `Auth0 Custom Domain` (for example, `brand-1.custom-domain.com`). Returning `null` or an empty value throws `InvalidConfigurationError`.
-The resolver receives a `context` object, which is the same `storeOptions` object passed to SDK method calls. 
+The resolver receives a `context` object, which is the same `storeOptions` object passed to SDK method calls.
 
 
 In framework integrations (or higher-level framework SDKs), this is usually provided by the integration layer and contains request-specific values (for example `{ request, reply }` in Fastify).
@@ -533,7 +533,7 @@ const authorizationUrl = await auth0.startInteractiveLogin(
 
 In the [Fastify example](#mcd-fastify-example) above, the `/auth/login` handler already shows this pattern by resolving `redirect_uri` per request. You must implement `resolveRedirectUri(request)` in your app and validate host/scheme safely for your deployment.
 
-> [!NOTE] 
+> [!NOTE]
 >
 > In [Resolver Mode](#resolver-mode), MCD needs an ID token in the callback so the SDK can validate the `iss` claim.
 > The `openid` scope is required to receive an ID token.
@@ -919,25 +919,25 @@ Passkeys let users sign up and log in with a WebAuthn credential (for example, a
 
 Because the WebAuthn ceremony (`navigator.credentials.create()` / `navigator.credentials.get()`) can only run in the browser, the flow is split across an HTTP round-trip between the browser and your server:
 
-1. The browser asks your server for a challenge. Your server calls `passkeyRegister()` (signup) or `passkeyChallenge()` (login) and returns the result to the browser.
+1. The browser asks your server for a challenge. Your server calls `passkey.register()` (signup) or `passkey.challenge()` (login) and returns the result to the browser.
 2. The browser runs the WebAuthn ceremony using `authnParamsPublicKey`, and sends the resulting credential — together with the `authSession` from step 1 — back to your server.
-3. Your server calls `passkeyGetToken()` to exchange the credential for tokens and create the session.
+3. Your server calls `passkey.getToken()` to exchange the credential for tokens and create the session.
 
 > [!IMPORTANT]
 > Before using passkeys, ensure the following are configured in your [Auth0 Dashboard](https://manage.auth0.com):
 >
 > 1. **Enable the passkey authentication method**: Go to **Authentication** > **Database** > your connection > **Authentication Methods** > **Passkey**.
-> 2. **Enable the WebAuthn passkey grant**: Go to your **Application** > **Advanced Settings** > **Grant Types** and enable the **Passkey** grant. `passkeyGetToken()` exchanges the credential via this grant, so the token exchange fails without it.
+> 2. **Enable the WebAuthn passkey grant**: Go to your **Application** > **Advanced Settings** > **Grant Types** and enable the **Passkey** grant. `passkey.getToken()` exchanges the credential via this grant, so the token exchange fails without it.
 > 3. **A custom domain is required**: Passkeys are bound to an origin (domain). A [custom domain](https://auth0.com/docs/customize/custom-domains) must be configured — passkeys will not work on the default `*.auth0.com` domain.
 >
 > Read [the Auth0 docs](https://auth0.com/docs/authenticate/database-connections/passkeys) to learn more about passkeys.
 
 ### Requesting a Signup Challenge
 
-To register a new user, call `passkeyRegister()` with the user's profile and return the result to the browser:
+To register a new user, call `passkey.register()` with the user's profile and return the result to the browser:
 
 ```ts
-const { authSession, authnParamsPublicKey } = await serverClient.passkeyRegister({
+const { authSession, authnParamsPublicKey } = await serverClient.passkey.register({
   email: 'user@example.com',
   name: 'Jane Doe',
 });
@@ -950,10 +950,10 @@ This method does not create a session.
 
 ### Requesting a Login Challenge
 
-To log in an existing user, call `passkeyChallenge()` and return the result to the browser:
+To log in an existing user, call `passkey.challenge()` and return the result to the browser:
 
 ```ts
-const { authSession, authnParamsPublicKey } = await serverClient.passkeyChallenge();
+const { authSession, authnParamsPublicKey } = await serverClient.passkey.challenge();
 ```
 
 - `authnParamsPublicKey`: WebAuthn credential request options. The browser passes these to `navigator.credentials.get()`.
@@ -963,24 +963,24 @@ This method does not create a session.
 
 ### Completing the Passkey Flow
 
-After the browser has run the WebAuthn ceremony, it sends the serialized credential and the `authSession` back to your server. Call `passkeyGetToken()` to exchange them for tokens and create the session:
+After the browser has run the WebAuthn ceremony, it sends the serialized credential and the `authSession` back to your server. Call `passkey.getToken()` to exchange them for tokens and create the session:
 
 ```ts
-await serverClient.passkeyGetToken({
+await serverClient.passkey.getToken({
   authSession,
   credential,
 });
 ```
 
-- `authSession`: The flow-state token returned by `passkeyRegister()` or `passkeyChallenge()`.
+- `authSession`: The flow-state token returned by `passkey.register()` or `passkey.challenge()`.
 - `credential`: The serialized credential from `navigator.credentials.create()` (signup) or `navigator.credentials.get()` (login).
 
 On success, the resulting session is persisted to the State Store, exactly like an interactive login. Afterwards, [`getUser()`](#retrieving-the-logged-in-user), [`getAccessToken()`](#retrieving-an-access-token) and [`logout()`](#logout) all work as usual.
 
-When using Rich Authorization Requests (RAR), `passkeyGetToken()` returns the granted `authorizationDetails`:
+When using Rich Authorization Requests (RAR), `passkey.getToken()` returns the granted `authorizationDetails`:
 
 ```ts
-const { authorizationDetails } = await serverClient.passkeyGetToken({
+const { authorizationDetails } = await serverClient.passkey.getToken({
   authSession,
   credential,
 });
@@ -988,13 +988,13 @@ const { authorizationDetails } = await serverClient.passkeyGetToken({
 
 #### Handling an `mfa_required` response
 
-When MFA is enabled, `passkeyGetToken()` can fail with an `mfa_required` response: the passkey is verified, but the user must still complete a second factor. The thrown `PasskeyGetTokenError` carries `cause.mfa_token` and `cause.mfa_requirements`, and **no session is persisted**. Use the `isMfaRequiredError` type guard to detect it and continue with the MFA APIs exposed on `serverClient.mfa`:
+When MFA is enabled, `passkey.getToken()` can fail with an `mfa_required` response: the passkey is verified, but the user must still complete a second factor. The thrown `PasskeyGetTokenError` carries `cause.mfa_token` and `cause.mfa_requirements`, and **no session is persisted**. Use the `isMfaRequiredError` type guard to detect it and continue with the MFA APIs exposed on `serverClient.mfa`:
 
 ```ts
 import { isMfaRequiredError } from '@auth0/auth0-server-js';
 
 try {
-  await serverClient.passkeyGetToken({ authSession, credential });
+  await serverClient.passkey.getToken({ authSession, credential });
 } catch (error) {
   if (isMfaRequiredError(error)) {
     // error.cause.mfa_token is guaranteed to be a string here
@@ -1011,15 +1011,18 @@ try {
 
 The passkey methods accept a final `storeOptions` argument. Its behavior differs per method:
 
-- `passkeyRegister()` and `passkeyChallenge()` do not persist any state. In resolver mode, `storeOptions` is only used to resolve the custom domain.
-- `passkeyGetToken()` persists the resulting session via the configured `stateStore`, passing `storeOptions` along to it (and using it for domain resolution in resolver mode).
+- `passkey.register()` and `passkey.challenge()` do not persist any state. In resolver mode, `storeOptions` is only used to resolve the custom domain.
+- `passkey.getToken()` persists the resulting session via the configured `stateStore`, passing `storeOptions` along to it (and using it for domain resolution in resolver mode).
 
 ```ts
 const storeOptions = {
   /* ... */
 };
-await serverClient.passkeyGetToken({ authSession, credential }, storeOptions);
+await serverClient.passkey.getToken({ authSession, credential }, storeOptions);
 ```
+
+> [!IMPORTANT]
+> When using a domain resolver (resolver mode), the `authSession` is tied to the domain that issued the challenge. You must pass the **same** `storeOptions` to `passkey.getToken()` that you passed to `passkey.register()` / `passkey.challenge()`, otherwise the token exchange resolves a different domain and fails.
 
 Read more above in [Configuring the Store](#configuring-the-store)
 

--- a/packages/auth0-server-js/src/index.ts
+++ b/packages/auth0-server-js/src/index.ts
@@ -2,13 +2,7 @@ export { ServerClient } from './server-client.js';
 export { AbstractStateStore } from './store/abstract-state-store.js';
 export { AbstractTransactionStore } from './store/abstract-transaction-store.js';
 export type { TokenResponse, ActClaim } from '@auth0/auth0-auth-js';
-export {
-  TokenExchangeError,
-  MissingClientAuthError,
-  PasskeyRegisterError,
-  PasskeyChallengeError,
-  PasskeyGetTokenError,
-} from '@auth0/auth0-auth-js';
+export { TokenExchangeError, MissingClientAuthError } from '@auth0/auth0-auth-js';
 
 export type { CookieHandler, CookieSerializeOptions } from './store/cookie-handler.js';
 export { CookieTransactionStore } from './store/cookie-transaction-store.js';
@@ -20,3 +14,4 @@ export { StatelessStateStore } from './store/stateless-state-store.js';
 export * from './errors.js';
 export * from './types.js';
 export * from './mfa/index.js';
+export * from './passkey/index.js';

--- a/packages/auth0-server-js/src/passkey/index.ts
+++ b/packages/auth0-server-js/src/passkey/index.ts
@@ -2,5 +2,12 @@ export { ServerPasskeyClient } from './server-passkey-client.js';
 
 // Re-export passkey error classes from auth0-auth-js for convenience, so consumers
 // can narrow thrown errors via `instanceof` without importing auth0-auth-js directly.
+// `OrganizationValidationError` is thrown by `getToken()` when an `organization` is
+// passed and the returned ID token's organization claim is missing or mismatched.
 // The passkey option/response types are re-exported from `../types.js`.
-export { PasskeyRegisterError, PasskeyChallengeError, PasskeyGetTokenError } from '@auth0/auth0-auth-js';
+export {
+  PasskeyRegisterError,
+  PasskeyChallengeError,
+  PasskeyGetTokenError,
+  OrganizationValidationError,
+} from '@auth0/auth0-auth-js';

--- a/packages/auth0-server-js/src/passkey/index.ts
+++ b/packages/auth0-server-js/src/passkey/index.ts
@@ -1,0 +1,6 @@
+export { ServerPasskeyClient } from './server-passkey-client.js';
+
+// Re-export passkey error classes from auth0-auth-js for convenience, so consumers
+// can narrow thrown errors via `instanceof` without importing auth0-auth-js directly.
+// The passkey option/response types are re-exported from `../types.js`.
+export { PasskeyRegisterError, PasskeyChallengeError, PasskeyGetTokenError } from '@auth0/auth0-auth-js';

--- a/packages/auth0-server-js/src/passkey/server-passkey-client.ts
+++ b/packages/auth0-server-js/src/passkey/server-passkey-client.ts
@@ -1,0 +1,113 @@
+import { updateStateData } from '../state/utils.js';
+import { ensureOpenIdScope } from '../utils.js';
+import type { ServerPasskeyClientOptions } from './types.js';
+import type {
+  PasskeyRegisterOptions,
+  PasskeyRegisterResponse,
+  PasskeyChallengeOptions,
+  PasskeyChallengeResponse,
+  PasskeyGetTokenOptions,
+  PasskeyGetTokenResult,
+} from '../types.js';
+
+export class ServerPasskeyClient<TStoreOptions = unknown> {
+  readonly #options: ServerPasskeyClientOptions<TStoreOptions>;
+
+  /**
+   * @internal
+   */
+  constructor(options: ServerPasskeyClientOptions<TStoreOptions>) {
+    this.#options = options;
+  }
+
+  /**
+   * Requests a passkey signup challenge for a new user.
+   *
+   * Returns the `authSession` and the WebAuthn credential creation options
+   * (`authnParamsPublicKey`). The application must return these to the browser,
+   * pass `authnParamsPublicKey` to `navigator.credentials.create()`, and then
+   * call `getToken()` with the resulting credential to complete signup.
+   *
+   * This method does not create a session; no state is persisted.
+   *
+   * @param options User profile data and optional realm/organization.
+   * @param storeOptions Optional options used to resolve the domain (resolver mode).
+   *
+   * @throws {PasskeyRegisterError} If there was an issue requesting the signup challenge.
+   *
+   * @returns A promise resolving to the signup challenge.
+   */
+  async register(options: PasskeyRegisterOptions, storeOptions?: TStoreOptions): Promise<PasskeyRegisterResponse> {
+    const domain = await this.#options.resolveDomain(storeOptions);
+    const authClient = this.#options.getAuthClient(domain);
+
+    return authClient.passkey.register(options);
+  }
+
+  /**
+   * Requests a passkey login challenge for an existing user.
+   *
+   * Returns the `authSession` and the WebAuthn credential request options
+   * (`authnParamsPublicKey`). The application must return these to the browser,
+   * pass `authnParamsPublicKey` to `navigator.credentials.get()`, and then
+   * call `getToken()` with the resulting credential to complete login.
+   *
+   * This method does not create a session; no state is persisted.
+   *
+   * @param options Optional realm/organization configuration.
+   * @param storeOptions Optional options used to resolve the domain (resolver mode).
+   *
+   * @throws {PasskeyChallengeError} If there was an issue requesting the login challenge.
+   *
+   * @returns A promise resolving to the login challenge.
+   */
+  async challenge(options?: PasskeyChallengeOptions, storeOptions?: TStoreOptions): Promise<PasskeyChallengeResponse> {
+    const domain = await this.#options.resolveDomain(storeOptions);
+    const authClient = this.#options.getAuthClient(domain);
+
+    return authClient.passkey.challenge(options);
+  }
+
+  /**
+   * Completes a passkey authentication flow (signup or login) by exchanging the
+   * WebAuthn credential for tokens, and persists the resulting session.
+   *
+   * Call this after obtaining a credential from `navigator.credentials.create()`
+   * (signup) or `navigator.credentials.get()` (login), passing the `authSession`
+   * returned by `register()` / `challenge()` together with the serialized credential.
+   *
+   * In resolver (multi-tenant) mode, pass the same `storeOptions` you passed to
+   * `register()` / `challenge()` so the token exchange resolves the same tenant
+   * that issued the `authSession`; otherwise the exchange will fail.
+   *
+   * @param options The auth session, serialized credential, and optional realm/scope/audience/organization.
+   * @param storeOptions Optional options used to pass to the State Store (and to resolve the domain in resolver mode).
+   *
+   * @throws {PasskeyGetTokenError} If there was an issue exchanging the credential for tokens. When the cause is `mfa_required`, use `isMfaRequiredError(error)` to narrow the error and read `cause.mfa_token`. No session is persisted in this case.
+   *
+   * @returns A promise resolving to an object containing the authorizationDetails (when RAR was used).
+   */
+  async getToken(options: PasskeyGetTokenOptions, storeOptions?: TStoreOptions): Promise<PasskeyGetTokenResult> {
+    const scope = ensureOpenIdScope(options.scope ?? this.#options.defaultScope);
+    const audience = options.audience ?? this.#options.defaultAudience;
+
+    const domain = await this.#options.resolveDomain(storeOptions);
+    const authClient = this.#options.getAuthClient(domain);
+
+    const tokenEndpointResponse = await authClient.passkey.getTokenByPasskey({
+      ...options,
+      scope,
+      audience,
+    });
+
+    const existingStateData = await this.#options.stateStore.get(this.#options.stateStoreIdentifier, storeOptions);
+
+    const stateData = updateStateData(audience ?? 'default', existingStateData, tokenEndpointResponse, { domain });
+
+    await this.#options.stateStore.set(this.#options.stateStoreIdentifier, stateData, true, storeOptions);
+
+    return {
+      authorizationDetails: tokenEndpointResponse.authorizationDetails,
+    };
+  }
+}

--- a/packages/auth0-server-js/src/passkey/server-passkey-client.ts
+++ b/packages/auth0-server-js/src/passkey/server-passkey-client.ts
@@ -84,6 +84,7 @@ export class ServerPasskeyClient<TStoreOptions = unknown> {
    * @param storeOptions Optional options used to pass to the State Store (and to resolve the domain in resolver mode).
    *
    * @throws {PasskeyGetTokenError} If there was an issue exchanging the credential for tokens. When the cause is `mfa_required`, use `isMfaRequiredError(error)` to narrow the error and read `cause.mfa_token`. No session is persisted in this case.
+   * @throws {OrganizationValidationError} When `organization` is passed and the returned ID token's organization claim is missing or does not match. The error is thrown before the session is written, so no session is persisted in this case.
    *
    * @returns A promise resolving to an object containing the authorizationDetails (when RAR was used).
    */

--- a/packages/auth0-server-js/src/passkey/types.ts
+++ b/packages/auth0-server-js/src/passkey/types.ts
@@ -1,0 +1,20 @@
+import type { StateStore } from '../types.js';
+import type { AuthClient } from '@auth0/auth0-auth-js';
+
+/**
+ * @internal
+ * Options for constructing a ServerPasskeyClient.
+ *
+ * Unlike the MFA client, the passkey client resolves the domain per call so it
+ * keeps working in resolver (multi-tenant) mode. It therefore receives the
+ * parent client's `resolveDomain` and `getAuthClient` helpers instead of a
+ * fixed domain/authClient.
+ */
+export interface ServerPasskeyClientOptions<TStoreOptions = unknown> {
+  resolveDomain: (storeOptions?: TStoreOptions) => Promise<string>;
+  getAuthClient: (domain: string) => AuthClient;
+  stateStore: StateStore<TStoreOptions>;
+  stateStoreIdentifier: string;
+  defaultScope?: string;
+  defaultAudience?: string;
+}

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -4889,6 +4889,48 @@ test('passkey.getToken - should propagate an mfa_required error and not write to
   expect(mockStateStore.set).not.toHaveBeenCalled();
 });
 
+test('passkey.getToken - should propagate an OrganizationValidationError and not write to the state store', async () => {
+  // The returned ID token has no org_id claim, so validation against the requested
+  // organization fails inside getTokenByPasskey (added in #200) before any session is written.
+  server.use(
+    http.post(mockOpenIdConfiguration.token_endpoint, async () =>
+      HttpResponse.json({
+        access_token: accessToken,
+        id_token: await generateToken(domain, 'user_123', '<client_id>'),
+        expires_in: 60,
+        token_type: 'Bearer',
+        scope: '<scope>',
+      })
+    )
+  );
+
+  const mockStateStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  const error = await serverClient.passkey
+    .getToken({
+      authSession: 'auth_session_challenge_123',
+      credential: fakePasskeyCredential,
+      organization: 'org_123',
+    })
+    .catch((e) => e);
+
+  expect(error).toBeInstanceOf(Auth0AuthJs.OrganizationValidationError);
+  expect(mockStateStore.set).not.toHaveBeenCalled();
+});
+
 test('passkey.getToken - should return the authorizationDetails when present in the response', async () => {
   server.use(
     http.post(mockOpenIdConfiguration.token_endpoint, async () =>

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -4705,7 +4705,7 @@ test('Telemetry - should include Auth0-Client header in token requests', async (
   expect(decoded.version).toMatch(/^\d+\.\d+\.\d+/);
 });
 
-test('passkeyRegister - should return the signup challenge and not write to the state store', async () => {
+test('passkey.register - should return the signup challenge and not write to the state store', async () => {
   const mockStateStore = {
     get: vi.fn(),
     set: vi.fn(),
@@ -4721,14 +4721,14 @@ test('passkeyRegister - should return the signup challenge and not write to the 
     stateStore: mockStateStore,
   });
 
-  const result = await serverClient.passkeyRegister({ email: 'jane@example.com', name: 'Jane' });
+  const result = await serverClient.passkey.register({ email: 'jane@example.com', name: 'Jane' });
 
   expect(result.authSession).toBe('auth_session_register_123');
   expect(result.authnParamsPublicKey.challenge).toBe('register_challenge');
   expect(mockStateStore.set).not.toHaveBeenCalled();
 });
 
-test('passkeyChallenge - should return the login challenge and not write to the state store', async () => {
+test('passkey.challenge - should return the login challenge and not write to the state store', async () => {
   const mockStateStore = {
     get: vi.fn(),
     set: vi.fn(),
@@ -4744,14 +4744,14 @@ test('passkeyChallenge - should return the login challenge and not write to the 
     stateStore: mockStateStore,
   });
 
-  const result = await serverClient.passkeyChallenge();
+  const result = await serverClient.passkey.challenge();
 
   expect(result.authSession).toBe('auth_session_challenge_123');
   expect(result.authnParamsPublicKey.challenge).toBe('login_challenge');
   expect(mockStateStore.set).not.toHaveBeenCalled();
 });
 
-test('passkeyGetToken - should exchange the credential and store the access token', async () => {
+test('passkey.getToken - should exchange the credential and store the access token', async () => {
   const mockStateStore = {
     get: vi.fn(),
     set: vi.fn(),
@@ -4767,7 +4767,7 @@ test('passkeyGetToken - should exchange the credential and store the access toke
     stateStore: mockStateStore,
   });
 
-  await serverClient.passkeyGetToken({
+  await serverClient.passkey.getToken({
     authSession: 'auth_session_challenge_123',
     credential: fakePasskeyCredential,
   });
@@ -4778,7 +4778,7 @@ test('passkeyGetToken - should exchange the credential and store the access toke
   expect(stateData.tokenSets[0].accessToken).toBe(accessToken);
 });
 
-test('passkeyGetToken - should always include openid in a custom scope', async () => {
+test('passkey.getToken - should always include openid in a custom scope', async () => {
   let capturedScope: string | null = null;
   server.use(
     http.post(mockOpenIdConfiguration.token_endpoint, async ({ request }) => {
@@ -4805,7 +4805,7 @@ test('passkeyGetToken - should always include openid in a custom scope', async (
     stateStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() },
   });
 
-  await serverClient.passkeyGetToken({
+  await serverClient.passkey.getToken({
     authSession: 'auth_session_challenge_123',
     credential: fakePasskeyCredential,
     scope: 'profile email',
@@ -4814,7 +4814,7 @@ test('passkeyGetToken - should always include openid in a custom scope', async (
   expect(capturedScope).toBe('openid profile email');
 });
 
-test('passkeyChallenge - should throw when the challenge endpoint fails', async () => {
+test('passkey.challenge - should throw when the challenge endpoint fails', async () => {
   server.use(
     http.post(`https://${domain}/passkey/challenge`, () => {
       return HttpResponse.json({ error: '<error_code>', error_description: '<error_description>' }, { status: 400 });
@@ -4829,10 +4829,10 @@ test('passkeyChallenge - should throw when the challenge endpoint fails', async 
     stateStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() },
   });
 
-  await expect(serverClient.passkeyChallenge()).rejects.toThrowError();
+  await expect(serverClient.passkey.challenge()).rejects.toThrowError();
 });
 
-test('passkeyRegister - should throw when the register endpoint fails', async () => {
+test('passkey.register - should throw when the register endpoint fails', async () => {
   server.use(
     http.post(`https://${domain}/passkey/register`, () => {
       return HttpResponse.json({ error: '<error_code>', error_description: '<error_description>' }, { status: 400 });
@@ -4847,10 +4847,10 @@ test('passkeyRegister - should throw when the register endpoint fails', async ()
     stateStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() },
   });
 
-  await expect(serverClient.passkeyRegister({ email: 'jane@example.com', name: 'Jane' })).rejects.toThrowError();
+  await expect(serverClient.passkey.register({ email: 'jane@example.com', name: 'Jane' })).rejects.toThrowError();
 });
 
-test('passkeyGetToken - should propagate an mfa_required error and not write to the state store', async () => {
+test('passkey.getToken - should propagate an mfa_required error and not write to the state store', async () => {
   server.use(
     http.post(mockOpenIdConfiguration.token_endpoint, async () =>
       HttpResponse.json(
@@ -4881,7 +4881,7 @@ test('passkeyGetToken - should propagate an mfa_required error and not write to 
   });
 
   const error = await serverClient
-    .passkeyGetToken({ authSession: 'auth_session_challenge_123', credential: fakePasskeyCredential })
+    .passkey.getToken({ authSession: 'auth_session_challenge_123', credential: fakePasskeyCredential })
     .catch((e) => e);
 
   expect(isMfaRequiredError(error)).toBe(true);
@@ -4889,7 +4889,7 @@ test('passkeyGetToken - should propagate an mfa_required error and not write to 
   expect(mockStateStore.set).not.toHaveBeenCalled();
 });
 
-test('passkeyGetToken - should return the authorizationDetails when present in the response', async () => {
+test('passkey.getToken - should return the authorizationDetails when present in the response', async () => {
   server.use(
     http.post(mockOpenIdConfiguration.token_endpoint, async () =>
       HttpResponse.json({
@@ -4911,7 +4911,7 @@ test('passkeyGetToken - should return the authorizationDetails when present in t
     stateStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() },
   });
 
-  const result = await serverClient.passkeyGetToken({
+  const result = await serverClient.passkey.getToken({
     authSession: 'auth_session_challenge_123',
     credential: fakePasskeyCredential,
   });
@@ -4919,7 +4919,7 @@ test('passkeyGetToken - should return the authorizationDetails when present in t
   expect(result.authorizationDetails).toEqual([{ type: 'accepted' }]);
 });
 
-test('passkeyGetToken - should forward audience and organization to the grant', async () => {
+test('passkey.getToken - should forward audience and organization to the grant', async () => {
   let capturedAudience: string | null = null;
   let capturedOrganization: string | null = null;
   server.use(
@@ -4948,7 +4948,7 @@ test('passkeyGetToken - should forward audience and organization to the grant', 
     stateStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() },
   });
 
-  await serverClient.passkeyGetToken({
+  await serverClient.passkey.getToken({
     authSession: 'auth_session_challenge_123',
     credential: fakePasskeyCredential,
     audience: 'https://api.example.com',
@@ -4957,4 +4957,21 @@ test('passkeyGetToken - should forward audience and organization to the grant', 
 
   expect(capturedAudience).toBe('https://api.example.com');
   expect(capturedOrganization).toBe('org_123');
+});
+
+test('passkey.register - should call the domain resolver with storeOptions (resolver mode)', async () => {
+  const domainResolver = vi.fn().mockResolvedValue(domain);
+  const serverClient = new ServerClient({
+    domain: domainResolver,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() },
+  });
+
+  const storeOptions = { request: { headers: { host: 'example.test' } } };
+
+  await serverClient.passkey.register({ email: 'jane@example.com', name: 'Jane' }, storeOptions);
+
+  expect(domainResolver).toHaveBeenCalledWith(storeOptions);
 });

--- a/packages/auth0-server-js/src/server-client.ts
+++ b/packages/auth0-server-js/src/server-client.ts
@@ -8,12 +8,6 @@ import {
   LoginWithCustomTokenExchangeOptions,
   LoginWithCustomTokenExchangeResult,
   LogoutOptions,
-  PasskeyRegisterResponse,
-  PasskeyRegisterOptions,
-  PasskeyChallengeOptions,
-  PasskeyChallengeResponse,
-  PasskeyGetTokenOptions,
-  PasskeyGetTokenResult,
   ServerClientOptions,
   SessionData,
   StartInteractiveLoginOptions,
@@ -40,13 +34,12 @@ import {
   TokenByRefreshTokenError,
   TokenResponse,
 } from '@auth0/auth0-auth-js';
-import { compareScopes } from './utils.js';
+import { compareScopes, ensureOpenIdScope } from './utils.js';
 import { decodeJwt } from 'jose';
 import type { AuthClientOptions } from '@auth0/auth0-auth-js';
 import { getTelemetryConfig } from './telemetry.js';
 import { ServerMfaClient } from './mfa/server-mfa-client.js';
-
-const DEFAULT_SCOPES = 'openid profile email offline_access';
+import { ServerPasskeyClient } from './passkey/server-passkey-client.js';
 
 const normalizeDomain = (value: string) => {
   const trimmed = value.trim();
@@ -63,25 +56,6 @@ const decodeIssuer = (token: string) => {
   }
 };
 
-/**
- * Ensures that the "openid" scope is always included in the scope string.
- *
- * @param scope - The scope provided by the user (optional)
- * @returns A scope string that includes "openid" if it was not already present.
- */
-const ensureOpenIdScope = (scope?: string) => {
-  if (!scope) {
-    return DEFAULT_SCOPES;
-  }
-
-  const scopes = scope.split(' ');
-  if (!scopes.includes('openid')) {
-    scopes.unshift('openid');
-  }
-
-  return scopes.join(' ');
-};
-
 export class ServerClient<TStoreOptions = unknown> {
   readonly #options: ServerClientOptions<TStoreOptions>;
   readonly #transactionStore: TransactionStore<TStoreOptions>;
@@ -92,6 +66,7 @@ export class ServerClient<TStoreOptions = unknown> {
   readonly #staticDomain?: string;
   readonly #authClient?: AuthClient;
   readonly #mfaClient?: ServerMfaClient<TStoreOptions>;
+  readonly #passkeyClient: ServerPasskeyClient<TStoreOptions>;
 
   /**
    * The underlying `authClient` instance that can be used to interact with the Auth0 Authentication API.
@@ -127,6 +102,20 @@ export class ServerClient<TStoreOptions = unknown> {
       throw new InvalidConfigurationError('mfa is only available when using a static domain configuration.');
     }
     return this.#mfaClient;
+  }
+
+  /**
+   * The passkey client for signing up and logging in users with WebAuthn credentials.
+   *
+   * Provides `register()` and `challenge()` to request signup/login challenges, and
+   * `getToken()` to exchange the resulting credential for tokens and persist the session.
+   *
+   * Unlike `mfa`, this property is available in both static and resolver (multi-tenant)
+   * domain modes. In resolver mode, pass the same `storeOptions` to `register()`/`challenge()`
+   * and `getToken()` so the credential is exchanged against the tenant that issued it.
+   */
+  public get passkey(): ServerPasskeyClient<TStoreOptions> {
+    return this.#passkeyClient;
   }
 
   constructor(options: ServerClientOptions<TStoreOptions>) {
@@ -176,6 +165,17 @@ export class ServerClient<TStoreOptions = unknown> {
         defaultAudience: this.#options.authorizationParams?.audience ?? 'default',
       });
     }
+
+    // The passkey client resolves the domain per call, so it is available in both
+    // static and resolver (multi-tenant) modes.
+    this.#passkeyClient = new ServerPasskeyClient({
+      resolveDomain: (storeOptions) => this.#resolveDomain(storeOptions),
+      getAuthClient: (domain) => this.#getAuthClient(domain),
+      stateStore: this.#stateStore,
+      stateStoreIdentifier: this.#stateStoreIdentifier,
+      defaultScope: this.#options.authorizationParams?.scope,
+      defaultAudience: this.#options.authorizationParams?.audience,
+    });
   }
 
   async #resolveDomain(storeOptions?: TStoreOptions): Promise<string> {
@@ -497,103 +497,6 @@ export class ServerClient<TStoreOptions = unknown> {
       tokenEndpointResponse,
       { domain }
     );
-
-    await this.#stateStore.set(this.#stateStoreIdentifier, stateData, true, storeOptions);
-
-    return {
-      authorizationDetails: tokenEndpointResponse.authorizationDetails,
-    };
-  }
-
-  /**
-   * Requests a passkey signup challenge for a new user.
-   *
-   * Returns the `authSession` and the WebAuthn credential creation options
-   * (`authnParamsPublicKey`). The application must return these to the browser,
-   * pass `authnParamsPublicKey` to `navigator.credentials.create()`, and then
-   * call `passkeyGetToken()` with the resulting credential to complete signup.
-   *
-   * This method does not create a session; no state is persisted.
-   *
-   * @param options User profile data and optional realm/organization.
-   * @param storeOptions Optional options used to resolve the domain (resolver mode).
-   *
-   * @throws {PasskeyRegisterError} If there was an issue requesting the signup challenge.
-   *
-   * @returns A promise resolving to the signup challenge.
-   */
-  public async passkeyRegister(
-    options: PasskeyRegisterOptions,
-    storeOptions?: TStoreOptions
-  ): Promise<PasskeyRegisterResponse> {
-    const domain = await this.#resolveDomain(storeOptions);
-    const authClient = this.#getAuthClient(domain);
-
-    return authClient.passkey.register(options);
-  }
-
-  /**
-   * Requests a passkey login challenge for an existing user.
-   *
-   * Returns the `authSession` and the WebAuthn credential request options
-   * (`authnParamsPublicKey`). The application must return these to the browser,
-   * pass `authnParamsPublicKey` to `navigator.credentials.get()`, and then
-   * call `passkeyGetToken()` with the resulting credential to complete login.
-   *
-   * This method does not create a session; no state is persisted.
-   *
-   * @param options Optional realm/organization configuration.
-   * @param storeOptions Optional options used to resolve the domain (resolver mode).
-   *
-   * @throws {PasskeyChallengeError} If there was an issue requesting the login challenge.
-   *
-   * @returns A promise resolving to the login challenge.
-   */
-  public async passkeyChallenge(
-    options?: PasskeyChallengeOptions,
-    storeOptions?: TStoreOptions
-  ): Promise<PasskeyChallengeResponse> {
-    const domain = await this.#resolveDomain(storeOptions);
-    const authClient = this.#getAuthClient(domain);
-
-    return authClient.passkey.challenge(options);
-  }
-
-  /**
-   * Completes a passkey authentication flow (signup or login) by exchanging the
-   * WebAuthn credential for tokens, and persists the resulting session.
-   *
-   * Call this after obtaining a credential from `navigator.credentials.create()`
-   * (signup) or `navigator.credentials.get()` (login), passing the `authSession`
-   * returned by `passkeyRegister()` / `passkeyChallenge()` together with the
-   * serialized credential.
-   *
-   * @param options The auth session, serialized credential, and optional realm/scope/audience/organization.
-   * @param storeOptions Optional options used to pass to the State Store (and to resolve the domain in resolver mode).
-   *
-   * @throws {PasskeyGetTokenError} If there was an issue exchanging the credential for tokens. When the cause is `mfa_required`, use `isMfaRequiredError(error)` to narrow the error and read `cause.mfa_token`. No session is persisted in this case.
-   *
-   * @returns A promise resolving to an object containing the authorizationDetails (when RAR was used).
-   */
-  public async passkeyGetToken(
-    options: PasskeyGetTokenOptions,
-    storeOptions?: TStoreOptions
-  ): Promise<PasskeyGetTokenResult> {
-    const scope = ensureOpenIdScope(options.scope ?? this.#options.authorizationParams?.scope);
-    const audience = options.audience ?? this.#options.authorizationParams?.audience;
-
-    const domain = await this.#resolveDomain(storeOptions);
-    const authClient = this.#getAuthClient(domain);
-
-    const tokenEndpointResponse = await authClient.passkey.getTokenByPasskey({
-      ...options,
-      scope,
-      audience,
-    });
-
-    const existingStateData = await this.#stateStore.get(this.#stateStoreIdentifier, storeOptions);
-
-    const stateData = updateStateData(audience ?? 'default', existingStateData, tokenEndpointResponse, { domain });
 
     await this.#stateStore.set(this.#stateStoreIdentifier, stateData, true, storeOptions);
 

--- a/packages/auth0-server-js/src/utils.ts
+++ b/packages/auth0-server-js/src/utils.ts
@@ -7,11 +7,12 @@ export const DEFAULT_SCOPES = 'openid profile email offline_access';
  * @returns A scope string that includes "openid" if it was not already present.
  */
 export const ensureOpenIdScope = (scope?: string) => {
-  if (!scope) {
+  const normalizedScope = scope?.trim();
+  if (!normalizedScope) {
     return DEFAULT_SCOPES;
   }
 
-  const scopes = scope.split(' ');
+  const scopes = normalizedScope.split(/\s+/);
   if (!scopes.includes('openid')) {
     scopes.unshift('openid');
   }

--- a/packages/auth0-server-js/src/utils.ts
+++ b/packages/auth0-server-js/src/utils.ts
@@ -1,3 +1,24 @@
+export const DEFAULT_SCOPES = 'openid profile email offline_access';
+
+/**
+ * Ensures that the "openid" scope is always included in the scope string.
+ *
+ * @param scope - The scope provided by the user (optional)
+ * @returns A scope string that includes "openid" if it was not already present.
+ */
+export const ensureOpenIdScope = (scope?: string) => {
+  if (!scope) {
+    return DEFAULT_SCOPES;
+  }
+
+  const scopes = scope.split(' ');
+  if (!scopes.includes('openid')) {
+    scopes.unshift('openid');
+  }
+
+  return scopes.join(' ');
+};
+
 /**
  * Compares two sets of scopes to determine if all required scopes are present in the provided scopes.
  * @param scopes Scopes to compare


### PR DESCRIPTION
### Summary

  Refactors the flat passkey methods on ServerClient into a dedicated passkey sub-client. This groups the passkey surface under one namespace and aligns the public API shape

  #### Before
  ```
  await serverClient.passkeyRegister({ email, name });
  await serverClient.passkeyChallenge();
  await serverClient.passkeyGetToken({ authSession, credential });
  ```
  
  #### After
  ```
  await serverClient.passkey.register({ email, name });
  await serverClient.passkey.challenge();
  await serverClient.passkey.getToken({ authSession, credential });
  ```

  ### Changes

  - New `src/passkey/ module: ServerPasskeyClient (register / challenge / getToken)`, its options interface, and a barrel that also re-exports the PasskeyRegisterError / PasskeyChallengeError / PasskeyGetTokenError classes for
  instanceof narrowing.
  - ServerClient: removed the three flat methods; added a get passkey() accessor. The sub-client is wired with `resolveDomain / getAuthClient` functions rather than a frozen domain.
  - Resolver-mode support preserved: unlike mfa (static-domain only, getter throws in resolver mode), passkey resolves the domain per-call, so it works in both static and multi-tenant (resolver) modes and is always available.
  - utils.ts: hoisted DEFAULT_SCOPES / ensureOpenIdScope so both ServerClient and the passkey sub-client share one implementation.
  - Exports: passkey barrel added to index.ts; care taken to avoid ESM export * name collisions (type aliases stay in types.ts; the barrel only exports the new client + error classes).
  - Docs: EXAMPLES.md updated to the passkey.* API, plus a resolver-mode note that the same storeOptions must be passed to register()/challenge() and getToken(), since authSession is bound to the issuing tenant.

 
  Test plan
  
  - npm test — passkey suite migrated to the sub-client (10 tests incl. a new resolver-mode domain-resolution test); 248 pass. (2 pre-existing Telemetry ESM-spy failures are unrelated/out of scope.)
  - npm run build — generated d.ts exposes get passkey(), ServerPasskeyClient, PasskeyGetTokenResult, all 3 error classes, and all passkey type aliases; no duplicate exports.
  - npm run lint — clean.
  - Manual testing on passjey signup and login

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not the default branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated server-side passkey client with `register()`, `challenge()`, and `getToken()` flow orchestration.
  * Updated passkey API usage to the newer `passkey.register()`, `passkey.challenge()`, and `passkey.getToken()` method names.
* **Documentation**
  * Refreshed passkey and Passkeys+MCD examples, including improved callouts and mTLS guidance formatting.
  * Clarified MFA handling and state persistence behavior across the passkey flow.
* **Bug Fixes / Behavior Changes**
  * `getToken()` now ensures `openid` is present (without duplication) when exchanging scopes.
* **Tests**
  * Updated server client passkey tests to match the new passkey API and verify state-store write behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->