### PR TITLE
feat(database): add signUp and changePassword to auth-js and server-js

### DIFF
--- a/examples/database-conns/.env.example
+++ b/examples/database-conns/.env.example
@@ -1,0 +1,6 @@
+AUTH0_DOMAIN=your-tenant.auth0.com
+AUTH0_CLIENT_ID=your_client_id
+AUTH0_CLIENT_SECRET=your_client_secret
+AUTH0_DB_CONNECTION=Username-Password-Authentication
+APP_BASE_URL=http://localhost:3000
+PORT=3000

--- a/examples/database-conns/README.md
+++ b/examples/database-conns/README.md
@@ -1,0 +1,114 @@
+# Database Connections POC Example
+
+This is a manual harness for live-tenant testing of `signUp` and `changePassword` database connection operations with Auth0.
+
+## Prerequisites
+
+- An Auth0 tenant with a database connection enabled on the app
+- Signup enabled on the connection (or expect documented signup-disabled behavior)
+- The client configured as either a confidential app (with client secret) or public app as configured
+- Node.js and npm installed
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in your Auth0 tenant credentials:
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Install workspace dependencies at the repo root:
+   ```bash
+   npm install
+   ```
+
+3. Build the auth0-auth-js and auth0-server-js packages first to ensure the example resolves the new database connection surface from dist:
+   ```bash
+   npm run build --workspace=packages/auth0-auth-js
+   npm run build --workspace=packages/auth0-server-js
+   ```
+
+4. Install the example dependencies:
+   ```bash
+   npm install --workspace=examples/database-conns
+   ```
+
+## Running
+
+```bash
+npm start --workspace=examples/database-conns
+```
+
+The app will start on the port specified in your `.env` (default: `http://localhost:3000`).
+
+## Testing
+
+### Sign Up
+
+Test user registration:
+
+```bash
+curl -X POST localhost:3000/signup \
+  -H 'content-type: application/json' \
+  -d '{"email":"new@example.com","password":"Str0ng-pw!"}'
+```
+
+Expected success response:
+```json
+{
+  "ok": true,
+  "user": {
+    "id": "...",
+    "email": "new@example.com",
+    "emailVerified": false
+  }
+}
+```
+
+Expected error when re-running with the same email:
+```json
+{
+  "ok": false,
+  "code": "signup_error",
+  "message": "...",
+  "cause": { "error": "..." }
+}
+```
+
+### Change Password
+
+Test password reset request:
+
+```bash
+curl -X POST localhost:3000/change-password \
+  -H 'content-type: application/json' \
+  -d '{"email":"new@example.com"}'
+```
+
+Expected success response:
+```json
+{
+  "ok": true,
+  "message": "We've just sent you an email to reset your password."
+}
+```
+
+A password reset email will be sent to the specified email address from your Auth0 tenant.
+
+## Investigation Notes
+
+This POC is the live-tenant check that closes the signup success-rate investigation. When running the tests above, capture observed status codes and response codes for:
+
+- Existing user signup attempt (expect 4xx validation error)
+- Weak password signup attempt (expect 4xx validation error)
+- Signup with disabled connection (expect 4xx validation error)
+
+These should all be expected validation 4xx responses, not a defect. Any 5xx or unexpected behavior indicates a platform issue.
+
+## Implementation Details
+
+The example:
+- Uses a simple no-op state store for the `ServerClient` (database operations never read or write session state)
+- Catches `SignUpError` and `ChangePasswordError` and surfaces them with appropriate HTTP status codes
+- Reads plain text responses from the change-password endpoint
+
+See the source files for implementation details.

--- a/examples/database-conns/package.json
+++ b/examples/database-conns/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "example-database-conns",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx src/index.ts --project tsconfig.json",
+    "build": "tsc --project tsconfig.json"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.1",
+    "tsx": "^4.19.2",
+    "typescript": "~5.8.3"
+  },
+  "dependencies": {
+    "@auth0/auth0-server-js": "*",
+    "dotenv": "^16.4.7",
+    "express": "^5.1.0"
+  }
+}

--- a/examples/database-conns/src/auth0.ts
+++ b/examples/database-conns/src/auth0.ts
@@ -1,0 +1,23 @@
+import 'dotenv/config';
+import { ServerClient } from '@auth0/auth0-server-js';
+
+export const connection = process.env.AUTH0_DB_CONNECTION!;
+
+export const auth0 = new ServerClient({
+  domain: process.env.AUTH0_DOMAIN!,
+  clientId: process.env.AUTH0_CLIENT_ID!,
+  clientSecret: process.env.AUTH0_CLIENT_SECRET!,
+  // ServerClient requires state and transaction stores at construction. The database operations
+  // (signUp / changePassword) never read or write them, so no-op stores are sufficient
+  // for this POC. A real app uses StatelessStateStore / StatefulStateStore and CookieTransactionStore.
+  stateStore: {
+    set: async () => {},
+    get: async () => undefined,
+    delete: async () => {},
+  } as any,
+  transactionStore: {
+    create: async () => 'noop',
+    read: async () => undefined,
+    delete: async () => {},
+  } as any,
+});

--- a/examples/database-conns/src/index.ts
+++ b/examples/database-conns/src/index.ts
@@ -1,0 +1,41 @@
+import express from 'express';
+import { auth0, connection } from './auth0.js';
+import { SignUpError, ChangePasswordError } from '@auth0/auth0-server-js';
+
+const app = express();
+app.use(express.json());
+
+// POST /signup { email, password }
+app.post('/signup', async (req, res) => {
+  try {
+    const result = await auth0.database.signUp({
+      email: req.body.email,
+      password: req.body.password,
+      connection,
+    });
+    res.json({ ok: true, user: result }); // result.id normalized
+  } catch (err) {
+    if (err instanceof SignUpError) {
+      res.status(400).json({ ok: false, code: err.code, message: err.message, cause: err.cause });
+    } else {
+      res.status(500).json({ ok: false, message: 'unexpected' });
+    }
+  }
+});
+
+// POST /change-password { email }
+app.post('/change-password', async (req, res) => {
+  try {
+    const message = await auth0.database.changePassword({ email: req.body.email, connection });
+    res.json({ ok: true, message }); // plain-text confirmation
+  } catch (err) {
+    if (err instanceof ChangePasswordError) {
+      res.status(400).json({ ok: false, code: err.code, message: err.message });
+    } else {
+      res.status(500).json({ ok: false, message: 'unexpected' });
+    }
+  }
+});
+
+const port = Number(process.env.PORT ?? 3000);
+app.listen(port, () => console.log(`database-conns POC on http://localhost:${port}`));

--- a/examples/database-conns/tsconfig.json
+++ b/examples/database-conns/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/auth0-auth-js/src/auth-client.spec.ts
+++ b/packages/auth0-auth-js/src/auth-client.spec.ts
@@ -3963,3 +3963,32 @@ describe('passwordless public export surface', () => {
     expect(mod.PasswordlessVerifyError).toBeDefined();
   });
 });
+
+test('exposes a database sub-client', () => {
+  const c = new AuthClient({ domain: 'auth0.local', clientId: 'test-client-id' });
+  expect(c.database).toBeDefined();
+  expect(typeof c.database.signUp).toBe('function');
+  expect(typeof c.database.changePassword).toBe('function');
+});
+
+test('database.signUp request carries the Auth0-Client telemetry header', async () => {
+  let headers: Headers | undefined;
+  server.use(http.post(`https://${domain}/dbconnections/signup`, ({ request }) => {
+    headers = request.headers;
+    return HttpResponse.json({ id: 'x', email: 'a@b.com', email_verified: true });
+  }));
+  const c = new AuthClient({ domain, clientId: 'test-client-id' });
+  await c.database.signUp({ email: 'a@b.com', password: 'pw', connection: 'db' });
+  expect(headers?.get('Auth0-Client')).toBeTruthy();
+});
+
+test('database.changePassword request carries the Auth0-Client telemetry header', async () => {
+  let headers: Headers | undefined;
+  server.use(http.post(`https://${domain}/dbconnections/change_password`, ({ request }) => {
+    headers = request.headers;
+    return new HttpResponse('ok', { status: 200 });
+  }));
+  const c = new AuthClient({ domain, clientId: 'test-client-id' });
+  await c.database.changePassword({ email: 'a@b.com', connection: 'db' });
+  expect(headers?.get('Auth0-Client')).toBeTruthy();
+});

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -25,6 +25,7 @@ import { PasskeyClient, PASSKEY_GRANT_TYPE } from './passkey/passkey-client.js';
 import { PasswordlessClient } from './passwordless/passwordless-client.js';
 import { PasswordlessVerifyError } from './passwordless/errors.js';
 import { isE164PhoneNumber } from './passwordless/utils.js';
