### PR TITLE
feat(auth0-server-js): add organization support

### DIFF
--- a/packages/auth0-server-js/EXAMPLES.md
+++ b/packages/auth0-server-js/EXAMPLES.md
@@ -21,6 +21,7 @@
 - [Starting Interactive Login](#starting-interactive-login)
   - [Passing `authorizationParams`](#passing-authorization-params)
   - [Passing `appState` to track state during login](#passing-appstate-to-track-state-during-login)
+  - [Logging in to an Organization](#logging-in-to-an-organization)
   - [Using Pushed Authorization Requests](#using-pushed-authorization-requests)
   - [Using Pushed Authorization Requests and Rich Authorization Requests](#using-pushed-authorization-requests-and-rich-authorization-requests)
   - [Passing `StoreOptions`](#passing-storeoptions)
@@ -635,6 +636,59 @@ console.log(appState.myKey); // Logs 'myValue'
 > - `url` points to a URL in the application, and is the URL Auth0 redirects the user back to after successful authentication.
 
 Using `appState` can be useful for a variaty of reasons, but is mostly supported to enable using a `returnTo` parameter in framework-specific SDKs that use `auth0-server-js`.
+
+### Logging in to an Organization
+
+Pass `organization` to log a user in to a specific Auth0 organization. It can be an organization ID (e.g. `org_abc123`) or an organization name (e.g. `acme-corp`). You can set it as a client-wide default, per login, or through `authorizationParams`:
+
+```ts
+// Client-wide default
+const serverClient = new ServerClient({
+  domain: '<AUTH0_DOMAIN>',
+  clientId: '<AUTH0_CLIENT_ID>',
+  clientSecret: '<AUTH0_CLIENT_SECRET>',
+  stateStore,
+  transactionStore,
+  authorizationParams: { redirect_uri: '<AUTH0_REDIRECT_URI>' },
+  organization: 'org_abc123',
+});
+
+// Per login (overrides the client-wide default)
+await serverClient.startInteractiveLogin({ organization: 'org_abc123' });
+
+// Equivalent, through authorizationParams
+await serverClient.startInteractiveLogin({ authorizationParams: { organization: 'org_abc123' } });
+```
+
+To handle an organization invitation (for example from an invitation link containing `invitation` and `organization` query parameters), forward the `invitation` ticket alongside the `organization`:
+
+```ts
+await serverClient.startInteractiveLogin({
+  organization: 'org_abc123',
+  invitation: 'inv_ticket_789',
+});
+```
+
+When `organization` is provided, the organization claim of the returned ID token is validated during `completeInteractiveLogin`:
+
+- an organization ID (the `org_` prefix) is matched **exactly** (case-sensitive) against the `org_id` claim;
+- an organization name (no `org_` prefix) is matched **case-insensitively** against the `org_name` claim.
+
+If the claim is missing or does not match, `completeInteractiveLogin` throws an `OrganizationValidationError` and no session is persisted.
+
+```ts
+import { OrganizationValidationError } from '@auth0/auth0-server-js';
+
+try {
+  await serverClient.completeInteractiveLogin(url);
+} catch (error) {
+  if (error instanceof OrganizationValidationError) {
+    // The user did not authenticate into the requested organization.
+  }
+}
+```
+
+See the [Auth0 Organizations documentation](https://auth0.com/docs/manage-users/organizations) for setup and concepts.
 
 ### Using Pushed Authorization Requests
 

--- a/packages/auth0-server-js/EXAMPLES.md
+++ b/packages/auth0-server-js/EXAMPLES.md
@@ -656,9 +656,11 @@ const serverClient = new ServerClient({
 // Per login (overrides the client-wide default)
 await serverClient.startInteractiveLogin({ organization: 'org_abc123' });
 
-// Equivalent, through authorizationParams
+// Also supported per login through authorizationParams
 await serverClient.startInteractiveLogin({ authorizationParams: { organization: 'org_abc123' } });
 ```
+
+Per-login values (the `organization` option or `authorizationParams.organization`) take precedence over the client-wide default. When both per-login forms are provided, the `organization` option wins.
 
 To handle an organization invitation (for example from an invitation link containing `invitation` and `organization` query parameters), forward the `invitation` ticket alongside the `organization`:
 

--- a/packages/auth0-server-js/package.json
+++ b/packages/auth0-server-js/package.json
@@ -25,7 +25,7 @@
     }
   },
   "dependencies": {
-    "@auth0/auth0-auth-js": "^1.9.1",
+    "@auth0/auth0-auth-js": "^1.10.0",
     "jose": "^6.0.8"
   },
   "devDependencies": {

--- a/packages/auth0-server-js/src/index.ts
+++ b/packages/auth0-server-js/src/index.ts
@@ -2,7 +2,7 @@ export { ServerClient } from './server-client.js';
 export { AbstractStateStore } from './store/abstract-state-store.js';
 export { AbstractTransactionStore } from './store/abstract-transaction-store.js';
 export type { TokenResponse, ActClaim } from '@auth0/auth0-auth-js';
-export { TokenExchangeError, MissingClientAuthError } from '@auth0/auth0-auth-js';
+export { TokenExchangeError, MissingClientAuthError, OrganizationValidationError } from '@auth0/auth0-auth-js';
 
 export type { CookieHandler, CookieSerializeOptions } from './store/cookie-handler.js';
 export { CookieTransactionStore } from './store/cookie-transaction-store.js';

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -6517,6 +6517,40 @@ describe('organization support', () => {
     expect(url.searchParams.get('organization')).toBe('org_viaparams');
   });
 
+  test('startInteractiveLogin - organization via client-level authorizationParams is resolved and stored', async () => {
+    const mockTransactionStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn() };
+    const serverClient = new ServerClient({
+      domain,
+      clientId: '<client_id>',
+      clientSecret: '<client_secret>',
+      stateStore: new DefaultStateStore({ secret: '<secret>' }),
+      transactionStore: mockTransactionStore,
+      authorizationParams: { redirect_uri: '/test_redirect_uri', organization: 'org_clientparams' },
+    });
+
+    const url = await serverClient.startInteractiveLogin();
+
+    expect(url.searchParams.get('organization')).toBe('org_clientparams');
+    expect(mockTransactionStore.set.mock.calls[0]?.[1]?.organization).toBe('org_clientparams');
+  });
+
+  test('startInteractiveLogin - throws OrganizationValidationError on a blank organization and stores nothing', async () => {
+    const mockTransactionStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn() };
+    const serverClient = new ServerClient({
+      domain,
+      clientId: '<client_id>',
+      clientSecret: '<client_secret>',
+      stateStore: new DefaultStateStore({ secret: '<secret>' }),
+      transactionStore: mockTransactionStore,
+      authorizationParams: { redirect_uri: '/test_redirect_uri' },
+    });
+
+    await expect(serverClient.startInteractiveLogin({ organization: '   ' })).rejects.toBeInstanceOf(
+      OrganizationValidationError
+    );
+    expect(mockTransactionStore.set).not.toHaveBeenCalled();
+  });
+
   test('startInteractiveLogin - forwards invitation alongside organization', async () => {
     const url = await newClient().startInteractiveLogin({
       organization: 'org_abc123',

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -6538,6 +6538,12 @@ describe('organization support', () => {
     );
   });
 
+  test('startInteractiveLogin - throws when invitation via authorizationParams is provided without an organization', async () => {
+    await expect(
+      newClient().startInteractiveLogin({ authorizationParams: { invitation: 'inv_ticket_789' } })
+    ).rejects.toBeInstanceOf(InvalidConfigurationError);
+  });
+
   test('startInteractiveLogin - organization via client-level authorizationParams is resolved and stored', async () => {
     const mockTransactionStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn() };
     const serverClient = new ServerClient({
@@ -6668,6 +6674,16 @@ describe('organization support', () => {
   test('completeInteractiveLogin - throws OrganizationValidationError and writes no session when the org_name claim mismatches', async () => {
     useOrgTokenHandler({ org_name: 'other-corp' });
     const { serverClient, mockStateStore } = completeClientWithOrg('acme-corp');
+
+    await expect(serverClient.completeInteractiveLogin(new URL(`https://${domain}?code=123`))).rejects.toBeInstanceOf(
+      OrganizationValidationError
+    );
+    expect(mockStateStore.set).not.toHaveBeenCalled();
+  });
+
+  test('completeInteractiveLogin - throws and writes no session when an org_id was requested but the token has no org claim', async () => {
+    useOrgTokenHandler({});
+    const { serverClient, mockStateStore } = completeClientWithOrg('org_abc123');
 
     await expect(serverClient.completeInteractiveLogin(new URL(`https://${domain}?code=123`))).rejects.toBeInstanceOf(
       OrganizationValidationError

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -6517,6 +6517,27 @@ describe('organization support', () => {
     expect(url.searchParams.get('organization')).toBe('org_viaparams');
   });
 
+  test('startInteractiveLogin - per-login authorizationParams organization overrides the client-level default', async () => {
+    const url = await newClient({ organization: 'org_default123' }).startInteractiveLogin({
+      authorizationParams: { organization: 'org_override456' },
+    });
+    expect(url.searchParams.get('organization')).toBe('org_override456');
+  });
+
+  test('startInteractiveLogin - per-login organization option wins over per-login authorizationParams', async () => {
+    const url = await newClient().startInteractiveLogin({
+      organization: 'org_option',
+      authorizationParams: { organization: 'org_viaparams' },
+    });
+    expect(url.searchParams.get('organization')).toBe('org_option');
+  });
+
+  test('startInteractiveLogin - throws when invitation is provided without an organization', async () => {
+    await expect(newClient().startInteractiveLogin({ invitation: 'inv_ticket_789' })).rejects.toBeInstanceOf(
+      InvalidConfigurationError
+    );
+  });
+
   test('startInteractiveLogin - organization via client-level authorizationParams is resolved and stored', async () => {
     const mockTransactionStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn() };
     const serverClient = new ServerClient({
@@ -6628,6 +6649,25 @@ describe('organization support', () => {
   test('completeInteractiveLogin - throws OrganizationValidationError and writes no session when the org_id claim mismatches', async () => {
     useOrgTokenHandler({ org_id: 'org_wrong' });
     const { serverClient, mockStateStore } = completeClientWithOrg('org_abc123');
+
+    await expect(serverClient.completeInteractiveLogin(new URL(`https://${domain}?code=123`))).rejects.toBeInstanceOf(
+      OrganizationValidationError
+    );
+    expect(mockStateStore.set).not.toHaveBeenCalled();
+  });
+
+  test('completeInteractiveLogin - succeeds when the org_name claim matches case-insensitively', async () => {
+    useOrgTokenHandler({ org_name: 'acme-corp' });
+    const { serverClient, mockStateStore } = completeClientWithOrg('ACME-Corp');
+
+    await serverClient.completeInteractiveLogin(new URL(`https://${domain}?code=123`));
+
+    expect(mockStateStore.set).toHaveBeenCalled();
+  });
+
+  test('completeInteractiveLogin - throws OrganizationValidationError and writes no session when the org_name claim mismatches', async () => {
+    useOrgTokenHandler({ org_name: 'other-corp' });
+    const { serverClient, mockStateStore } = completeClientWithOrg('acme-corp');
 
     await expect(serverClient.completeInteractiveLogin(new URL(`https://${domain}?code=123`))).rejects.toBeInstanceOf(
       OrganizationValidationError

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -6,7 +6,7 @@ import {
   MissingTransactionError,
   SessionExpiredError,
 } from './errors.js';
-import { AuthClient, TokenResponse, isMfaRequiredError } from '@auth0/auth0-auth-js';
+import { AuthClient, TokenResponse, isMfaRequiredError, OrganizationValidationError } from '@auth0/auth0-auth-js';
 
 import * as Auth0AuthJs from '@auth0/auth0-auth-js';
 
@@ -6482,4 +6482,131 @@ test('startUnlinkUser - throws SessionExpiredError and never builds the unlink U
   } finally {
     buildSpy.mockRestore();
   }
+});
+
+describe('organization support', () => {
+  const newClient = (overrides?: Partial<ConstructorParameters<typeof ServerClient>[0]>) =>
+    new ServerClient({
+      domain,
+      clientId: '<client_id>',
+      clientSecret: '<client_secret>',
+      stateStore: new DefaultStateStore({ secret: '<secret>' }),
+      transactionStore: new DefaultTransactionStore({ secret: '<secret>' }),
+      authorizationParams: { redirect_uri: '/test_redirect_uri' },
+      ...overrides,
+    });
+
+  // ─── startInteractiveLogin: forwarding + precedence + storage ─────────
+
+  test('startInteractiveLogin - forwards client-level organization to the authorize url', async () => {
+    const url = await newClient({ organization: 'org_default123' }).startInteractiveLogin();
+    expect(url.searchParams.get('organization')).toBe('org_default123');
+  });
+
+  test('startInteractiveLogin - per-login organization overrides the client default', async () => {
+    const url = await newClient({ organization: 'org_default123' }).startInteractiveLogin({
+      organization: 'org_override456',
+    });
+    expect(url.searchParams.get('organization')).toBe('org_override456');
+  });
+
+  test('startInteractiveLogin - organization via authorizationParams still works', async () => {
+    const url = await newClient().startInteractiveLogin({
+      authorizationParams: { organization: 'org_viaparams' },
+    });
+    expect(url.searchParams.get('organization')).toBe('org_viaparams');
+  });
+
+  test('startInteractiveLogin - forwards invitation alongside organization', async () => {
+    const url = await newClient().startInteractiveLogin({
+      organization: 'org_abc123',
+      invitation: 'inv_ticket_789',
+    });
+    expect(url.searchParams.get('organization')).toBe('org_abc123');
+    expect(url.searchParams.get('invitation')).toBe('inv_ticket_789');
+  });
+
+  test('startInteractiveLogin - does not add organization or invitation when not provided', async () => {
+    const url = await newClient().startInteractiveLogin();
+    expect(url.searchParams.has('organization')).toBe(false);
+    expect(url.searchParams.has('invitation')).toBe(false);
+  });
+
+  test('startInteractiveLogin - stores the resolved organization in the transaction', async () => {
+    const mockTransactionStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn() };
+    const serverClient = new ServerClient({
+      domain,
+      clientId: '<client_id>',
+      clientSecret: '<client_secret>',
+      stateStore: new DefaultStateStore({ secret: '<secret>' }),
+      transactionStore: mockTransactionStore,
+      authorizationParams: { redirect_uri: '/test_redirect_uri' },
+    });
+
+    await serverClient.startInteractiveLogin({ organization: 'org_abc123' });
+
+    expect(mockTransactionStore.set).toHaveBeenCalled();
+    expect(mockTransactionStore.set.mock.calls[0]?.[1]?.organization).toBe('org_abc123');
+  });
+
+  // ─── completeInteractiveLogin: claim validation ──────────────────────
+
+  const useOrgTokenHandler = (orgClaims: Record<string, unknown>) => {
+    server.use(
+      http.post(mockOpenIdConfiguration.token_endpoint, async () => {
+        return HttpResponse.json({
+          access_token: accessToken,
+          id_token: await generateToken(domain, 'user_123', '<client_id>', undefined, orgClaims),
+          expires_in: 60,
+          token_type: 'Bearer',
+          scope: '<scope>',
+        });
+      })
+    );
+  };
+
+  const completeClientWithOrg = (organization?: string) => {
+    const mockTransactionStore = {
+      get: vi.fn().mockResolvedValue({ codeVerifier: 'test-code-verifier', organization }),
+      set: vi.fn(),
+      delete: vi.fn(),
+    };
+    const mockStateStore = { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() };
+    const serverClient = new ServerClient({
+      domain,
+      clientId: '<client_id>',
+      clientSecret: '<client_secret>',
+      stateStore: mockStateStore,
+      transactionStore: mockTransactionStore,
+    });
+    return { serverClient, mockStateStore, mockTransactionStore };
+  };
+
+  test('completeInteractiveLogin - succeeds when the org_id claim matches the requested organization', async () => {
+    useOrgTokenHandler({ org_id: 'org_abc123' });
+    const { serverClient, mockStateStore } = completeClientWithOrg('org_abc123');
+
+    await serverClient.completeInteractiveLogin(new URL(`https://${domain}?code=123`));
+
+    expect(mockStateStore.set).toHaveBeenCalled();
+  });
+
+  test('completeInteractiveLogin - throws OrganizationValidationError and writes no session when the org_id claim mismatches', async () => {
+    useOrgTokenHandler({ org_id: 'org_wrong' });
+    const { serverClient, mockStateStore } = completeClientWithOrg('org_abc123');
+
+    await expect(serverClient.completeInteractiveLogin(new URL(`https://${domain}?code=123`))).rejects.toBeInstanceOf(
+      OrganizationValidationError
+    );
+    expect(mockStateStore.set).not.toHaveBeenCalled();
+  });
+
+  test('completeInteractiveLogin - does not validate when no organization was requested even if the token carries a claim', async () => {
+    useOrgTokenHandler({ org_id: 'org_abc123' });
+    const { serverClient, mockStateStore } = completeClientWithOrg(undefined);
+
+    await serverClient.completeInteractiveLogin(new URL(`https://${domain}?code=123`));
+
+    expect(mockStateStore.set).toHaveBeenCalled();
+  });
 });

--- a/packages/auth0-server-js/src/server-client.ts
+++ b/packages/auth0-server-js/src/server-client.ts
@@ -261,6 +261,8 @@ export class ServerClient<TStoreOptions = unknown> {
    * @param options Optional options used to configure the interactive login process.
    * @param storeOptions Optional options used to pass to the Transaction and State Store.
    *
+   * @throws {OrganizationValidationError} If the resolved `organization` is blank.
+   * @throws {InvalidConfigurationError} If `invitation` is provided without an `organization`.
    * @throws {BuildAuthorizationUrlError} If there was an issue when building the Authorization URL.
    *
    * @returns A promise resolving to a URL object, representing the URL to redirect the user-agent to to request authorization at Auth0.
@@ -273,12 +275,13 @@ export class ServerClient<TStoreOptions = unknown> {
 
     const scope = ensureOpenIdScope(options?.authorizationParams?.scope ?? this.#options.authorizationParams?.scope);
 
-    // Resolve organization in precedence order: per-login option, client-level
-    // default, per-login authorizationParams, then client-level authorizationParams.
-    // The explicit option wins, but authorizationParams.organization remains
-    // supported at both the per-login and client level (the latter is merged into
-    // the authorize request by the underlying AuthClient, so it must be resolved
-    // here too, otherwise its claim would never be validated at callback).
+    // Resolve organization in precedence order. Per-login values always win over
+    // client-level values (consistent with how audience/scope/redirect_uri resolve
+    // in this method): per-login option, then per-login authorizationParams, then
+    // client-level option, then client-level authorizationParams. authorizationParams.organization
+    // remains supported at both levels (the client-level one is merged into the
+    // authorize request by the underlying AuthClient, so it must be resolved here
+    // too, otherwise its claim would never be validated at callback).
     const perLoginAuthParamsOrganization =
       typeof options?.authorizationParams?.organization === 'string'
         ? options.authorizationParams.organization
@@ -289,8 +292,8 @@ export class ServerClient<TStoreOptions = unknown> {
         : undefined;
     const resolvedOrganization =
       options?.organization ??
-      this.#options.organization ??
       perLoginAuthParamsOrganization ??
+      this.#options.organization ??
       clientAuthParamsOrganization;
 
     // Fail fast on a blank organization before the redirect, mirroring the
@@ -298,6 +301,13 @@ export class ServerClient<TStoreOptions = unknown> {
     // validation) or only surfacing the error after the round-trip to Auth0.
     if (resolvedOrganization !== undefined && !resolvedOrganization.trim()) {
       throw new OrganizationValidationError('organization must not be blank');
+    }
+
+    // An invitation ticket is only meaningful in the context of an organization;
+    // Auth0's invitation flow requires both parameters. Fail fast rather than
+    // sending an invalid authorize request.
+    if (options?.invitation && !resolvedOrganization) {
+      throw new InvalidConfigurationError('organization is required when invitation is provided.');
     }
 
     const domain = await this.#resolveDomain(storeOptions);

--- a/packages/auth0-server-js/src/server-client.ts
+++ b/packages/auth0-server-js/src/server-client.ts
@@ -41,6 +41,7 @@ import {
   TokenForConnectionError,
   AuthClient,
   AuthorizationDetails,
+  OrganizationValidationError,
   PasswordlessStartError,
   PasswordlessVerifyError,
   TokenByRefreshTokenError,
@@ -272,15 +273,32 @@ export class ServerClient<TStoreOptions = unknown> {
 
     const scope = ensureOpenIdScope(options?.authorizationParams?.scope ?? this.#options.authorizationParams?.scope);
 
-    // Resolve organization: per-login option, then client-level default, then
-    // whatever may have been passed through authorizationParams. The explicit
-    // option wins, but authorizationParams.organization remains supported.
-    const organizationFromAuthParams =
+    // Resolve organization in precedence order: per-login option, client-level
+    // default, per-login authorizationParams, then client-level authorizationParams.
+    // The explicit option wins, but authorizationParams.organization remains
+    // supported at both the per-login and client level (the latter is merged into
+    // the authorize request by the underlying AuthClient, so it must be resolved
+    // here too, otherwise its claim would never be validated at callback).
+    const perLoginAuthParamsOrganization =
       typeof options?.authorizationParams?.organization === 'string'
         ? options.authorizationParams.organization
         : undefined;
+    const clientAuthParamsOrganization =
+      typeof this.#options.authorizationParams?.organization === 'string'
+        ? this.#options.authorizationParams.organization
+        : undefined;
     const resolvedOrganization =
-      options?.organization ?? this.#options.organization ?? organizationFromAuthParams;
+      options?.organization ??
+      this.#options.organization ??
+      perLoginAuthParamsOrganization ??
+      clientAuthParamsOrganization;
+
+    // Fail fast on a blank organization before the redirect, mirroring the
+    // core's up-front check, rather than silently dropping it (and skipping
+    // validation) or only surfacing the error after the round-trip to Auth0.
+    if (resolvedOrganization !== undefined && !resolvedOrganization.trim()) {
+      throw new OrganizationValidationError('organization must not be blank');
+    }
 
     const domain = await this.#resolveDomain(storeOptions);
     const authClient = this.#getAuthClient(domain);

--- a/packages/auth0-server-js/src/server-client.ts
+++ b/packages/auth0-server-js/src/server-client.ts
@@ -252,6 +252,11 @@ export class ServerClient<TStoreOptions = unknown> {
 
   /**
    * Starts the interactive login process, and returns a URL to redirect the user-agent to to request authorization at Auth0.
+   *
+   * When `organization` is provided (per-login option, client-level default, or via
+   * `authorizationParams.organization`), it is forwarded to `/authorize` and remembered so the
+   * returned ID token's organization claim can be validated in `completeInteractiveLogin`.
+   *
    * @param options Optional options used to configure the interactive login process.
    * @param storeOptions Optional options used to pass to the Transaction and State Store.
    *
@@ -267,6 +272,16 @@ export class ServerClient<TStoreOptions = unknown> {
 
     const scope = ensureOpenIdScope(options?.authorizationParams?.scope ?? this.#options.authorizationParams?.scope);
 
+    // Resolve organization: per-login option, then client-level default, then
+    // whatever may have been passed through authorizationParams. The explicit
+    // option wins, but authorizationParams.organization remains supported.
+    const organizationFromAuthParams =
+      typeof options?.authorizationParams?.organization === 'string'
+        ? options.authorizationParams.organization
+        : undefined;
+    const resolvedOrganization =
+      options?.organization ?? this.#options.organization ?? organizationFromAuthParams;
+
     const domain = await this.#resolveDomain(storeOptions);
     const authClient = this.#getAuthClient(domain);
     const { codeVerifier, authorizationUrl } = await authClient.buildAuthorizationUrl({
@@ -275,6 +290,8 @@ export class ServerClient<TStoreOptions = unknown> {
         ...options?.authorizationParams,
         redirect_uri: redirectUri,
         scope,
+        ...(resolvedOrganization ? { organization: resolvedOrganization } : {}),
+        ...(options?.invitation ? { invitation: options.invitation } : {}),
       },
     });
 
@@ -283,6 +300,10 @@ export class ServerClient<TStoreOptions = unknown> {
       codeVerifier,
       domain,
     };
+
+    if (resolvedOrganization) {
+      transactionState.organization = resolvedOrganization;
+    }
 
     if (options?.appState) {
       transactionState.appState = options.appState;
@@ -301,6 +322,7 @@ export class ServerClient<TStoreOptions = unknown> {
    *
    * @throws {MissingTransactionError} When no transaction was found.
    * @throws {TokenByCodeError} If there was an issue requesting the access token.
+   * @throws {OrganizationValidationError} When an organization was requested at login and the returned ID token's organization claim is missing or does not match; nothing is persisted.
    * @throws {SessionExpiredError} When the ID token's `session_expiry` is already in the past at login (the session is born expired); nothing is persisted.
    *
    * @returns A promise resolving to an object, containing the original appState (if present) and the authorizationDetails (when RAR was used).
@@ -317,6 +339,7 @@ export class ServerClient<TStoreOptions = unknown> {
     const tokenEndpointResponse = await authClient.getTokenByCode(url, {
       // TransactionData.codeVerifier is optional only to accommodate magic-link transactions.
       codeVerifier: transactionData.codeVerifier!,
+      organization: transactionData.organization,
     });
 
     // The transaction (and its code_verifier) is single-use and spent once the code is exchanged.

--- a/packages/auth0-server-js/src/server-client.ts
+++ b/packages/auth0-server-js/src/server-client.ts
@@ -305,8 +305,11 @@ export class ServerClient<TStoreOptions = unknown> {
 
     // An invitation ticket is only meaningful in the context of an organization;
     // Auth0's invitation flow requires both parameters. Fail fast rather than
-    // sending an invalid authorize request.
-    if (options?.invitation && !resolvedOrganization) {
+    // sending an invalid authorize request. `invitation` is supported both as the
+    // first-class option and via authorizationParams (which is spread into the
+    // request below), so both sources are guarded.
+    const hasInvitation = !!(options?.invitation || options?.authorizationParams?.invitation);
+    if (hasInvitation && !resolvedOrganization) {
       throw new InvalidConfigurationError('organization is required when invitation is provided.');
     }
 

--- a/packages/auth0-server-js/src/types.ts
+++ b/packages/auth0-server-js/src/types.ts
@@ -38,6 +38,12 @@ export interface ServerClientOptions<TStoreOptions = unknown> {
   clientAssertionSigningKey?: string | CryptoKey;
   clientAssertionSigningAlg?: string;
   authorizationParams?: AuthorizationParameters;
+  /**
+   * Default organization for all interactive login flows from this client.
+   * Can be an organization ID (e.g. `org_abc123`) or an organization name (e.g. `acme-corp`).
+   * A per-login value in {@link StartInteractiveLoginOptions} overrides this.
+   */
+  organization?: string;
   discoveryCache?: DiscoveryCacheOptions;
   transactionIdentifier?: string;
   stateIdentifier?: string;
@@ -72,6 +78,7 @@ export interface UserClaims {
   email?: string;
   email_verified?: boolean;
   org_id?: string;
+  org_name?: string;
 
   [key: string]: unknown;
 }
@@ -136,6 +143,11 @@ export interface TransactionData {
    */
   codeVerifier?: string;
   domain?: string;
+  /**
+   * The organization requested at login, carried across the redirect so the
+   * returned ID token's organization claim can be validated at callback.
+   */
+  organization?: string;
   [key: string]: unknown;
 }
 
@@ -174,6 +186,16 @@ export interface StartInteractiveLoginOptions<TAppState = unknown> {
   pushedAuthorizationRequests?: boolean;
   appState?: TAppState;
   authorizationParams?: AuthorizationParameters;
+  /**
+   * The organization to log the user into. Overrides the client-level
+   * `organization` default. Can be an organization ID (`org_abc123`) or name
+   * (`acme-corp`). Also passable via `authorizationParams.organization`.
+   */
+  organization?: string;
+  /**
+   * The organization invitation ticket, when handling an invitation-acceptance flow.
+   */
+  invitation?: string;
 }
 
 export interface LoginBackchannelOptions {

--- a/packages/auth0-server-js/src/types.ts
+++ b/packages/auth0-server-js/src/types.ts
@@ -87,6 +87,12 @@ export interface AuthorizationParameters {
   scope?: string;
   audience?: string;
   redirect_uri?: string;
+  /**
+   * The organization to log the user into. Prefer the first-class `organization`
+   * option on {@link StartInteractiveLoginOptions} / {@link ServerClientOptions};
+   * this is supported for backwards compatibility.
+   */
+  organization?: string;
 
   [key: string]: unknown;
 }
@@ -194,6 +200,8 @@ export interface StartInteractiveLoginOptions<TAppState = unknown> {
   organization?: string;
   /**
    * The organization invitation ticket, when handling an invitation-acceptance flow.
+   * Requires `organization` to be set (per-login, client-level default, or via
+   * `authorizationParams`); providing `invitation` without an organization throws.
    */
   invitation?: string;
 }


### PR DESCRIPTION
This adds first class support for Auth0 Organizations in the interactive login flow.

### What changed
You can now pass an `organization` when logging in, either as a client wide default or per login:

```ts
  // Client default
  const client = new ServerClient({ /* ... */, organization: 'org_abc123' });

  // Per login (overrides the default)
  await client.startInteractiveLogin({ organization: 'org_abc123' });
 ```

The value can be an organization ID (org_abc123) or an organization name (acme-corp). It still works if you pass it through authorizationParams like before.

There is also a new invitation option for handling organization invitation links:
```ts
  await client.startInteractiveLogin({ organization: 'org_abc123', invitation: 'inv_ticket_789' });
```

When an organization is provided, the returned ID token is checked at `completeInteractiveLogin`. An `org_ prefixed` value is matched exactly against the `org_id` claim, otherwise the value is matched (case insensitive) against the `org_name` claim. If the claim is missing or does not match, it throws `OrganizationValidationError` and no session is saved.

### Notes

The actual claim check lives in `auth0-auth-js`. This SDK resolves the organization, forwards it to `/authorize`, remembers it across the redirect, and passes it to the core for validation. `OrganizationValidationError` is now re-exported so you can catch it. All new fields are optional so nothing breaks for existing apps.

### Testing

  - Added tests for organization forwarding, precedence, invitation, and claim validation at callback
  - build, lint, and the full test suite pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added organization-aware interactive login, including client-wide defaults, per-login overrides, and invitation-based flows.
  * Propagates organization details through the redirect flow to support consistent organization claim validation.
* **Bug Fixes**
  * Improved handling by rejecting blank organizations, enforcing matching organization claims (case-insensitive), and preventing session persistence when validation fails or claims are missing.
* **Documentation**
  * Expanded examples and guidance for logging in to an organization, including invitation forwarding and validation error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->