### PR TITLE
fix(auth0-server-js): restore MRRT audience/scope overload on getAccessToken()

### DIFF
--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -89,6 +89,7 @@ const restHandlers = [
       : await request.formData();
 
     let accessTokenToUse = accessToken;
+    const scopeToReturn = info.get('scope') ?? '<scope>';
 
     if (info.get('auth_req_id') === 'auth_req_789') {
       accessTokenToUse = accessTokenWithAudienceAndBindingMessage;
@@ -109,7 +110,7 @@ const restHandlers = [
           id_token: await generateToken(domain, 'user_123', '<client_id>'),
           expires_in: 60,
           token_type: 'Bearer',
-          scope: '<scope>',
+          scope: scopeToReturn,
           ...(info.get('auth_req_id') === 'auth_req_with_authorization_details'
             ? { authorization_details: [{ type: 'accepted' }] }
             : {}),
@@ -3635,6 +3636,670 @@ test('getAccessToken - should throw an error when refresh_token grant failed', a
       }),
     })
   );
+});
+
+test('getAccessToken - should support new signature with audience option', async () => {
+  const mockStateStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+    },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [
+      {
+        audience: 'default',
+        accessToken: '<access_token>',
+        expiresAt: (Date.now() - 500) / 1000,
+        scope: '<scope>',
+      },
+    ],
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const result = await serverClient.getAccessToken({ audience: '<audience>' });
+
+  expect(result.accessToken).toBe(accessToken);
+  expect(result.audience).toBe('<audience>');
+});
+
+test('getAccessToken - should support new signature with scope option', async () => {
+  const mockStateStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+    },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [
+      {
+        audience: 'default',
+        accessToken: '<access_token>',
+        expiresAt: (Date.now() - 500) / 1000,
+        scope: 'openid profile',
+      },
+    ],
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const result = await serverClient.getAccessToken({ scope: 'read:data write:data' });
+
+  expect(result.accessToken).toBe(accessToken);
+  expect(result.scope).toBe('read:data write:data');
+});
+
+test('getAccessToken - should support new signature with both audience and scope options', async () => {
+  const mockStateStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+    },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [
+      {
+        audience: 'default',
+        accessToken: '<access_token>',
+        expiresAt: (Date.now() - 500) / 1000,
+        scope: 'openid profile',
+      },
+    ],
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const result = await serverClient.getAccessToken({
+    audience: '<new_audience>',
+    scope: 'read:data write:data',
+  });
+
+  expect(result.accessToken).toBe(accessToken);
+  expect(result.audience).toBe('<new_audience>');
+  expect(result.scope).toBe('read:data write:data');
+});
+
+test('getAccessToken - should pass options and storeOptions correctly with new signature', async () => {
+  const mockStateStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const storeOptions = { someOption: 'value' };
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+    },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [
+      {
+        audience: 'default',
+        accessToken: '<access_token>',
+        expiresAt: (Date.now() - 500) / 1000,
+        scope: '<scope>',
+      },
+    ],
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  await serverClient.getAccessToken({ audience: '<audience>' }, storeOptions);
+
+  expect(mockStateStore.get).toHaveBeenCalledWith('__a0_session', storeOptions);
+  expect(mockStateStore.set).toHaveBeenCalledWith('__a0_session', expect.anything(), false, storeOptions);
+});
+
+test('getAccessToken - should verify authClient receives correct parameters with audience', async () => {
+  const mockStateStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+    },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [
+      {
+        audience: 'default',
+        accessToken: '<access_token>',
+        expiresAt: (Date.now() - 500) / 1000,
+        scope: '<scope>',
+      },
+    ],
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const spy = vi.spyOn(serverClient.authClient, 'getTokenByRefreshToken');
+
+  await serverClient.getAccessToken({ audience: 'https://api.example.com' });
+
+  expect(spy).toHaveBeenCalledWith({
+    refreshToken: '<refresh_token>',
+    audience: 'https://api.example.com',
+  });
+
+  spy.mockRestore();
+});
+
+test('getAccessToken - should verify authClient receives correct parameters with scope', async () => {
+  const mockStateStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+    },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [
+      {
+        audience: 'default',
+        accessToken: '<access_token>',
+        expiresAt: (Date.now() - 500) / 1000,
+        scope: '<scope>',
+      },
+    ],
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const spy = vi.spyOn(serverClient.authClient, 'getTokenByRefreshToken');
+
+  await serverClient.getAccessToken({ scope: 'read:data write:data' });
+
+  expect(spy).toHaveBeenCalledWith({
+    refreshToken: '<refresh_token>',
+    scope: 'read:data write:data',
+  });
+
+  spy.mockRestore();
+});
+
+test('getAccessToken - should verify authClient receives correct parameters with both audience and scope', async () => {
+  const mockStateStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+    },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [
+      {
+        audience: 'default',
+        accessToken: '<access_token>',
+        expiresAt: (Date.now() - 500) / 1000,
+        scope: '<scope>',
+      },
+    ],
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const spy = vi.spyOn(serverClient.authClient, 'getTokenByRefreshToken');
+
+  await serverClient.getAccessToken({
+    audience: 'https://api.example.com',
+    scope: 'openid profile read:data',
+  });
+
+  expect(spy).toHaveBeenCalledWith({
+    refreshToken: '<refresh_token>',
+    audience: 'https://api.example.com',
+    scope: 'openid profile read:data',
+  });
+
+  spy.mockRestore();
+});
+
+test('getAccessToken - should correctly handle empty options object with storeOptions', async () => {
+  const mockStateStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    authorizationParams: {
+      audience: '<configured_audience>',
+    },
+    transactionStore: {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+    },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [
+      {
+        audience: '<configured_audience>',
+        accessToken: '<cached_access_token>',
+        expiresAt: (Date.now() + 500000) / 1000,
+        scope: '<scope>',
+      },
+    ],
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const storeOptions = { customOption: 'value' };
+  const result = await serverClient.getAccessToken({}, storeOptions);
+
+  expect(result.accessToken).toBe('<cached_access_token>');
+  expect(result.audience).toBe('<configured_audience>');
+  expect(mockStateStore.get).toHaveBeenCalledWith('__a0_session', storeOptions);
+});
+
+test('getAccessToken - should not send audience/scope to Auth0 when called with legacy storeOptions-only signature', async () => {
+  const mockStateStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+    },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [
+      {
+        audience: 'default',
+        accessToken: '<access_token>',
+        expiresAt: (Date.now() - 500) / 1000,
+        scope: '<scope>',
+      },
+    ],
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const spy = vi.spyOn(serverClient.authClient, 'getTokenByRefreshToken');
+
+  await serverClient.getAccessToken();
+
+  expect(spy).toHaveBeenCalledWith({
+    refreshToken: '<refresh_token>',
+  });
+
+  spy.mockRestore();
+});
+
+test('getAccessToken - should request a fresh token per audience using MRRT (cache keyed by audience)', async () => {
+  const mockStateStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+    },
+    stateStore: mockStateStore,
+  });
+
+  // Cache already holds a valid token for the default audience.
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [
+      {
+        audience: 'default',
+        accessToken: '<cached_default_token>',
+        expiresAt: (Date.now() + 500000) / 1000,
+        scope: '<scope>',
+      },
+    ],
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  // Requesting a different audience must not return the cached default token;
+  // it should exchange the refresh token for the new audience.
+  const result = await serverClient.getAccessToken({ audience: 'https://other-api.example.com' });
+
+  expect(result.accessToken).toBe(accessToken);
+  expect(result.audience).toBe('https://other-api.example.com');
+  expect(mockStateStore.set).toHaveBeenCalled();
+});
+
+test('getAccessToken - should support audience option in resolver mode when domain matches', async () => {
+  const domainResolver = vi.fn().mockResolvedValue(domain);
+  const mockStateStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain: domainResolver,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+    },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [],
+    domain,
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const result = await serverClient.getAccessToken({ audience: '<resolver_audience>' });
+
+  expect(result.accessToken).toBe(accessToken);
+  expect(result.audience).toBe('<resolver_audience>');
+  expect(domainResolver).toHaveBeenCalled();
+});
+
+test('getAccessToken - should throw in resolver mode when session domain does not match even with audience option', async () => {
+  const domainResolver = vi.fn().mockResolvedValue('other.local');
+  const mockStateStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain: domainResolver,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+    },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [],
+    domain,
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  await expect(serverClient.getAccessToken({ audience: '<resolver_audience>' })).rejects.toThrowError(
+    MissingSessionError
+  );
+});
+
+test('getAccessToken - should pass resolved storeOptions to the resolver in resolver mode with options', async () => {
+  const domainResolver = vi.fn().mockResolvedValue(domain);
+  const mockStateStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const storeOptions = { tenantScopedOption: 'value' };
+
+  const serverClient = new ServerClient({
+    domain: domainResolver,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+    },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [],
+    domain,
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  await serverClient.getAccessToken({ audience: '<resolver_audience>' }, storeOptions);
+
+  expect(mockStateStore.get).toHaveBeenCalledWith('__a0_session', storeOptions);
+  expect(mockStateStore.set).toHaveBeenCalledWith('__a0_session', expect.anything(), false, storeOptions);
+});
+
+test('getAccessToken - should support scope-only down-scoping in resolver mode when domain matches', async () => {
+  const domainResolver = vi.fn().mockResolvedValue(domain);
+  const mockStateStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain: domainResolver,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+    },
+    stateStore: mockStateStore,
+  });
+
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [
+      {
+        audience: 'default',
+        accessToken: '<access_token>',
+        expiresAt: (Date.now() - 500) / 1000,
+        scope: 'read:data write:data',
+      },
+    ],
+    domain,
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  const result = await serverClient.getAccessToken({ scope: 'read:data' });
+
+  expect(result.accessToken).toBe(accessToken);
+  expect(result.scope).toBe('read:data');
+  expect(domainResolver).toHaveBeenCalled();
+});
+
+test('getAccessToken - should return cached token when requested scope is a subset of the cached scope, regardless of order', async () => {
+  const mockStateStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+    },
+    stateStore: mockStateStore,
+  });
+
+  // Cached token grants 'read:data write:data' and is still valid.
+  const stateData: StateData = {
+    user: { sub: '<sub>' },
+    idToken: '<id_token>',
+    refreshToken: '<refresh_token>',
+    tokenSets: [
+      {
+        audience: 'default',
+        accessToken: '<cached_access_token>',
+        expiresAt: (Date.now() + 500000) / 1000,
+        scope: 'read:data write:data',
+      },
+    ],
+    internal: { sid: '<sid>', createdAt: Date.now() },
+  };
+  mockStateStore.get.mockResolvedValue(stateData);
+
+  // Requesting the same scopes in a different order must be a cache hit (no network call).
+  const result = await serverClient.getAccessToken({ scope: 'write:data read:data' });
+
+  expect(result.accessToken).toBe('<cached_access_token>');
+  expect(mockStateStore.set).not.toHaveBeenCalled();
 });
 
 test('getAccessTokenForConnection - should throw when nothing in cache', async () => {

--- a/packages/auth0-server-js/src/server-client.ts
+++ b/packages/auth0-server-js/src/server-client.ts
@@ -9,6 +9,7 @@ import {
   LoginWithCustomTokenExchangeResult,
   CompletePasswordlessOptions,
   CompletePasswordlessResult,
+  GetAccessTokenOptions,
   LogoutOptions,
   ServerClientOptions,
   SessionData,
@@ -37,6 +38,7 @@ import {
   PasswordlessStartError,
   PasswordlessVerifyError,
   TokenByRefreshTokenError,
+  TokenByRefreshTokenOptions,
   TokenResponse,
 } from '@auth0/auth0-auth-js';
 import { compareScopes, ensureOpenIdScope } from './utils.js';
@@ -770,19 +772,49 @@ export class ServerClient<TStoreOptions = unknown> {
     }
   }
 
+  // TEMPORARY: Overloads for backwards compatibility in minor version.
+  // In the next major version, remove the first overload and use only the second signature.
+  public async getAccessToken(storeOptions?: TStoreOptions): Promise<TokenSet>;
+  public async getAccessToken(options: GetAccessTokenOptions, storeOptions?: TStoreOptions): Promise<TokenSet>;
   /**
    * Retrieves the access token from the store, or calls Auth0 when the access token is expired and a refresh token is available in the store.
    * Also updates the store when a new token was retrieved from Auth0.
+   *
+   * When `options.audience` and/or `options.scope` are provided, the SDK uses the session's refresh token to
+   * request an access token for that audience/scope (Multi-Resource Refresh Tokens). Tokens are cached per
+   * audience and scope combination.
+   *
+   * @param options Optional options for requesting a specific audience/scope.
    * @param storeOptions Optional options used to pass to the Transaction and State Store.
    *
    * @throws {TokenByRefreshTokenError} If the refresh token was not found or there was an issue requesting the access token. When the cause is `mfa_required`, use `isMfaRequiredError(error)` to narrow the error and read `cause.mfa_token`.
    *
    * @returns The Token Set, containing the access token, as well as additional information.
    */
-  public async getAccessToken(storeOptions?: TStoreOptions): Promise<TokenSet> {
-    const stateData = await this.#stateStore.get(this.#stateStoreIdentifier, storeOptions);
-    const audience = this.#options.authorizationParams?.audience ?? 'default';
-    const scope = this.#options.authorizationParams?.scope;
+  public async getAccessToken(
+    tokenOptionsOrStoreOptions?: GetAccessTokenOptions | TStoreOptions,
+    storeOptions?: TStoreOptions
+  ): Promise<TokenSet> {
+    // TEMPORARY: Detect if first arg is GetAccessTokenOptions (has audience/scope)
+    // or storeOptions (old behavior). Remove in next major version.
+    const hasTokenOptions =
+      // If second arg exists, first arg must be GetAccessTokenOptions
+      storeOptions !== undefined ||
+      // OR if first arg has audience/scope properties
+      (!!tokenOptionsOrStoreOptions &&
+        typeof tokenOptionsOrStoreOptions === 'object' &&
+        ('audience' in tokenOptionsOrStoreOptions || 'scope' in tokenOptionsOrStoreOptions));
+
+    const [resolvedOptions, resolvedStoreOptions] = hasTokenOptions
+      ? [tokenOptionsOrStoreOptions as GetAccessTokenOptions, storeOptions]
+      : [undefined, tokenOptionsOrStoreOptions as TStoreOptions];
+
+    const stateData = await this.#stateStore.get(this.#stateStoreIdentifier, resolvedStoreOptions);
+    // The requested audience as sent to Auth0. `undefined` means "no specific audience" and is
+    // intentionally not sent on the wire. `'default'` below is only a synthetic cache key.
+    const requestedAudience = resolvedOptions?.audience ?? this.#options.authorizationParams?.audience;
+    const audience = requestedAudience ?? 'default';
+    const scope = resolvedOptions?.scope ?? this.#options.authorizationParams?.scope;
 
     const sessionDomain = stateData ? this.#getSessionDomain(stateData) : this.#staticDomain;
     if (this.#isResolverMode()) {
@@ -792,7 +824,7 @@ export class ServerClient<TStoreOptions = unknown> {
       if (!sessionDomain) {
         throw new MissingSessionError('Session domain does not match the current domain.');
       }
-      const resolvedDomain = await this.#resolveDomain(storeOptions);
+      const resolvedDomain = await this.#resolveDomain(resolvedStoreOptions);
       if (sessionDomain !== resolvedDomain) {
         throw new MissingSessionError('Session domain does not match the current domain.');
       }
@@ -813,15 +845,24 @@ export class ServerClient<TStoreOptions = unknown> {
     }
 
     const domainForSession = sessionDomain!;
-    const tokenEndpointResponse = await this.#getAuthClient(domainForSession).getTokenByRefreshToken({
+    const tokenByRefreshTokenOptions: TokenByRefreshTokenOptions = {
       refreshToken: stateData.refreshToken,
-    });
-    const existingStateData = await this.#stateStore.get(this.#stateStoreIdentifier, storeOptions);
+      // Only forward audience/scope to Auth0 when token options were explicitly supplied, and
+      // never send the synthetic 'default' cache-key audience as a real request parameter.
+      ...(hasTokenOptions && {
+        ...(requestedAudience && { audience: requestedAudience }),
+        ...(scope && { scope }),
+      }),
+    };
+
+    const tokenEndpointResponse =
+      await this.#getAuthClient(domainForSession).getTokenByRefreshToken(tokenByRefreshTokenOptions);
+    const existingStateData = await this.#stateStore.get(this.#stateStoreIdentifier, resolvedStoreOptions);
     const updatedStateData = updateStateData(audience, existingStateData, tokenEndpointResponse, {
       domain: domainForSession,
     });
 
-    await this.#stateStore.set(this.#stateStoreIdentifier, updatedStateData, false, storeOptions);
+    await this.#stateStore.set(this.#stateStoreIdentifier, updatedStateData, false, resolvedStoreOptions);
 
     return {
       accessToken: tokenEndpointResponse.accessToken,


### PR DESCRIPTION
### Summary
Restores the `audience` / `scope` options on `getAccessToken()` in `auth0-server-js`. These options were added in #124 (shipped in `1.3.0`) for Multi-Resource Refresh Token (MRRT) support, but were accidentally dropped by the MCD merge (#119, `3e4c2b2`) in `1.4.0`. They have been missing from `1.4.0` through `1.6.1`. The MCD branch was started before #124 existed. When it merged, it rewrote `getAccessToken()` back to the old single-argument signature and removed the overload and its tests in the same commit, so nothing flagged the regression.

### What changed
  - Re-added the `getAccessToken(options, storeOptions)` overload, layered on top of the current resolver-mode (MCD) logic. This is a merge, not a revert.
  - The `audience` and `scope` are now only sent to Auth0 when the caller passes them. The cache key and the value sent to `Auth0` are now kept in two separate variables, so the placeholder `'default'` can never end up in the request.
  - Restored the original tests from #124 and added new tests for MRRT options under resolver mode, scope-only down-scoping, and scope-order cache hits.

### Behavior note
For a `scope`-only call with no audience, this version does **not** send `audience=default` to Auth0. PR #124 did. This is a deliberate change, not an oversight.

### Scope
- Limited to `auth0-server-js`.
- The token cache layer (`updateStateData`) was never broken and needed no changes.
- No doc changes. `EXAMPLES.md` already describes this API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `audience` and `scope` parameters in access token requests, enabling fine-grained token control.
  * Enhanced token caching with scope-aware matching and multi-request caching semantics.

* **Tests**
  * Expanded test coverage for access token retrieval with new parameter combinations and caching scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->