+import { DatabaseClient } from './database/database-client.js';
 import { createTelemetryFetch, getTelemetryConfig } from './telemetry.js';
 import {
   AuthClientOptions,
@@ -281,6 +282,7 @@ export class AuthClient {
    * {@link AuthClient#getTokenByPasswordlessEmail} / {@link AuthClient#getTokenByPasswordlessSms}.
    */
   public passwordless: PasswordlessClient;
+  public database: DatabaseClient;
 
   constructor(options: AuthClientOptions) {
     this.#options = options;
@@ -354,6 +356,12 @@ export class AuthClient {
         const tokenEndpointResponse = await client.genericGrantRequest(configuration, grantType, params);
         return TokenResponse.fromTokenEndpointResponse(tokenEndpointResponse);
       },
+    });
+
+    this.database = new DatabaseClient({
+      domain: this.#options.domain,
+      clientId: this.#options.clientId,
+      customFetch: this.#customFetch,
     });
   }
 

--- a/packages/auth0-auth-js/src/database/database-client.spec.ts
+++ b/packages/auth0-auth-js/src/database/database-client.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test, describe, beforeAll, afterAll, afterEach } from 'vitest';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import { DatabaseClient } from './database-client.js';
+import { SignUpError, ChangePasswordError } from './errors.js';
+
+const domain = 'auth0.local';
+const clientId = 'test-client-id';
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const makeClient = () => new DatabaseClient({ domain, clientId });
+
+describe('signUp', () => {
+  test('normalizes _id and sends client_id, no client auth', async () => {
+    let captured: any;
+    server.use(http.post(`https://${domain}/dbconnections/signup`, async ({ request }) => {
+      captured = await request.json();
+      return HttpResponse.json({ _id: 'abc', email: 'a@b.com', email_verified: false });
+    }));
+    const res = await makeClient().signUp({ email: 'a@b.com', password: 'pw', connection: 'db' });
+    expect(res.id).toBe('abc');
+    expect(captured.client_id).toBe(clientId);
+    expect(captured.client_secret).toBeUndefined();
+    expect(captured.client_assertion).toBeUndefined();
+  });
+
+  test('clientId override wins', async () => {
+    let captured: any;
+    server.use(http.post(`https://${domain}/dbconnections/signup`, async ({ request }) => {
+      captured = await request.json();
+      return HttpResponse.json({ id: 'x', email: 'a@b.com', email_verified: true });
+    }));
+    await makeClient().signUp({ email: 'a@b.com', password: 'pw', connection: 'db', clientId: 'override' });
+    expect(captured.client_id).toBe('override');
+  });
+
+  test('missing password throws SignUpError before request', async () => {
+    await expect(makeClient().signUp({ email: 'a@b.com', connection: 'db' } as any))
+      .rejects.toBeInstanceOf(SignUpError);
+  });
+
+  test('400 {code,description} maps to SignUpError with cause', async () => {
+    server.use(http.post(`https://${domain}/dbconnections/signup`, () =>
+      HttpResponse.json({ name: 'BadRequestError', code: 'invalid_signup', description: 'Invalid sign up' }, { status: 400 })));
+    await expect(makeClient().signUp({ email: 'a@b.com', password: 'pw', connection: 'db' }))
+      .rejects.toMatchObject({ name: 'SignUpError', message: 'Invalid sign up', cause: { error: 'invalid_signup' } });
+  });
+
+  test('network failure wraps in SignUpError', async () => {
+    server.use(http.post(`https://${domain}/dbconnections/signup`, () => { throw new Error('boom'); }));
+    await expect(makeClient().signUp({ email: 'a@b.com', password: 'pw', connection: 'db' }))
+      .rejects.toBeInstanceOf(SignUpError);
+  });
+});
+
+describe('changePassword', () => {
+  test('returns plain text and sends client_id, no client auth', async () => {
+    let captured: any;
+    server.use(http.post(`https://${domain}/dbconnections/change_password`, async ({ request }) => {
+      captured = await request.json();
+      return new HttpResponse("We've just sent you an email to reset your password.", { status: 200 });
+    }));
+    const msg = await makeClient().changePassword({ email: 'a@b.com', connection: 'db' });
+    expect(msg).toBe("We've just sent you an email to reset your password.");
+    expect(captured.client_id).toBe(clientId);
+    expect(captured.client_secret).toBeUndefined();
+  });
+
+  test('missing connection throws ChangePasswordError before request', async () => {
+    await expect(makeClient().changePassword({ email: 'a@b.com' } as any))
+      .rejects.toBeInstanceOf(ChangePasswordError);
+  });
+
+  test('400 error maps to ChangePasswordError', async () => {
+    server.use(http.post(`https://${domain}/dbconnections/change_password`, () =>
+      HttpResponse.json({ error: 'bad', error_description: 'nope' }, { status: 400 })));
+    await expect(makeClient().changePassword({ email: 'a@b.com', connection: 'db' }))
+      .rejects.toMatchObject({ name: 'ChangePasswordError', message: 'nope' });
+  });
+});

--- a/packages/auth0-auth-js/src/database/database-client.spec.ts
+++ b/packages/auth0-auth-js/src/database/database-client.spec.ts
@@ -3,6 +3,7 @@ import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
 import { DatabaseClient } from './database-client.js';
 import { SignUpError, ChangePasswordError } from './errors.js';
+import type { SignUpOptions, ChangePasswordOptions } from './types.js';
 
 const domain = 'auth0.local';
 const clientId = 'test-client-id';
@@ -15,9 +16,9 @@ const makeClient = () => new DatabaseClient({ domain, clientId });
 
 describe('signUp', () => {
   test('normalizes _id and sends client_id, no client auth', async () => {
-    let captured: any;
+    let captured: Record<string, unknown> = {};
     server.use(http.post(`https://${domain}/dbconnections/signup`, async ({ request }) => {
-      captured = await request.json();
+      captured = (await request.json()) as Record<string, unknown>;
       return HttpResponse.json({ _id: 'abc', email: 'a@b.com', email_verified: false });
     }));
     const res = await makeClient().signUp({ email: 'a@b.com', password: 'pw', connection: 'db' });
@@ -28,9 +29,9 @@ describe('signUp', () => {
   });
 
   test('clientId override wins', async () => {
-    let captured: any;
+    let captured: Record<string, unknown> = {};
     server.use(http.post(`https://${domain}/dbconnections/signup`, async ({ request }) => {
-      captured = await request.json();
+      captured = (await request.json()) as Record<string, unknown>;
       return HttpResponse.json({ id: 'x', email: 'a@b.com', email_verified: true });
     }));
     await makeClient().signUp({ email: 'a@b.com', password: 'pw', connection: 'db', clientId: 'override' });
@@ -38,7 +39,7 @@ describe('signUp', () => {
   });
 
   test('missing password throws SignUpError before request', async () => {
-    await expect(makeClient().signUp({ email: 'a@b.com', connection: 'db' } as any))
+    await expect(makeClient().signUp({ email: 'a@b.com', connection: 'db' } as unknown as SignUpOptions))
       .rejects.toBeInstanceOf(SignUpError);
   });
 
@@ -47,6 +48,32 @@ describe('signUp', () => {
       HttpResponse.json({ name: 'BadRequestError', code: 'invalid_signup', description: 'Invalid sign up' }, { status: 400 })));
     await expect(makeClient().signUp({ email: 'a@b.com', password: 'pw', connection: 'db' }))
       .rejects.toMatchObject({ name: 'SignUpError', message: 'Invalid sign up', cause: { error: 'invalid_signup' } });
+  });
+
+  test('cause is sanitized to {error, error_description, message} only', async () => {
+    server.use(http.post(`https://${domain}/dbconnections/signup`, () =>
+      HttpResponse.json(
+        { error: 'invalid_signup', error_description: 'Invalid sign up', trace_id: 'leak', internal: 'secret' },
+        { status: 400 }
+      )));
+    const err: SignUpError = await makeClient()
+      .signUp({ email: 'a@b.com', password: 'pw', connection: 'db' })
+      .then(() => { throw new Error('expected signUp to reject'); }, (e) => e as SignUpError);
+    expect(err).toBeInstanceOf(SignUpError);
+    expect(err.cause).toEqual({ error: 'invalid_signup', error_description: 'Invalid sign up', message: undefined });
+    const cause = err.cause as unknown as Record<string, unknown>;
+    expect(cause.trace_id).toBeUndefined();
+    expect(cause.internal).toBeUndefined();
+  });
+
+  test('missing email throws SignUpError before request', async () => {
+    await expect(makeClient().signUp({ password: 'pw', connection: 'db' } as unknown as SignUpOptions))
+      .rejects.toBeInstanceOf(SignUpError);
+  });
+
+  test('missing connection throws SignUpError before request', async () => {
+    await expect(makeClient().signUp({ email: 'a@b.com', password: 'pw' } as unknown as SignUpOptions))
+      .rejects.toBeInstanceOf(SignUpError);
   });
 
   test('network failure wraps in SignUpError', async () => {
@@ -58,9 +85,9 @@ describe('signUp', () => {
 
 describe('changePassword', () => {
   test('returns plain text and sends client_id, no client auth', async () => {
-    let captured: any;
+    let captured: Record<string, unknown> = {};
     server.use(http.post(`https://${domain}/dbconnections/change_password`, async ({ request }) => {
-      captured = await request.json();
+      captured = (await request.json()) as Record<string, unknown>;
       return new HttpResponse("We've just sent you an email to reset your password.", { status: 200 });
     }));
     const msg = await makeClient().changePassword({ email: 'a@b.com', connection: 'db' });
@@ -69,8 +96,39 @@ describe('changePassword', () => {
     expect(captured.client_secret).toBeUndefined();
   });
 
+  test('clientId override wins', async () => {
+    let captured: Record<string, unknown> = {};
+    server.use(http.post(`https://${domain}/dbconnections/change_password`, async ({ request }) => {
+      captured = (await request.json()) as Record<string, unknown>;
+      return new HttpResponse('ok', { status: 200 });
+    }));
+    await makeClient().changePassword({ email: 'a@b.com', connection: 'db', clientId: 'override' });
+    expect(captured.client_id).toBe('override');
+  });
+
+  test('organization is forwarded on the wire when set', async () => {
+    let captured: Record<string, unknown> = {};
+    server.use(http.post(`https://${domain}/dbconnections/change_password`, async ({ request }) => {
+      captured = (await request.json()) as Record<string, unknown>;
+      return new HttpResponse('ok', { status: 200 });
+    }));
+    await makeClient().changePassword({ email: 'a@b.com', connection: 'db', organization: 'org_1' });
+    expect(captured.organization).toBe('org_1');
+  });
+
   test('missing connection throws ChangePasswordError before request', async () => {
-    await expect(makeClient().changePassword({ email: 'a@b.com' } as any))
+    await expect(makeClient().changePassword({ email: 'a@b.com' } as unknown as ChangePasswordOptions))
+      .rejects.toBeInstanceOf(ChangePasswordError);
+  });
+
+  test('missing email throws ChangePasswordError before request', async () => {
+    await expect(makeClient().changePassword({ connection: 'db' } as unknown as ChangePasswordOptions))
+      .rejects.toBeInstanceOf(ChangePasswordError);
+  });
+
+  test('network failure wraps in ChangePasswordError', async () => {
+    server.use(http.post(`https://${domain}/dbconnections/change_password`, () => { throw new Error('boom'); }));
+    await expect(makeClient().changePassword({ email: 'a@b.com', connection: 'db' }))
       .rejects.toBeInstanceOf(ChangePasswordError);
   });
 

--- a/packages/auth0-auth-js/src/database/database-client.spec.ts
+++ b/packages/auth0-auth-js/src/database/database-client.spec.ts
@@ -121,9 +121,20 @@ describe('changePassword', () => {
       .rejects.toBeInstanceOf(ChangePasswordError);
   });
 
-  test('missing email throws ChangePasswordError before request', async () => {
+  test('missing both email and username throws ChangePasswordError before request', async () => {
     await expect(makeClient().changePassword({ connection: 'db' } as unknown as ChangePasswordOptions))
       .rejects.toBeInstanceOf(ChangePasswordError);
+  });
+
+  test('username-only (no email) is forwarded on the wire', async () => {
+    let captured: Record<string, unknown> = {};
+    server.use(http.post(`https://${domain}/dbconnections/change_password`, async ({ request }) => {
+      captured = (await request.json()) as Record<string, unknown>;
+      return new HttpResponse('ok', { status: 200 });
+    }));
+    await makeClient().changePassword({ username: 'jane', connection: 'db' });
+    expect(captured.username).toBe('jane');
+    expect(captured.email).toBeUndefined();
   });
 
   test('network failure wraps in ChangePasswordError', async () => {

--- a/packages/auth0-auth-js/src/database/database-client.ts
+++ b/packages/auth0-auth-js/src/database/database-client.ts
@@ -1,0 +1,59 @@
+import { SignUpError, ChangePasswordError } from './errors.js';
+import type { DatabaseClientOptions, SignUpOptions, ChangePasswordOptions, SignUpResult } from './types.js';
+import {
+  requireFields, transformSignUpRequest, transformChangePasswordRequest,
+  normalizeSignUpResult, parseErrorBody,
+} from './utils.js';
+
+export class DatabaseClient {
+  #baseUrl: string;
+  #clientId: string;
+  #customFetch: typeof fetch;
+
+  /** @internal */
+  constructor(options: DatabaseClientOptions) {
+    this.#baseUrl = `https://${options.domain}`;
+    this.#clientId = options.clientId;
+    this.#customFetch = options.customFetch ?? ((...args) => fetch(...args));
+  }
+
+  async signUp(options: SignUpOptions): Promise<SignUpResult> {
+    requireFields(options, ['email', 'password', 'connection'], SignUpError);
+    const body = { client_id: options.clientId ?? this.#clientId, ...transformSignUpRequest(options) };
+    const response = await this.#post('/dbconnections/signup', body, SignUpError, 'Failed to sign up');
+    const raw = (await response.json()) as Record<string, unknown>;
+    return normalizeSignUpResult(raw);
+  }
+
+  async changePassword(options: ChangePasswordOptions): Promise<string> {
+    requireFields(options, ['email', 'connection'], ChangePasswordError);
+    const body = { client_id: options.clientId ?? this.#clientId, ...transformChangePasswordRequest(options) };
+    const response = await this.#post(
+      '/dbconnections/change_password', body, ChangePasswordError, 'Failed to request a password change'
+    );
+    return response.text();
+  }
+
+  async #post(
+    path: string,
+    body: Record<string, unknown>,
+    ErrorClass: typeof SignUpError | typeof ChangePasswordError,
+    failureMessage: string
+  ): Promise<Response> {
+    let response: Response;
+    try {
+      response = await this.#customFetch(`${this.#baseUrl}${path}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+    } catch {
+      throw new ErrorClass(`${failureMessage}: a network error occurred.`);
+    }
+    if (response.ok) {
+      return response;
+    }
+    const errorBody = await parseErrorBody(response);
+    throw new ErrorClass(errorBody?.error_description || failureMessage, errorBody);
+  }
+}

--- a/packages/auth0-auth-js/src/database/database-client.ts
+++ b/packages/auth0-auth-js/src/database/database-client.ts
@@ -26,7 +26,10 @@ export class DatabaseClient {
   }
 
   async changePassword(options: ChangePasswordOptions): Promise<string> {
-    requireFields(options, ['email', 'connection'], ChangePasswordError);
+    requireFields(options, ['connection'], ChangePasswordError);
+    if (!options.email && !options.username) {
+      throw new ChangePasswordError('Either "email" or "username" is required.');
+    }
     const body = { client_id: options.clientId ?? this.#clientId, ...transformChangePasswordRequest(options) };
     const response = await this.#post(
       '/dbconnections/change_password', body, ChangePasswordError, 'Failed to request a password change'

--- a/packages/auth0-auth-js/src/database/errors.spec.ts
+++ b/packages/auth0-auth-js/src/database/errors.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from 'vitest';
+import { SignUpError, ChangePasswordError } from './errors.js';
+
+test('SignUpError carries code, name, message, cause', () => {
+  const cause = { error: 'invalid_signup', error_description: 'Invalid sign up' };
+  const err = new SignUpError('Invalid sign up', cause);
+  expect(err).toBeInstanceOf(Error);
+  expect(err.name).toBe('SignUpError');
+  expect(err.code).toBe('signup_error');
+  expect(err.message).toBe('Invalid sign up');
+  expect(err.cause).toEqual(cause);
+});
+
+test('ChangePasswordError carries code and name', () => {
+  const err = new ChangePasswordError('boom');
+  expect(err.name).toBe('ChangePasswordError');
+  expect(err.code).toBe('change_password_error');
+  expect(err.cause).toBeUndefined();
+});

--- a/packages/auth0-auth-js/src/database/errors.ts
+++ b/packages/auth0-auth-js/src/database/errors.ts
@@ -1,3 +1,4 @@
+/** Wire format of an Auth0 Database API error response (snake_case fields as returned by `/dbconnections/*`). */
 export interface DatabaseApiErrorResponse {
   error: string;
   error_description: string;
@@ -11,7 +12,11 @@ abstract class DatabaseError extends Error {
     super(message);
     Object.setPrototypeOf(this, new.target.prototype);
     this.code = code;
-    this.cause = cause;
+    this.cause = cause && {
+      error: cause.error,
+      error_description: cause.error_description,
+      message: cause.message,
+    };
   }
 }
 

--- a/packages/auth0-auth-js/src/database/errors.ts
+++ b/packages/auth0-auth-js/src/database/errors.ts
@@ -1,0 +1,30 @@
+export interface DatabaseApiErrorResponse {
+  error: string;
+  error_description: string;
+  message?: string;
+}
+
+abstract class DatabaseError extends Error {
+  public cause?: DatabaseApiErrorResponse;
+  public code: string;
+  constructor(code: string, message: string, cause?: DatabaseApiErrorResponse) {
+    super(message);
+    Object.setPrototypeOf(this, new.target.prototype);
+    this.code = code;
+    this.cause = cause;
+  }
+}
+
+export class SignUpError extends DatabaseError {
+  constructor(message: string, cause?: DatabaseApiErrorResponse) {
+    super('signup_error', message, cause);
+    this.name = 'SignUpError';
+  }
+}
+
+export class ChangePasswordError extends DatabaseError {
+  constructor(message: string, cause?: DatabaseApiErrorResponse) {
+    super('change_password_error', message, cause);
+    this.name = 'ChangePasswordError';
+  }
+}

--- a/packages/auth0-auth-js/src/database/index.ts
+++ b/packages/auth0-auth-js/src/database/index.ts
@@ -1,0 +1,9 @@
+export { DatabaseClient } from './database-client.js';
+export { SignUpError, ChangePasswordError } from './errors.js';
+export type { DatabaseApiErrorResponse } from './errors.js';
+export type {
+  DatabaseClientOptions,
+  SignUpOptions,
+  ChangePasswordOptions,
+  SignUpResult,
+} from './types.js';

--- a/packages/auth0-auth-js/src/database/types.ts
+++ b/packages/auth0-auth-js/src/database/types.ts
@@ -26,6 +26,7 @@ export interface ChangePasswordOptions {
 }
 
 export interface SignUpResult {
+  /** Normalized user identifier (from `id`, `_id`, or `user_id`). May be undefined when the server response omits an identifier. */
   id?: string;
   email: string;
   emailVerified: boolean;

--- a/packages/auth0-auth-js/src/database/types.ts
+++ b/packages/auth0-auth-js/src/database/types.ts
@@ -1,0 +1,39 @@
+export interface DatabaseClientOptions {
+  domain: string;
+  clientId: string;
+  customFetch?: typeof fetch;
+}
+
+export interface SignUpOptions {
+  email: string;
+  password: string;
+  connection: string;
+  clientId?: string;
+  username?: string;
+  givenName?: string;
+  familyName?: string;
+  name?: string;
+  nickname?: string;
+  picture?: string;
+  userMetadata?: Record<string, unknown>;
+}
+
+export interface ChangePasswordOptions {
+  email: string;
+  connection: string;
+  clientId?: string;
+  organization?: string;
+}
+
+export interface SignUpResult {
+  id?: string;
+  email: string;
+  emailVerified: boolean;
+  username?: string;
+  givenName?: string;
+  familyName?: string;
+  name?: string;
+  nickname?: string;
+  picture?: string;
+  userMetadata?: Record<string, unknown>;
+}

--- a/packages/auth0-auth-js/src/database/types.ts
+++ b/packages/auth0-auth-js/src/database/types.ts
@@ -15,7 +15,11 @@ export interface SignUpOptions {
   name?: string;
   nickname?: string;
   picture?: string;
-  userMetadata?: Record<string, unknown>;
+  /**
+   * Additional user metadata. Server constraints: values must be strings,
+   * max 10 fields, field names ≤ 100 chars, values ≤ 500 chars, no dotted keys.
+   */
+  userMetadata?: Record<string, string>;
 }
 
 export interface ChangePasswordOptions {

--- a/packages/auth0-auth-js/src/database/types.ts
+++ b/packages/auth0-auth-js/src/database/types.ts
@@ -15,6 +15,9 @@ export interface SignUpOptions {
   name?: string;
   nickname?: string;
   picture?: string;
+  // TODO(DEFER): phone_number — gated on `fuji_connection_attribute_configuration`
+  // feature flag + connection attribute config (Flexible Identifiers). Not part of
+  // the classic /dbconnections/signup contract; add when the gated path is GA.
   /**
    * Additional user metadata. Server constraints: values must be strings,
    * max 10 fields, field names ≤ 100 chars, values ≤ 500 chars, no dotted keys.
@@ -23,7 +26,10 @@ export interface SignUpOptions {
 }
 
 export interface ChangePasswordOptions {
-  email: string;
+  /** User's email. Provide `email` or `username`; at least one is required. Ignored server-side when both are sent. */
+  email?: string;
+  /** User's username, for username-only database connections. Provide `email` or `username`; at least one is required. */
+  username?: string;
   connection: string;
   clientId?: string;
   organization?: string;

--- a/packages/auth0-auth-js/src/database/utils.spec.ts
+++ b/packages/auth0-auth-js/src/database/utils.spec.ts
@@ -32,6 +32,15 @@ test('normalizeSignUpResult resolves identifier from _id, user_id, id', () => {
   expect(normalizeSignUpResult({ id: 'z', email: 'a@b.com', email_verified: true }).id).toBe('z');
 });
 
+test('normalizeSignUpResult prefers _id over user_id over id (node-auth0 precedence)', () => {
+  expect(normalizeSignUpResult({ _id: 'a', user_id: 'b', id: 'c', email: 'a@b.com', email_verified: false }).id).toBe('a');
+  expect(normalizeSignUpResult({ user_id: 'b', id: 'c', email: 'a@b.com', email_verified: false }).id).toBe('b');
+});
+
+test('normalizeSignUpResult defaults email to empty string when server omits it', () => {
+  expect(normalizeSignUpResult({ id: 'z', email_verified: false }).email).toBe('');
+});
+
 test('normalizeSignUpResult leaves id undefined when no identifier present', () => {
   const r = normalizeSignUpResult({ email: 'a@b.com', email_verified: false, given_name: 'Jo' });
   expect(r.id).toBeUndefined();
@@ -56,6 +65,12 @@ test('normalizeSignUpResult maps all optional profile fields to camelCase (T1.4)
 test('requireFields throws the given error class before any work', () => {
   expect(() => requireFields(
     { email: 'a@b.com' } as unknown as SignUpOptions, ['email', 'password'], SignUpError
+  )).toThrowError(SignUpError);
+});
+
+test('requireFields rejects empty-string values', () => {
+  expect(() => requireFields(
+    { email: '', password: 'pw' } as unknown as SignUpOptions, ['email', 'password'], SignUpError
   )).toThrowError(SignUpError);
 });
 

--- a/packages/auth0-auth-js/src/database/utils.spec.ts
+++ b/packages/auth0-auth-js/src/database/utils.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from 'vitest';
+import {
+  requireFields, transformSignUpRequest, transformChangePasswordRequest,
+  normalizeSignUpResult, parseErrorBody,
+} from './utils.js';
+import { SignUpError } from './errors.js';
+
+test('transformSignUpRequest maps camelCase to snake_case, omits clientId', () => {
+  const wire = transformSignUpRequest({
+    email: 'a@b.com', password: 'pw', connection: 'db', clientId: 'override',
+    givenName: 'Jo', familyName: 'Bloggs', userMetadata: { plan: 'free' },
+  });
+  expect(wire).toEqual({
+    email: 'a@b.com', password: 'pw', connection: 'db',
+    given_name: 'Jo', family_name: 'Bloggs', user_metadata: { plan: 'free' },
+  });
+  expect(wire.clientId).toBeUndefined();
+  expect(wire.client_id).toBeUndefined(); // client_id added by the client, not here
+});
+
+test('transformChangePasswordRequest includes organization only when set', () => {
+  expect(transformChangePasswordRequest({ email: 'a@b.com', connection: 'db' }))
+    .toEqual({ email: 'a@b.com', connection: 'db' });
+  expect(transformChangePasswordRequest({ email: 'a@b.com', connection: 'db', organization: 'org_1' }))
+    .toEqual({ email: 'a@b.com', connection: 'db', organization: 'org_1' });
+});
+
+test('normalizeSignUpResult resolves identifier from _id, user_id, id', () => {
+  expect(normalizeSignUpResult({ _id: 'x', email: 'a@b.com', email_verified: false }).id).toBe('x');
+  expect(normalizeSignUpResult({ user_id: 'y', email: 'a@b.com', email_verified: true }).id).toBe('y');
+  expect(normalizeSignUpResult({ id: 'z', email: 'a@b.com', email_verified: true }).id).toBe('z');
+});
+
+test('normalizeSignUpResult leaves id undefined when no identifier present', () => {
+  const r = normalizeSignUpResult({ email: 'a@b.com', email_verified: false, given_name: 'Jo' });
+  expect(r.id).toBeUndefined();
+  expect(r.email).toBe('a@b.com');
+  expect(r.emailVerified).toBe(false);
+  expect(r.givenName).toBe('Jo');
+});
+
+test('normalizeSignUpResult maps all optional profile fields to camelCase (T1.4)', () => {
+  const r = normalizeSignUpResult({
+    id: 'z', email: 'a@b.com', email_verified: true,
+    username: 'jo', given_name: 'Jo', family_name: 'Bloggs', name: 'Jo Bloggs',
+    nickname: 'jojo', picture: 'https://img', user_metadata: { plan: 'pro' },
+  });
+  expect(r).toEqual({
+    id: 'z', email: 'a@b.com', emailVerified: true,
+    username: 'jo', givenName: 'Jo', familyName: 'Bloggs', name: 'Jo Bloggs',
+    nickname: 'jojo', picture: 'https://img', userMetadata: { plan: 'pro' },
+  });
+});
+
+test('requireFields throws the given error class before any work', () => {
+  expect(() => requireFields({ email: 'a@b.com' } as any, ['email', 'password'], SignUpError))
+    .toThrowError(SignUpError);
+});
+
+test('parseErrorBody accepts {code,description} and {error,error_description}', async () => {
+  const a = await parseErrorBody(new Response(JSON.stringify({ code: 'invalid_signup', description: 'Invalid sign up' }), { status: 400 }));
+  expect(a).toEqual({ error: 'invalid_signup', error_description: 'Invalid sign up' });
+  const b = await parseErrorBody(new Response(JSON.stringify({ error: 'bad', error_description: 'nope' }), { status: 400 }));
+  expect(b).toEqual({ error: 'bad', error_description: 'nope' });
+  const c = await parseErrorBody(new Response('not json', { status: 500 }));
+  expect(c).toBeUndefined();
+});

--- a/packages/auth0-auth-js/src/database/utils.spec.ts
+++ b/packages/auth0-auth-js/src/database/utils.spec.ts
@@ -4,6 +4,7 @@ import {
   normalizeSignUpResult, parseErrorBody,
 } from './utils.js';
 import { SignUpError } from './errors.js';
+import type { SignUpOptions } from './types.js';
 
 test('transformSignUpRequest maps camelCase to snake_case, omits clientId', () => {
   const wire = transformSignUpRequest({
@@ -53,8 +54,9 @@ test('normalizeSignUpResult maps all optional profile fields to camelCase (T1.4)
 });
 
 test('requireFields throws the given error class before any work', () => {
-  expect(() => requireFields({ email: 'a@b.com' } as any, ['email', 'password'], SignUpError))
-    .toThrowError(SignUpError);
+  expect(() => requireFields(
+    { email: 'a@b.com' } as unknown as SignUpOptions, ['email', 'password'], SignUpError
+  )).toThrowError(SignUpError);
 });
 
 test('parseErrorBody accepts {code,description} and {error,error_description}', async () => {
@@ -64,4 +66,6 @@ test('parseErrorBody accepts {code,description} and {error,error_description}', 
   expect(b).toEqual({ error: 'bad', error_description: 'nope' });
   const c = await parseErrorBody(new Response('not json', { status: 500 }));
   expect(c).toBeUndefined();
+  const d = await parseErrorBody(new Response(JSON.stringify({ code: 'x' }), { status: 400 }));
+  expect(d).toEqual({ error: 'x', error_description: '' });
 });

--- a/packages/auth0-auth-js/src/database/utils.spec.ts
+++ b/packages/auth0-auth-js/src/database/utils.spec.ts
@@ -26,6 +26,13 @@ test('transformChangePasswordRequest includes organization only when set', () =>
     .toEqual({ email: 'a@b.com', connection: 'db', organization: 'org_1' });
 });
 
+test('transformChangePasswordRequest forwards username for username-only connections', () => {
+  expect(transformChangePasswordRequest({ username: 'jane', connection: 'db' }))
+    .toEqual({ connection: 'db', username: 'jane' });
+  expect(transformChangePasswordRequest({ email: 'a@b.com', username: 'jane', connection: 'db' }))
+    .toEqual({ connection: 'db', email: 'a@b.com', username: 'jane' });
+});
+
 test('normalizeSignUpResult resolves identifier from _id, user_id, id', () => {
   expect(normalizeSignUpResult({ _id: 'x', email: 'a@b.com', email_verified: false }).id).toBe('x');
   expect(normalizeSignUpResult({ user_id: 'y', email: 'a@b.com', email_verified: true }).id).toBe('y');

--- a/packages/auth0-auth-js/src/database/utils.ts
+++ b/packages/auth0-auth-js/src/database/utils.ts
@@ -65,7 +65,10 @@ export async function parseErrorBody(response: Response): Promise<DatabaseApiErr
     return raw as unknown as DatabaseApiErrorResponse;
   }
   if (typeof raw.code === 'string') {
-    return { error: raw.code, error_description: (raw.description as string) ?? '' };
+    return {
+      error: raw.code,
+      error_description: typeof raw.description === 'string' ? raw.description : '',
+    };
   }
   return undefined;
 }

--- a/packages/auth0-auth-js/src/database/utils.ts
+++ b/packages/auth0-auth-js/src/database/utils.ts
@@ -7,8 +7,8 @@ export function requireFields<T>(
   options: T, keys: Array<keyof T>, ErrorClass: ErrorCtor
 ): void {
   for (const key of keys) {
-    if (options[key] === null || options[key] === undefined) {
-      throw new ErrorClass(`Required parameter "${String(key)}" was null or undefined.`);
+    if (options[key] === null || options[key] === undefined || options[key] === '') {
+      throw new ErrorClass(`Required parameter "${String(key)}" was null, undefined, or empty.`);
     }
   }
 }
@@ -39,10 +39,11 @@ export function transformChangePasswordRequest(options: ChangePasswordOptions): 
 }
 
 export function normalizeSignUpResult(raw: Record<string, unknown>): SignUpResult {
-  const id = (raw.id ?? raw._id ?? raw.user_id) as string | undefined;
+  // Match node-auth0 identifier precedence: `_id || user_id || id`.
+  const id = (raw._id ?? raw.user_id ?? raw.id) as string | undefined;
   return {
     id,
-    email: raw.email as string,
+    email: typeof raw.email === 'string' ? raw.email : '',
     emailVerified: Boolean(raw.email_verified),
     username: raw.username as string | undefined,
     givenName: raw.given_name as string | undefined,
@@ -50,7 +51,7 @@ export function normalizeSignUpResult(raw: Record<string, unknown>): SignUpResul
     name: raw.name as string | undefined,
     nickname: raw.nickname as string | undefined,
     picture: raw.picture as string | undefined,
-    userMetadata: raw.user_metadata as Record<string, unknown> | undefined,
+    userMetadata: raw.user_metadata as Record<string, string> | undefined,
   };
 }
 

--- a/packages/auth0-auth-js/src/database/utils.ts
+++ b/packages/auth0-auth-js/src/database/utils.ts
@@ -1,0 +1,71 @@
+import type { SignUpOptions, ChangePasswordOptions, SignUpResult } from './types.js';
+import type { DatabaseApiErrorResponse } from './errors.js';
+
+type ErrorCtor = new (message: string, cause?: DatabaseApiErrorResponse) => Error;
+
+export function requireFields<T>(
+  options: T, keys: Array<keyof T>, ErrorClass: ErrorCtor
+): void {
+  for (const key of keys) {
+    if (options[key] === null || options[key] === undefined) {
+      throw new ErrorClass(`Required parameter "${String(key)}" was null or undefined.`);
+    }
+  }
+}
+
+export function transformSignUpRequest(options: SignUpOptions): Record<string, unknown> {
+  const wire: Record<string, unknown> = {
+    email: options.email,
+    password: options.password,
+    connection: options.connection,
+  };
+  if (options.username !== undefined) wire.username = options.username;
+  if (options.givenName !== undefined) wire.given_name = options.givenName;
+  if (options.familyName !== undefined) wire.family_name = options.familyName;
+  if (options.name !== undefined) wire.name = options.name;
+  if (options.nickname !== undefined) wire.nickname = options.nickname;
+  if (options.picture !== undefined) wire.picture = options.picture;
+  if (options.userMetadata !== undefined) wire.user_metadata = options.userMetadata;
+  return wire;
+}
+
+export function transformChangePasswordRequest(options: ChangePasswordOptions): Record<string, unknown> {
+  const wire: Record<string, unknown> = {
+    email: options.email,
+    connection: options.connection,
+  };
+  if (options.organization !== undefined) wire.organization = options.organization;
+  return wire;
+}
+
+export function normalizeSignUpResult(raw: Record<string, unknown>): SignUpResult {
+  const id = (raw.id ?? raw._id ?? raw.user_id) as string | undefined;
+  return {
+    id,
+    email: raw.email as string,
+    emailVerified: Boolean(raw.email_verified),
+    username: raw.username as string | undefined,
+    givenName: raw.given_name as string | undefined,
+    familyName: raw.family_name as string | undefined,
+    name: raw.name as string | undefined,
+    nickname: raw.nickname as string | undefined,
+    picture: raw.picture as string | undefined,
+    userMetadata: raw.user_metadata as Record<string, unknown> | undefined,
+  };
+}
+
+export async function parseErrorBody(response: Response): Promise<DatabaseApiErrorResponse | undefined> {
+  let raw: Record<string, unknown> | undefined;
+  try {
+    raw = (await response.json()) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+  if (typeof raw.error === 'string') {
+    return raw as unknown as DatabaseApiErrorResponse;
+  }
+  if (typeof raw.code === 'string') {
+    return { error: raw.code, error_description: (raw.description as string) ?? '' };
+  }
+  return undefined;
+}

--- a/packages/auth0-auth-js/src/database/utils.ts
+++ b/packages/auth0-auth-js/src/database/utils.ts
@@ -31,9 +31,10 @@ export function transformSignUpRequest(options: SignUpOptions): Record<string, u
 
 export function transformChangePasswordRequest(options: ChangePasswordOptions): Record<string, unknown> {
   const wire: Record<string, unknown> = {
-    email: options.email,
     connection: options.connection,
   };
+  if (options.email !== undefined) wire.email = options.email;
+  if (options.username !== undefined) wire.username = options.username;
   if (options.organization !== undefined) wire.organization = options.organization;
   return wire;
 }
@@ -51,7 +52,7 @@ export function normalizeSignUpResult(raw: Record<string, unknown>): SignUpResul
     name: raw.name as string | undefined,
     nickname: raw.nickname as string | undefined,
     picture: raw.picture as string | undefined,
-    userMetadata: raw.user_metadata as Record<string, string> | undefined,
+    userMetadata: raw.user_metadata as Record<string, unknown> | undefined,
   };
 }
 

--- a/packages/auth0-auth-js/src/index.ts
+++ b/packages/auth0-auth-js/src/index.ts
@@ -17,9 +17,4 @@ export type {
   PasswordlessChallenge,
   TokenByPasswordlessDbConnectionOptions,
 } from './passwordless/types.js';
-export { DatabaseClient } from './database/database-client.js';
-export { SignUpError, ChangePasswordError } from './database/errors.js';
-export type { DatabaseApiErrorResponse } from './database/errors.js';
-export type {
-  DatabaseClientOptions, SignUpOptions, ChangePasswordOptions, SignUpResult,
-} from './database/types.js';
+export * from './database/index.js';

--- a/packages/auth0-auth-js/src/index.ts
+++ b/packages/auth0-auth-js/src/index.ts
@@ -17,3 +17,9 @@ export type {
   PasswordlessChallenge,
   TokenByPasswordlessDbConnectionOptions,
 } from './passwordless/types.js';
+export { DatabaseClient } from './database/database-client.js';
+export { SignUpError, ChangePasswordError } from './database/errors.js';
+export type { DatabaseApiErrorResponse } from './database/errors.js';
+export type {
+  DatabaseClientOptions, SignUpOptions, ChangePasswordOptions, SignUpResult,
+} from './database/types.js';

--- a/packages/auth0-server-js/src/database/index.ts
+++ b/packages/auth0-server-js/src/database/index.ts
@@ -1,0 +1,6 @@
+export { ServerDatabaseClient } from './server-database-client.js';
+
+// Re-export database error classes from auth0-auth-js for convenience, so consumers
+// can narrow thrown errors via `instanceof` without importing auth0-auth-js directly.
+// The database option/result types are re-exported from `../types.js`.
+export { SignUpError, ChangePasswordError } from '@auth0/auth0-auth-js';

--- a/packages/auth0-server-js/src/database/server-database-client.spec.ts
+++ b/packages/auth0-server-js/src/database/server-database-client.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test, afterAll, afterEach, beforeAll, vi } from 'vitest';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import { ServerClient } from '../server-client.js';
+import { SignUpError, ChangePasswordError } from '../index.js';
+import { DefaultStateStore } from '../test-utils/default-state-store.js';
+
+const domain = 'auth0.local';
+const server = setupServer();
+beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const makeClient = (domainOption: string | (() => Promise<string>) = domain) =>
+  new ServerClient({
+    domain: domainOption,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: new DefaultStateStore({ secret: '<secret>' }),
+  });
+
+test('exposes a database sub-client with signUp and changePassword', () => {
+  const sc = makeClient();
+  expect(sc.database).toBeDefined();
+  expect(typeof sc.database.signUp).toBe('function');
+  expect(typeof sc.database.changePassword).toBe('function');
+});
+
+test('database.signUp delegates and writes no session', async () => {
+  let captured: Record<string, unknown> = {};
+  server.use(http.post(`https://${domain}/dbconnections/signup`, async ({ request }) => {
+    captured = (await request.json()) as Record<string, unknown>;
+    return HttpResponse.json({ _id: 'abc', email: 'a@b.com', email_verified: false });
+  }));
+  const stateStore = new DefaultStateStore({ secret: '<secret>' });
+  const setSpy = vi.spyOn(stateStore, 'set');
+  const sc = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore,
+  });
+
+  const res = await sc.database.signUp({ email: 'a@b.com', password: 'pw', connection: 'db' });
+
+  expect(res.id).toBe('abc');
+  expect(captured.client_id).toBe('<client_id>');
+  expect(setSpy).not.toHaveBeenCalled();
+});
+
+test('database.changePassword delegates and writes no session', async () => {
+  server.use(http.post(`https://${domain}/dbconnections/change_password`, () =>
+    new HttpResponse("We've just sent you an email to reset your password.", { status: 200 })));
+  const stateStore = new DefaultStateStore({ secret: '<secret>' });
+  const setSpy = vi.spyOn(stateStore, 'set');
+  const sc = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore,
+  });
+
+  const msg = await sc.database.changePassword({ email: 'a@b.com', connection: 'db' });
+
+  expect(msg).toContain('reset your password');
+  expect(setSpy).not.toHaveBeenCalled();
+});
+
+test('database.signUp resolves the domain in resolver mode', async () => {
+  let host: string | undefined;
+  server.use(http.post(`https://${domain}/dbconnections/signup`, ({ request }) => {
+    host = new URL(request.url).host;
+    return HttpResponse.json({ id: 'x', email: 'a@b.com', email_verified: true });
+  }));
+
+  const res = await makeClient(async () => domain).database.signUp({
+    email: 'a@b.com',
+    password: 'pw',
+    connection: 'db',
+  });
+
+  expect(res.id).toBe('x');
+  expect(host).toBe(domain);
+});
+
+test('database.signUp surfaces SignUpError from the underlying client', async () => {
+  server.use(http.post(`https://${domain}/dbconnections/signup`, () =>
+    HttpResponse.json({ error: 'invalid_signup', error_description: 'Invalid sign up' }, { status: 400 })));
+
+  await expect(
+    makeClient().database.signUp({ email: 'a@b.com', password: 'pw', connection: 'db' })
+  ).rejects.toBeInstanceOf(SignUpError);
+});
+
+test('database.changePassword surfaces ChangePasswordError from the underlying client', async () => {
+  server.use(http.post(`https://${domain}/dbconnections/change_password`, () =>
+    HttpResponse.json({ error: 'bad', error_description: 'nope' }, { status: 400 })));
+
+  await expect(
+    makeClient().database.changePassword({ email: 'a@b.com', connection: 'db' })
+  ).rejects.toBeInstanceOf(ChangePasswordError);
+});

--- a/packages/auth0-server-js/src/database/server-database-client.ts
+++ b/packages/auth0-server-js/src/database/server-database-client.ts
@@ -1,0 +1,51 @@
+import type { ServerDatabaseClientOptions } from './types.js';
+import type { SignUpOptions, ChangePasswordOptions, SignUpResult } from '../types.js';
+
+export class ServerDatabaseClient<TStoreOptions = unknown> {
+  readonly #options: ServerDatabaseClientOptions<TStoreOptions>;
+
+  /**
+   * @internal
+   */
+  constructor(options: ServerDatabaseClientOptions<TStoreOptions>) {
+    this.#options = options;
+  }
+
+  /**
+   * Registers a new user in a database connection.
+   *
+   * Delegates to the underlying `AuthClient.database.signUp` without any session
+   * state modification. The caller is responsible for handling the returned user
+   * data as needed.
+   *
+   * @param options The signup options (email, password, connection, etc.).
+   * @param storeOptions Optional options used to resolve the domain (resolver mode).
+   *
+   * @throws {SignUpError} If there was an issue signing the user up.
+   *
+   * @returns A promise resolving to the created user result with a normalized `id` field.
+   */
+  async signUp(options: SignUpOptions, storeOptions?: TStoreOptions): Promise<SignUpResult> {
+    const domain = await this.#options.resolveDomain(storeOptions);
+    return this.#options.getAuthClient(domain).database.signUp(options);
+  }
+
+  /**
+   * Requests a password-change email for a database connection user.
+   *
+   * Delegates to the underlying `AuthClient.database.changePassword` without any
+   * session state modification. The caller is responsible for informing the user
+   * of the sent email as needed.
+   *
+   * @param options The password change options (email, connection, organization, etc.).
+   * @param storeOptions Optional options used to resolve the domain (resolver mode).
+   *
+   * @throws {ChangePasswordError} If there was an issue requesting the password change.
+   *
+   * @returns A promise resolving to the server's plain-text confirmation message.
+   */
+  async changePassword(options: ChangePasswordOptions, storeOptions?: TStoreOptions): Promise<string> {
+    const domain = await this.#options.resolveDomain(storeOptions);
+    return this.#options.getAuthClient(domain).database.changePassword(options);
+  }
+}

--- a/packages/auth0-server-js/src/database/types.ts
+++ b/packages/auth0-server-js/src/database/types.ts
@@ -1,0 +1,16 @@
+import type { AuthClient } from '@auth0/auth0-auth-js';
+
+/**
+ * @internal
+ * Options for constructing a ServerDatabaseClient.
+ *
+ * Like the passkey client, the database client resolves the domain per call so
+ * it keeps working in resolver (multi-tenant) mode. It therefore receives the
+ * parent client's `resolveDomain` and `getAuthClient` helpers instead of a
+ * fixed domain/authClient. Unlike the MFA/passkey clients, it never touches the
+ * state store — signup and change-password write no session.
+ */
+export interface ServerDatabaseClientOptions<TStoreOptions = unknown> {
+  resolveDomain: (storeOptions?: TStoreOptions) => Promise<string>;
+  getAuthClient: (domain: string) => AuthClient;
+}

--- a/packages/auth0-server-js/src/index.ts
+++ b/packages/auth0-server-js/src/index.ts
@@ -2,7 +2,7 @@ export { ServerClient } from './server-client.js';
 export { AbstractStateStore } from './store/abstract-state-store.js';
 export { AbstractTransactionStore } from './store/abstract-transaction-store.js';
 export type { TokenResponse, ActClaim } from '@auth0/auth0-auth-js';
-export { TokenExchangeError, MissingClientAuthError, OrganizationValidationError } from '@auth0/auth0-auth-js';
+export { TokenExchangeError, MissingClientAuthError, OrganizationValidationError, SignUpError, ChangePasswordError } from '@auth0/auth0-auth-js';
 
 export type { CookieHandler, CookieSerializeOptions } from './store/cookie-handler.js';
 export { CookieTransactionStore } from './store/cookie-transaction-store.js';

--- a/packages/auth0-server-js/src/index.ts
+++ b/packages/auth0-server-js/src/index.ts
@@ -2,7 +2,7 @@ export { ServerClient } from './server-client.js';
 export { AbstractStateStore } from './store/abstract-state-store.js';
 export { AbstractTransactionStore } from './store/abstract-transaction-store.js';
 export type { TokenResponse, ActClaim } from '@auth0/auth0-auth-js';
-export { TokenExchangeError, MissingClientAuthError, OrganizationValidationError, SignUpError, ChangePasswordError } from '@auth0/auth0-auth-js';
+export { TokenExchangeError, MissingClientAuthError, OrganizationValidationError } from '@auth0/auth0-auth-js';
 
 export type { CookieHandler, CookieSerializeOptions } from './store/cookie-handler.js';
 export { CookieTransactionStore } from './store/cookie-transaction-store.js';
@@ -15,3 +15,4 @@ export * from './errors.js';
 export * from './types.js';
 export * from './mfa/index.js';
 export * from './passkey/index.js';
+export * from './database/index.js';

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -6700,3 +6700,59 @@ describe('organization support', () => {
     expect(mockStateStore.set).toHaveBeenCalled();
   });
 });
+
+test('signUp passes through and writes no session', async () => {
+  let captured: any;
+  server.use(http.post(`https://${domain}/dbconnections/signup`, async ({ request }) => {
+    captured = await request.json();
+    return HttpResponse.json({ _id: 'abc', email: 'a@b.com', email_verified: false });
+  }));
+  const stateStore = new DefaultStateStore({ secret: '<secret>' });
+  const setSpy = vi.spyOn(stateStore, 'set');
+  const sc = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore,
+  });
+  const res = await sc.signUp({ email: 'a@b.com', password: 'pw', connection: 'db' });
+  expect(res.id).toBe('abc');
+  expect(captured.client_id).toBe('<client_id>');
+  expect(setSpy).not.toHaveBeenCalled();
+});
+
+test('changePassword passes through and writes no session', async () => {
+  server.use(http.post(`https://${domain}/dbconnections/change_password`, () =>
+    new HttpResponse("We've just sent you an email to reset your password.", { status: 200 })));
+  const stateStore = new DefaultStateStore({ secret: '<secret>' });
+  const setSpy = vi.spyOn(stateStore, 'set');
+  const sc = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore,
+  });
+  const msg = await sc.changePassword({ email: 'a@b.com', connection: 'db' });
+  expect(msg).toContain('reset your password');
+  expect(setSpy).not.toHaveBeenCalled();
+});
+
+test('signUp resolves the domain in resolver mode (T4.3)', async () => {
+  let host: string | undefined;
+  server.use(http.post(`https://${domain}/dbconnections/signup`, ({ request }) => {
+    host = new URL(request.url).host;
+    return HttpResponse.json({ id: 'x', email: 'a@b.com', email_verified: true });
+  }));
+  const sc = new ServerClient({
+    domain: async () => domain,          // resolver mode
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: new DefaultStateStore({ secret: '<secret>' }),
+  });
+  const res = await sc.signUp({ email: 'a@b.com', password: 'pw', connection: 'db' });
+  expect(res.id).toBe('x');
+  expect(host).toBe(domain);
+});

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -6756,3 +6756,21 @@ test('signUp resolves the domain in resolver mode (T4.3)', async () => {
   expect(res.id).toBe('x');
   expect(host).toBe(domain);
 });
+
+test('changePassword resolves the domain in resolver mode (T4.3)', async () => {
+  let host: string | undefined;
+  server.use(http.post(`https://${domain}/dbconnections/change_password`, ({ request }) => {
+    host = new URL(request.url).host;
+    return new HttpResponse("We've just sent you an email to reset your password.", { status: 200 });
+  }));
+  const sc = new ServerClient({
+    domain: async () => domain,          // resolver mode
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: new DefaultStateStore({ secret: '<secret>' }),
+  });
+  const msg = await sc.changePassword({ email: 'a@b.com', connection: 'db' });
+  expect(msg).toContain('reset your password');
+  expect(host).toBe(domain);
+});

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -6716,7 +6716,7 @@ test('signUp passes through and writes no session', async () => {
     transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
     stateStore,
   });
-  const res = await sc.signUp({ email: 'a@b.com', password: 'pw', connection: 'db' });
+  const res = await sc.database.signUp({ email: 'a@b.com', password: 'pw', connection: 'db' });
   expect(res.id).toBe('abc');
   expect(captured.client_id).toBe('<client_id>');
   expect(setSpy).not.toHaveBeenCalled();
@@ -6734,7 +6734,7 @@ test('changePassword passes through and writes no session', async () => {
     transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
     stateStore,
   });
-  const msg = await sc.changePassword({ email: 'a@b.com', connection: 'db' });
+  const msg = await sc.database.changePassword({ email: 'a@b.com', connection: 'db' });
   expect(msg).toContain('reset your password');
   expect(setSpy).not.toHaveBeenCalled();
 });
@@ -6752,7 +6752,7 @@ test('signUp resolves the domain in resolver mode (T4.3)', async () => {
     transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
     stateStore: new DefaultStateStore({ secret: '<secret>' }),
   });
-  const res = await sc.signUp({ email: 'a@b.com', password: 'pw', connection: 'db' });
+  const res = await sc.database.signUp({ email: 'a@b.com', password: 'pw', connection: 'db' });
   expect(res.id).toBe('x');
   expect(host).toBe(domain);
 });
@@ -6770,7 +6770,7 @@ test('changePassword resolves the domain in resolver mode (T4.3)', async () => {
     transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
     stateStore: new DefaultStateStore({ secret: '<secret>' }),
   });
-  const msg = await sc.changePassword({ email: 'a@b.com', connection: 'db' });
+  const msg = await sc.database.changePassword({ email: 'a@b.com', connection: 'db' });
   expect(msg).toContain('reset your password');
   expect(host).toBe(domain);
 });

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -6702,9 +6702,9 @@ describe('organization support', () => {
 });
 
 test('signUp passes through and writes no session', async () => {
-  let captured: any;
+  let captured: Record<string, unknown> = {};
   server.use(http.post(`https://${domain}/dbconnections/signup`, async ({ request }) => {
-    captured = await request.json();
+    captured = (await request.json()) as Record<string, unknown>;
     return HttpResponse.json({ _id: 'abc', email: 'a@b.com', email_verified: false });
   }));
   const stateStore = new DefaultStateStore({ secret: '<secret>' });

--- a/packages/auth0-server-js/src/server-client.ts
+++ b/packages/auth0-server-js/src/server-client.ts
@@ -47,9 +47,6 @@ import {
   TokenByRefreshTokenError,
   TokenByRefreshTokenOptions,
   TokenResponse,
-  type SignUpOptions,
-  type ChangePasswordOptions,
-  type SignUpResult,
 } from '@auth0/auth0-auth-js';
 import { compareScopes, ensureOpenIdScope } from './utils.js';
 import { decodeJwt } from 'jose';
@@ -57,6 +54,7 @@ import type { AuthClientOptions } from '@auth0/auth0-auth-js';
 import { getTelemetryConfig } from './telemetry.js';
 import { ServerMfaClient } from './mfa/server-mfa-client.js';
 import { ServerPasskeyClient } from './passkey/server-passkey-client.js';
+import { ServerDatabaseClient } from './database/server-database-client.js';
 
 const normalizeDomain = (value: string) => {
   const trimmed = value.trim();
@@ -84,6 +82,7 @@ export class ServerClient<TStoreOptions = unknown> {
   readonly #authClient?: AuthClient;
   readonly #mfaClient?: ServerMfaClient<TStoreOptions>;
   readonly #passkeyClient: ServerPasskeyClient<TStoreOptions>;
+  readonly #databaseClient: ServerDatabaseClient<TStoreOptions>;
 
   /**
    * The underlying `authClient` instance that can be used to interact with the Auth0 Authentication API.
@@ -133,6 +132,22 @@ export class ServerClient<TStoreOptions = unknown> {
    */
   public get passkey(): ServerPasskeyClient<TStoreOptions> {
     return this.#passkeyClient;
+  }
+
+  /**
+   * The database client for self-service sign-up and password-change requests
+   * against an Auth0 database connection.
+   *
+   * Provides `signUp()` to register a user and `changePassword()` to request a
+   * password-reset email. Both are pure passthrough operations to the Auth0
+   * Authentication API — they never read or write the session/state store.
+   *
+   * Like `passkey`, this property is available in both static and resolver
+   * (multi-tenant) domain modes. In resolver mode, pass `storeOptions` so the
+   * request resolves the intended tenant.
+   */
+  public get database(): ServerDatabaseClient<TStoreOptions> {
+    return this.#databaseClient;
   }
 
   constructor(options: ServerClientOptions<TStoreOptions>) {
@@ -192,6 +207,14 @@ export class ServerClient<TStoreOptions = unknown> {
       stateStoreIdentifier: this.#stateStoreIdentifier,
       defaultScope: this.#options.authorizationParams?.scope,
       defaultAudience: this.#options.authorizationParams?.audience,
+    });
+
+    // The database client resolves the domain per call (works in both static and
+    // resolver modes) and never touches the state store — signup / change-password
+    // write no session.
+    this.#databaseClient = new ServerDatabaseClient({
+      resolveDomain: (storeOptions) => this.#resolveDomain(storeOptions),
+      getAuthClient: (domain) => this.#getAuthClient(domain),
     });
   }
 
@@ -1187,35 +1210,5 @@ export class ServerClient<TStoreOptions = unknown> {
     const logoutTokenClaims = await authClient.verifyLogoutToken({ logoutToken });
 
     await this.#stateStore.deleteByLogoutToken({ ...logoutTokenClaims, iss: issuer }, storeOptions);
-  }
-
-  /**
-   * Performs database connection signup.
-   *
-   * Delegates to the underlying `AuthClient.database.signUp` without any session state modification.
-   * The caller is responsible for handling the returned user data as needed.
-   *
-   * @param options - The signup options (email, password, connection, etc.)
-   * @param storeOptions - Optional store-specific options for domain resolution in resolver mode
-   * @returns The created user result with normalized id field
-   */
-  public async signUp(options: SignUpOptions, storeOptions?: TStoreOptions): Promise<SignUpResult> {
-    const domain = await this.#resolveDomain(storeOptions);
-    return this.#getAuthClient(domain).database.signUp(options);
-  }
-
-  /**
-   * Requests a password change email for database connection users.
-   *
-   * Delegates to the underlying `AuthClient.database.changePassword` without any session state modification.
-   * The caller is responsible for informing the user of the sent email as needed.
-   *
-   * @param options - The password change options (email, connection, organization, etc.)
-   * @param storeOptions - Optional store-specific options for domain resolution in resolver mode
-   * @returns A plain text confirmation message from the server
-   */
-  public async changePassword(options: ChangePasswordOptions, storeOptions?: TStoreOptions): Promise<string> {
-    const domain = await this.#resolveDomain(storeOptions);
-    return this.#getAuthClient(domain).database.changePassword(options);
   }
 }

--- a/packages/auth0-server-js/src/server-client.ts
+++ b/packages/auth0-server-js/src/server-client.ts
@@ -47,6 +47,9 @@ import {
   TokenByRefreshTokenError,
   TokenByRefreshTokenOptions,
   TokenResponse,
+  type SignUpOptions,
+  type ChangePasswordOptions,
+  type SignUpResult,
 } from '@auth0/auth0-auth-js';
 import { compareScopes, ensureOpenIdScope } from './utils.js';
 import { decodeJwt } from 'jose';
@@ -1184,5 +1187,35 @@ export class ServerClient<TStoreOptions = unknown> {
     const logoutTokenClaims = await authClient.verifyLogoutToken({ logoutToken });
 
     await this.#stateStore.deleteByLogoutToken({ ...logoutTokenClaims, iss: issuer }, storeOptions);
+  }
+
+  /**
+   * Performs database connection signup.
+   *
+   * Delegates to the underlying `AuthClient.database.signUp` without any session state modification.
+   * The caller is responsible for handling the returned user data as needed.
+   *
+   * @param options - The signup options (email, password, connection, etc.)
+   * @param storeOptions - Optional store-specific options for domain resolution in resolver mode
+   * @returns The created user result with normalized id field
+   */
+  public async signUp(options: SignUpOptions, storeOptions?: TStoreOptions): Promise<SignUpResult> {
+    const domain = await this.#resolveDomain(storeOptions);
+    return this.#getAuthClient(domain).database.signUp(options);
+  }
+
+  /**
+   * Requests a password change email for database connection users.
+   *
+   * Delegates to the underlying `AuthClient.database.changePassword` without any session state modification.
+   * The caller is responsible for informing the user of the sent email as needed.
+   *
+   * @param options - The password change options (email, connection, organization, etc.)
+   * @param storeOptions - Optional store-specific options for domain resolution in resolver mode
+   * @returns A plain text confirmation message from the server
+   */
+  public async changePassword(options: ChangePasswordOptions, storeOptions?: TStoreOptions): Promise<string> {
+    const domain = await this.#resolveDomain(storeOptions);
+    return this.#getAuthClient(domain).database.changePassword(options);
   }
 }

--- a/packages/auth0-server-js/src/types.ts
+++ b/packages/auth0-server-js/src/types.ts
@@ -10,6 +10,9 @@ export type {
   GetTokenByPasskeyOptions as PasskeyGetTokenOptions,
   PasskeyCreationOptions,
   PasskeyRequestOptions,
+  SignUpOptions,
+  ChangePasswordOptions,
+  SignUpResult,
 } from '@auth0/auth0-auth-js';
 
 /**


### PR DESCRIPTION
## Summary
Adds database-connection self-service operations to the SDK:
- **auth0-auth-js**: new `DatabaseClient` sub-client exposed as `authClient.database` with `signUp()` and `changePassword()`, request/response transforms (camelCase ↔ snake_case wire), id normalization (`id ?? _id ?? user_id`), `SignUpError` / `ChangePasswordError` (sanitized `cause`), and a `database/` barrel export.
- **auth0-server-js**: `ServerClient.signUp()` / `changePassword()` as **pure passthrough** — no session/state writes; resolver-mode domain resolution supported.

## Design notes
- `/dbconnections/*` are public endpoints: only `clientId` is sent (no secret/assertion).
- `changePassword` returns the server's **plain-text** confirmation (read via `response.text()`).
- Error `cause` is sanitized to `{ error, error_description, message }` (parity with `MfaError`).

## Test plan
- [x] `npm run build` — auth-js, server-js, api-js
- [x] `npm run test:ci` — auth-js 329 pass, server-js 336 pass
- [x] `npm run lint` — auth-js, server-js, api-js
- [x] Live-tenant POC run: signup (200, id normalized), duplicate (400 invalid_signup), weak-pw (400 invalid_password), change-password (200 plain-text)

## Related PRs
- Example app: `feat/database-conns-example`
- Docs: `feat/database-conns-docs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `database` sub-client to both client and server SDKs with `signUp` and `changePassword`.
  * Introduced database request/response types, plus `SignUpError` and `ChangePasswordError` for typed failure handling.
  * Expanded top-level package exports to include database APIs.
* **Bug Fixes**
  * Requests now normalize payloads consistently and include the expected telemetry header; inputs are strictly validated and server error responses map to the correct typed errors.
* **Tests**
  * Added/expanded coverage for request payloads, normalization, error behavior, and resolver-mode domain handling.
* **Documentation**
  * Added a database-connections example (README, env, and starter Express server).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->