### PR TITLE
feat(auth0-server-js): add Session Transfer Token support for CTE imp…

### DIFF
--- a/packages/auth0-server-js/EXAMPLES.md
+++ b/packages/auth0-server-js/EXAMPLES.md
@@ -48,6 +48,10 @@
   - [Performing a delegation exchange without a session](#performing-a-delegation-exchange-without-a-session)
   - [Using actor tokens for delegation](#using-actor-tokens-for-delegation)
   - [Passing `StoreOptions`](#passing-storeoptions-6)
+- [Impersonation via Session Transfer](#impersonation-via-session-transfer)
+  - [Initiator: requesting a Session Transfer Token and redirecting](#initiator-requesting-a-session-transfer-token-and-redirecting)
+  - [Target: redeeming the Session Transfer Token](#target-redeeming-the-session-transfer-token)
+  - [Reading the `act` claim on the impersonation session](#reading-the-act-claim-on-the-impersonation-session)
 - [Retrieving the logged-in User](#retrieving-the-logged-in-user)
   - [Passing `StoreOptions`](#passing-storeoptions-7)
 - [Retrieving the Session Data](#retrieving-the-session-data)
@@ -1158,6 +1162,108 @@ const tokenResponse = await serverClient.customTokenExchange({ subjectToken, sub
 ```
 
 Read more above in [Configuring the Store](#configuring-the-store)
+
+## Impersonation via Session Transfer
+
+Custom Token Exchange Impersonation via Session Transfer lets a support/admin application log an agent **into a target web application as a customer** — for example, so a support engineer can reproduce a customer's exact experience without ever knowing their password. It builds on Custom Token Exchange and involves two roles and two applications:
+
+- **Initiator** — your support/admin app (this SDK). It requests a short-lived, single-use **Session Transfer Token (STT)** and redirects the agent's browser to the target app's login URL carrying the STT.
+- **Target** — the customer's own web app. Its login route forwards the STT to `/authorize`, where Auth0 redeems it and establishes an ephemeral, device-bound session **as the customer**, recording the agent in the `act` (actor) claim.
+
+The STT is **opaque, single-use, and short-lived (~60s)**. The SDK requests it, surfaces it, and helps you build the redirect — it never decodes, validates, caches, or persists it.
+
+> [!IMPORTANT]
+> This is a two-client, two-role flow with tenant prerequisites configured out of band (via the Management API / Dashboard):
+>
+> - The feature flag `cte_session_transfer_token` must be enabled on the tenant.
+> - The **issuing (initiator) client** needs `session_transfer.can_create_session_transfer_token: true` and a Custom Token Exchange profile / Action that calls `setActor`.
+> - The **redeeming (target) client** needs `session_transfer.delegation.allow_delegated_access: true`, `session_transfer.allowed_authentication_methods` including `"query"`, and `session_transfer.delegation.enforce_device_binding` (`"ip"` by default).
+>
+> See the [Custom Token Exchange documentation](https://auth0.com/docs/authenticate/custom-token-exchange) for the full setup.
+
+### Initiator: requesting a Session Transfer Token and redirecting
+
+The agent must be **logged in** to the initiator app: the SDK sources the actor from the agent's current session ID token by default (refreshing it if it has expired). Run your own authorization check — _is this agent allowed to impersonate this customer, right now?_ — before calling the SDK.
+
+```ts
+// In your support console's "View as customer" route (agent is already logged in):
+const result = await serverClient.requestSessionTransferToken(
+  {
+    // Your own proof of which customer to impersonate — validated by your Action.
+    // The SDK never produces this; you supply it in whatever form your Action expects.
+    subjectToken,
+    subjectTokenType: 'urn:acme:customer-subject',
+    // Optional: forward custom context to your Action (e.g. an audited reason).
+    extra: { reason: 'Investigating TCK-4821' },
+  },
+  storeOptions
+);
+
+// Build the redirect to the TARGET app's login URL (a trusted, app-controlled value).
+const url = serverClient.buildSessionTransferRedirect('https://app.example.com/auth/login', result);
+
+// Hand the URL to your framework's redirect (e.g. Fastify: reply.redirect(url.toString())).
+```
+
+By default the actor is the agent session's ID token. To supply the acting party explicitly, pass `actor`:
+
+```ts
+const result = await serverClient.requestSessionTransferToken(
+  {
+    subjectToken,
+    subjectTokenType: 'urn:acme:customer-subject',
+    actor: { token: agentIdToken }, // type defaults to the ID token URN
+  },
+  storeOptions
+);
+```
+
+If the customer belongs to an organization, forward it on the redirect so it reaches the target's `/authorize`:
+
+```ts
+const url = serverClient.buildSessionTransferRedirect('https://app.example.com/auth/login', result, {
+  organization: 'org_globex',
+});
+```
+
+> [!IMPORTANT]
+> An **actor is mandatory** for an STT — that is what makes this auditable impersonation ("X acting as Y") rather than a silent takeover. If no explicit `actor` is passed and no usable session ID token can be resolved (no logged-in agent, or an expired ID token with no refresh token), the SDK throws a `TokenExchangeError` with code `actor_unavailable` **before any network call**. The agent's session ID token must also be unexpired; the SDK refreshes it automatically when a refresh token is available.
+
+> [!NOTE]
+> `buildSessionTransferRedirect` attaches a single-use credential to the URL, so `targetLoginUrl` **must be a trusted, app-controlled value** and use `https` (`http` is allowed only for `localhost`). Never derive it from untrusted input such as a `returnTo` parameter, or the token could leak to an attacker-controlled host.
+
+The exchange is **stateless** — the STT is never written to the session or state store. Do not cache or persist it; hand it straight to the redirect and discard it.
+
+### Target: redeeming the Session Transfer Token
+
+On the target app, the STT is redeemed as part of a **standard interactive login** — you just forward `session_transfer_token` (and `organization`, when present) to `/authorize` via `startInteractiveLogin`'s `authorizationParams`:
+
+```ts
+// In the target app's login route, reading session_transfer_token from the query string:
+const url = await serverClient.startInteractiveLogin(
+  {
+    authorizationParams: {
+      session_transfer_token: sessionTransferToken,
+      organization, // only when the STT was issued in an organization context
+    },
+  },
+  storeOptions
+);
+
+// Redirect the browser to `url`; the callback completes with a standard authorization-code login.
+```
+
+> [!NOTE]
+> The `session_transfer_token` is redeemed as a **query** parameter, so the redeeming client's `session_transfer.allowed_authentication_methods` must include `"query"`. The established session is short-lived (hard-capped at 2 hours) and **cannot mint a refresh token** — to continue, re-run the whole flow. If the target needs `online_access`, set it through the SDK's `scope` configuration.
+
+### Reading the `act` claim on the impersonation session
+
+Once the target session is established, the acting agent is available as the `act` claim on the session user — read it through the existing session surface to drive UI such as an impersonation banner:
+
+```ts
+const session = await serverClient.getSession(storeOptions);
+const actor = session?.user?.act; // { sub: 'support-agent-007', ... } when impersonated
+```
 
 ## Passwordless Authentication
 

--- a/packages/auth0-server-js/EXAMPLES.md
+++ b/packages/auth0-server-js/EXAMPLES.md
@@ -1230,7 +1230,7 @@ const url = serverClient.buildSessionTransferRedirect('https://app.example.com/a
 > An **actor is mandatory** for an STT — that is what makes this auditable impersonation ("X acting as Y") rather than a silent takeover. If no explicit `actor` is passed and no usable session ID token can be resolved (no logged-in agent, or an expired ID token with no refresh token), the SDK throws a `TokenExchangeError` with code `actor_unavailable` **before any network call**. The agent's session ID token must also be unexpired; the SDK refreshes it automatically when a refresh token is available.
 
 > [!NOTE]
-> `buildSessionTransferRedirect` attaches a single-use credential to the URL, so `targetLoginUrl` **must be a trusted, app-controlled value** and use `https` (`http` is allowed only for `localhost`). Never derive it from untrusted input such as a `returnTo` parameter, or the token could leak to an attacker-controlled host.
+> `buildSessionTransferRedirect` attaches a single-use credential to the URL, so `targetLoginUrl` **must be a trusted, app-controlled value** and use `https` (`http` is allowed only for the loopback hosts `localhost`, `127.0.0.1`, and `[::1]`). Never derive it from untrusted input such as a `returnTo` parameter, or the token could leak to an attacker-controlled host.
 
 The exchange is **stateless** — the STT is never written to the session or state store. Do not cache or persist it; hand it straight to the redirect and discard it.
 
@@ -1255,6 +1255,9 @@ const url = await serverClient.startInteractiveLogin(
 
 > [!NOTE]
 > The `session_transfer_token` is redeemed as a **query** parameter, so the redeeming client's `session_transfer.allowed_authentication_methods` must include `"query"`. The established session is short-lived (hard-capped at 2 hours) and **cannot mint a refresh token** — to continue, re-run the whole flow. If the target needs `online_access`, set it through the SDK's `scope` configuration.
+
+> [!NOTE]
+> Because the STT travels as a query parameter, it can land in places that log or retain full URLs — web-server access logs, proxy/CDN logs, and the browser's history. This is inherent to the redemption mechanism and is mitigated by the token being **single-use and short-lived (~60s)** and, when configured, **device-bound** (`enforce_device_binding`): a leaked STT is worthless once redeemed or expired. Even so, avoid logging redemption URLs verbatim, and never persist or forward the STT beyond the immediate redirect.
 
 ### Reading the `act` claim on the impersonation session
 

--- a/packages/auth0-server-js/src/errors.spec.ts
+++ b/packages/auth0-server-js/src/errors.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { SessionExpiredError, StartLinkUserError } from './errors.js';
+import { SessionExpiredError, StartLinkUserError, TokenExchangeErrorCode } from './errors.js';
 
 describe('StartLinkUserError', () => {
   test('sets name and code', () => {
@@ -25,5 +25,13 @@ describe('SessionExpiredError', () => {
 
     expect(error.message).toBe('ceiling reached');
     expect(error.code).toBe('session_expired');
+  });
+});
+
+describe('TokenExchangeErrorCode', () => {
+  test('exposes the Session Transfer Token codes', () => {
+    expect(TokenExchangeErrorCode.ACTOR_UNAVAILABLE).toBe('actor_unavailable');
+    expect(TokenExchangeErrorCode.SETACTOR_REQUIRED).toBe('setactor_required');
+    expect(TokenExchangeErrorCode.SESSION_TRANSFER_DISABLED).toBe('session_transfer_disabled');
   });
 });

--- a/packages/auth0-server-js/src/errors.ts
+++ b/packages/auth0-server-js/src/errors.ts
@@ -1,4 +1,31 @@
 /**
+ * Codes carried on the `code` field of a `TokenExchangeError` raised by the Session
+ * Transfer Token (STT) flow. These are specific to Custom Token Exchange Impersonation
+ * via Session Transfer:
+ *
+ * - `actor_unavailable` — raised client-side, before any network call, when a Session
+ *   Transfer Token is requested but no actor could be resolved (no explicit actor and
+ *   no usable session ID token).
+ * - `setactor_required` — the server rejected the exchange because the Action did not
+ *   call `setActor` (an actor is mandatory for a Session Transfer Token).
+ * - `session_transfer_disabled` — the server rejected the exchange because the tenant
+ *   feature flag is off.
+ *
+ * Only `actor_unavailable` is raised by the SDK itself. `setactor_required` and
+ * `session_transfer_disabled` are surfaced from the raw server response via the
+ * error's `cause.error` / `cause.error_description`; they are defined here as named
+ * constants for documentation and for the day the platform returns a machine-readable
+ * code.
+ */
+export const TokenExchangeErrorCode = {
+  ACTOR_UNAVAILABLE: 'actor_unavailable',
+  SETACTOR_REQUIRED: 'setactor_required',
+  SESSION_TRANSFER_DISABLED: 'session_transfer_disabled',
+} as const;
+
+export type TokenExchangeErrorCode = (typeof TokenExchangeErrorCode)[keyof typeof TokenExchangeErrorCode];
+
+/**
  * Error thrown when there is no transaction available.
  */
 export class MissingTransactionError extends Error {

--- a/packages/auth0-server-js/src/index.ts
+++ b/packages/auth0-server-js/src/index.ts
@@ -11,6 +11,10 @@ export { StatefulStateStore } from './store/stateful-state-store.js';
 export type { StatefulStateStoreOptions } from './store/stateful-state-store.js';
 export { StatelessStateStore } from './store/stateless-state-store.js';
 
+// Explicitly surface the STT error-code constant (also covered by `export * from './errors.js'`),
+// for parity with the explicitly re-exported error classes above.
+export { TokenExchangeErrorCode } from './errors.js';
+
 export * from './errors.js';
 export * from './types.js';
 export * from './mfa/index.js';

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -7494,6 +7494,74 @@ test('requestSessionTransferToken - throws ACTOR_UNAVAILABLE when session ID tok
   }
 });
 
+test('requestSessionTransferToken - throws ACTOR_UNAVAILABLE when the session belongs to a different domain (resolver mode)', async () => {
+  const agentIdToken = await generateToken('other.custom.example.com', 'agent_123', '<client_id>');
+  const exchangeSpy = vi.spyOn(AuthClient.prototype, 'exchangeToken');
+
+  const serverClient = new ServerClient({
+    // Resolver mode: the request resolves to a different domain than the session's.
+    domain: async () => 'tenant.custom.example.com',
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: {
+      get: vi
+        .fn()
+        .mockResolvedValue({ ...sessionStateWith(agentIdToken, '<refresh_token>'), domain: 'other.custom.example.com' }),
+      set: vi.fn(),
+      delete: vi.fn(),
+      deleteByLogoutToken: vi.fn(),
+    },
+  });
+
+  try {
+    await expect(
+      serverClient.requestSessionTransferToken({
+        subjectToken: 'customer-proof-token',
+        subjectTokenType: 'urn:acme:customer-subject',
+      })
+    ).rejects.toThrowError(expect.objectContaining({ code: 'actor_unavailable' }));
+    expect(exchangeSpy).not.toHaveBeenCalled();
+  } finally {
+    exchangeSpy.mockRestore();
+  }
+});
+
+test('requestSessionTransferToken - throws SessionExpiredError and clears the session when the session_expiry ceiling is reached', async () => {
+  const agentIdToken = await generateToken(domain, 'agent_123', '<client_id>');
+  const exchangeSpy = vi.spyOn(AuthClient.prototype, 'exchangeToken');
+  const mockStateStore = {
+    get: vi
+      .fn()
+      .mockResolvedValue({ ...sessionStateWith(agentIdToken, '<refresh_token>'), sessionExpiresAt: Math.floor(Date.now() / 1000) - 60 }),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  try {
+    await expect(
+      serverClient.requestSessionTransferToken({
+        subjectToken: 'customer-proof-token',
+        subjectTokenType: 'urn:acme:customer-subject',
+      })
+    ).rejects.toThrowError(SessionExpiredError);
+    // The expired session must be cleared, and no exchange attempted.
+    expect(mockStateStore.delete).toHaveBeenCalled();
+    expect(exchangeSpy).not.toHaveBeenCalled();
+  } finally {
+    exchangeSpy.mockRestore();
+  }
+});
+
 test('requestSessionTransferToken - refreshes an expired session ID token and uses the fresh one as actor', async () => {
   const expiredIdToken = await generateToken(domain, 'agent_123', '<client_id>', undefined, undefined, '-1h');
   const freshIdToken = await generateToken(domain, 'agent_123', '<client_id>');

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, afterAll, afterEach, beforeAll, beforeEach, vi, describe 
 import { ServerClient } from './server-client.js';
 import {
   InvalidConfigurationError,
+  MissingRequiredArgumentError,
   MissingSessionError,
   MissingTransactionError,
   SessionExpiredError,
@@ -107,6 +108,29 @@ const restHandlers = [
       info.get('code') === '<code_should_fail>' ||
       info.get('subject_token') === '<refresh_token_should_fail>' ||
       info.get('refresh_token') === '<refresh_token_should_fail>';
+
+    // Session Transfer Token (STT) exchange: recognised by the session_transfer audience. Returns
+    // an opaque STT (not a bearer access token) with issued_token_type set to the session-transfer
+    // URN and token_type "N_A". A missing actor is rejected server-side (setActor required).
+    const audienceParam = info.get('audience');
+    if (typeof audienceParam === 'string' && audienceParam.endsWith(':session_transfer')) {
+      if (!info.get('actor_token')) {
+        return HttpResponse.json(
+          {
+            error: 'invalid_request',
+            error_description: 'setActor is required when requesting a session transfer token via token exchange.',
+          },
+          { status: 400 }
+        );
+      }
+      return HttpResponse.json({
+        access_token: '<opaque-session-transfer-token>',
+        issued_token_type: 'urn:auth0:params:oauth:token-type:session_transfer_token',
+        token_type: 'N_A',
+        expires_in: 60,
+        scope: scopeToReturn,
+      });
+    }
 
     return shouldFailTokenExchange
       ? HttpResponse.json({ error: '<error_code>', error_description: '<error_description>' }, { status: 400 })
@@ -7231,4 +7255,587 @@ describe('logout revocation', () => {
     expect(mockStateStore.delete).not.toHaveBeenCalled();
     expect(url).toBeDefined();
   });
+});
+
+// ============================================================================
+// Session Transfer Token (STT) — impersonation via session transfer
+// ============================================================================
+
+const SESSION_TRANSFER_TOKEN_TYPE = 'urn:auth0:params:oauth:token-type:session_transfer_token';
+const ID_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:id_token';
+
+const sessionStateWith = (idToken: string, refreshToken?: string): StateData => ({
+  user: { sub: 'agent_123' },
+  idToken,
+  refreshToken,
+  tokenSets: [],
+  domain,
+  internal: { sid: '<sid>', createdAt: Math.floor(Date.now() / 1000) },
+});
+
+test('requestSessionTransferToken - parses the STT result and branches on issuedTokenType', async () => {
+  const agentIdToken = await generateToken(domain, 'agent_123', '<client_id>');
+  const mockStateStore = {
+    get: vi.fn().mockResolvedValue(sessionStateWith(agentIdToken, '<refresh_token>')),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  const result = await serverClient.requestSessionTransferToken({
+    subjectToken: 'customer-proof-token',
+    subjectTokenType: 'urn:acme:customer-subject',
+  });
+
+  expect(result.issuedTokenType).toBe(SESSION_TRANSFER_TOKEN_TYPE);
+  expect(result.sessionTransferToken).toBe('<opaque-session-transfer-token>');
+  // token_type is informational only (never branched on); openid-client normalizes it to lowercase.
+  expect(result.tokenType?.toLowerCase()).toBe('n_a');
+  expect(result.expiresIn).toBeGreaterThan(0);
+  // The STT must never be placed in an access-token field.
+  expect((result as unknown as { accessToken?: string }).accessToken).toBeUndefined();
+});
+
+test('requestSessionTransferToken - never persists the STT (stateless exchange)', async () => {
+  const agentIdToken = await generateToken(domain, 'agent_123', '<client_id>');
+  const mockStateStore = {
+    get: vi.fn().mockResolvedValue(sessionStateWith(agentIdToken, '<refresh_token>')),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  await serverClient.requestSessionTransferToken({
+    subjectToken: 'customer-proof-token',
+    subjectTokenType: 'urn:acme:customer-subject',
+  });
+
+  // The actor was already fresh, so no refresh/persist happened: nothing written to the store.
+  expect(mockStateStore.set).not.toHaveBeenCalled();
+});
+
+test('requestSessionTransferToken - sources the actor from the agent session ID token', async () => {
+  const agentIdToken = await generateToken(domain, 'agent_123', '<client_id>');
+  const exchangeSpy = vi.spyOn(AuthClient.prototype, 'exchangeToken');
+
+  const mockStateStore = {
+    get: vi.fn().mockResolvedValue(sessionStateWith(agentIdToken, '<refresh_token>')),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  try {
+    await serverClient.requestSessionTransferToken({
+      subjectToken: 'customer-proof-token',
+      subjectTokenType: 'urn:acme:customer-subject',
+    });
+
+    expect(exchangeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorToken: agentIdToken,
+        actorTokenType: ID_TOKEN_TYPE,
+        audience: `urn:${domain}:session_transfer`,
+        subjectToken: 'customer-proof-token',
+        subjectTokenType: 'urn:acme:customer-subject',
+      })
+    );
+  } finally {
+    exchangeSpy.mockRestore();
+  }
+});
+
+test('requestSessionTransferToken - honours an explicit actor override (no session read)', async () => {
+  const explicitActor = await generateToken(domain, 'explicit_agent', '<client_id>');
+  const exchangeSpy = vi.spyOn(AuthClient.prototype, 'exchangeToken');
+
+  const mockStateStore = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  try {
+    await serverClient.requestSessionTransferToken({
+      subjectToken: 'customer-proof-token',
+      subjectTokenType: 'urn:acme:customer-subject',
+      actor: { token: explicitActor, type: ID_TOKEN_TYPE },
+    });
+
+    // With an explicit actor, the session must not be read for the actor.
+    expect(mockStateStore.get).not.toHaveBeenCalled();
+    expect(exchangeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ actorToken: explicitActor, actorTokenType: ID_TOKEN_TYPE })
+    );
+  } finally {
+    exchangeSpy.mockRestore();
+  }
+});
+
+test('requestSessionTransferToken - defaults the explicit actor type to the ID token URN', async () => {
+  const explicitActor = await generateToken(domain, 'explicit_agent', '<client_id>');
+  const exchangeSpy = vi.spyOn(AuthClient.prototype, 'exchangeToken');
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() },
+  });
+
+  try {
+    await serverClient.requestSessionTransferToken({
+      subjectToken: 'customer-proof-token',
+      subjectTokenType: 'urn:acme:customer-subject',
+      actor: { token: explicitActor },
+    });
+
+    expect(exchangeSpy).toHaveBeenCalledWith(expect.objectContaining({ actorTokenType: ID_TOKEN_TYPE }));
+  } finally {
+    exchangeSpy.mockRestore();
+  }
+});
+
+test('requestSessionTransferToken - throws ACTOR_UNAVAILABLE (client-side) when no actor and no session', async () => {
+  const exchangeSpy = vi.spyOn(AuthClient.prototype, 'exchangeToken');
+  const mockStateStore = {
+    get: vi.fn().mockResolvedValue(undefined),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  try {
+    await expect(
+      serverClient.requestSessionTransferToken({
+        subjectToken: 'customer-proof-token',
+        subjectTokenType: 'urn:acme:customer-subject',
+      })
+    ).rejects.toThrowError(
+      expect.objectContaining({ name: 'TokenExchangeError', code: 'actor_unavailable' })
+    );
+    // No network call must have been made.
+    expect(exchangeSpy).not.toHaveBeenCalled();
+  } finally {
+    exchangeSpy.mockRestore();
+  }
+});
+
+test('requestSessionTransferToken - throws ACTOR_UNAVAILABLE when session ID token is expired and no refresh token', async () => {
+  const expiredIdToken = await generateToken(domain, 'agent_123', '<client_id>', undefined, undefined, '-1h');
+  const exchangeSpy = vi.spyOn(AuthClient.prototype, 'exchangeToken');
+  const mockStateStore = {
+    get: vi.fn().mockResolvedValue(sessionStateWith(expiredIdToken, undefined)),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  try {
+    await expect(
+      serverClient.requestSessionTransferToken({
+        subjectToken: 'customer-proof-token',
+        subjectTokenType: 'urn:acme:customer-subject',
+      })
+    ).rejects.toThrowError(expect.objectContaining({ code: 'actor_unavailable' }));
+    expect(exchangeSpy).not.toHaveBeenCalled();
+  } finally {
+    exchangeSpy.mockRestore();
+  }
+});
+
+test('requestSessionTransferToken - refreshes an expired session ID token and uses the fresh one as actor', async () => {
+  const expiredIdToken = await generateToken(domain, 'agent_123', '<client_id>', undefined, undefined, '-1h');
+  const freshIdToken = await generateToken(domain, 'agent_123', '<client_id>');
+  const refreshedResponse = new TokenResponse('<new_access_token>', Date.now() / 1000 + 3600, freshIdToken, '<new_refresh_token>');
+  const refreshSpy = vi
+    .spyOn(AuthClient.prototype, 'getTokenByRefreshToken')
+    .mockResolvedValue(refreshedResponse);
+  const exchangeSpy = vi.spyOn(AuthClient.prototype, 'exchangeToken');
+
+  const mockStateStore = {
+    get: vi.fn().mockResolvedValue(sessionStateWith(expiredIdToken, '<refresh_token>')),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  try {
+    await serverClient.requestSessionTransferToken({
+      subjectToken: 'customer-proof-token',
+      subjectTokenType: 'urn:acme:customer-subject',
+    });
+
+    expect(refreshSpy).toHaveBeenCalledWith(expect.objectContaining({ refreshToken: '<refresh_token>' }));
+    expect(exchangeSpy).toHaveBeenCalledWith(expect.objectContaining({ actorToken: freshIdToken }));
+    // The refreshed agent session must be persisted (refresh-token rotation coherence).
+    expect(mockStateStore.set).toHaveBeenCalled();
+  } finally {
+    refreshSpy.mockRestore();
+    exchangeSpy.mockRestore();
+  }
+});
+
+test('requestSessionTransferToken - throws ACTOR_UNAVAILABLE when refresh fails', async () => {
+  const expiredIdToken = await generateToken(domain, 'agent_123', '<client_id>', undefined, undefined, '-1h');
+  const refreshSpy = vi
+    .spyOn(AuthClient.prototype, 'getTokenByRefreshToken')
+    .mockRejectedValue(new Error('refresh failed'));
+  const exchangeSpy = vi.spyOn(AuthClient.prototype, 'exchangeToken');
+
+  const mockStateStore = {
+    get: vi.fn().mockResolvedValue(sessionStateWith(expiredIdToken, '<refresh_token>')),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  try {
+    await expect(
+      serverClient.requestSessionTransferToken({
+        subjectToken: 'customer-proof-token',
+        subjectTokenType: 'urn:acme:customer-subject',
+      })
+    ).rejects.toThrowError(expect.objectContaining({ code: 'actor_unavailable' }));
+    expect(exchangeSpy).not.toHaveBeenCalled();
+  } finally {
+    refreshSpy.mockRestore();
+    exchangeSpy.mockRestore();
+  }
+});
+
+test('requestSessionTransferToken - surfaces SETACTOR_REQUIRED as a TokenExchangeError from the server', async () => {
+  const agentIdToken = await generateToken(domain, 'agent_123', '<client_id>');
+  // Force the server to see no actor even though the SDK sends one, by overriding the handler
+  // to always return the setActor-required error for the session_transfer audience.
+  server.use(
+    http.post(mockOpenIdConfiguration.token_endpoint, () =>
+      HttpResponse.json(
+        {
+          error: 'invalid_request',
+          error_description: 'setActor is required when requesting a session transfer token via token exchange.',
+        },
+        { status: 400 }
+      )
+    )
+  );
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: {
+      get: vi.fn().mockResolvedValue(sessionStateWith(agentIdToken, '<refresh_token>')),
+      set: vi.fn(),
+      delete: vi.fn(),
+      deleteByLogoutToken: vi.fn(),
+    },
+  });
+
+  await expect(
+    serverClient.requestSessionTransferToken({
+      subjectToken: 'customer-proof-token',
+      subjectTokenType: 'urn:acme:customer-subject',
+    })
+  ).rejects.toThrowError(
+    expect.objectContaining({
+      name: 'TokenExchangeError',
+      cause: expect.objectContaining({
+        error_description: 'setActor is required when requesting a session transfer token via token exchange.',
+      }),
+    })
+  );
+});
+
+test('requestSessionTransferToken - builds the session_transfer audience from the resolved (MCD) domain', async () => {
+  const customDomain = 'tenant.custom.example.com';
+  const agentIdToken = await generateToken(customDomain, 'agent_123', '<client_id>');
+  const exchangeSpy = vi
+    .spyOn(AuthClient.prototype, 'exchangeToken')
+    .mockResolvedValue(
+      Object.assign(new TokenResponse('<stt>', Date.now() / 1000 + 60), {
+        issuedTokenType: SESSION_TRANSFER_TOKEN_TYPE,
+        tokenType: 'N_A',
+      })
+    );
+
+  const serverClient = new ServerClient({
+    domain: async () => customDomain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: {
+      get: vi.fn().mockResolvedValue({ ...sessionStateWith(agentIdToken, '<refresh_token>'), domain: customDomain }),
+      set: vi.fn(),
+      delete: vi.fn(),
+      deleteByLogoutToken: vi.fn(),
+    },
+  });
+
+  try {
+    await serverClient.requestSessionTransferToken({
+      subjectToken: 'customer-proof-token',
+      subjectTokenType: 'urn:acme:customer-subject',
+    });
+
+    expect(exchangeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ audience: `urn:${customDomain}:session_transfer` })
+    );
+  } finally {
+    exchangeSpy.mockRestore();
+  }
+});
+
+test('requestSessionTransferToken - forwards scope and extra params', async () => {
+  const agentIdToken = await generateToken(domain, 'agent_123', '<client_id>');
+  const exchangeSpy = vi.spyOn(AuthClient.prototype, 'exchangeToken');
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: {
+      get: vi.fn().mockResolvedValue(sessionStateWith(agentIdToken, '<refresh_token>')),
+      set: vi.fn(),
+      delete: vi.fn(),
+      deleteByLogoutToken: vi.fn(),
+    },
+  });
+
+  try {
+    await serverClient.requestSessionTransferToken({
+      subjectToken: 'customer-proof-token',
+      subjectTokenType: 'urn:acme:customer-subject',
+      scope: 'openid profile read:tickets',
+      extra: { reason: 'Investigating TCK-4821' },
+    });
+
+    expect(exchangeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: 'openid profile read:tickets',
+        extra: { reason: 'Investigating TCK-4821' },
+      })
+    );
+  } finally {
+    exchangeSpy.mockRestore();
+  }
+});
+
+test('buildSessionTransferRedirect - appends the URL-encoded STT as a query parameter', () => {
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() },
+  });
+
+  const url = serverClient.buildSessionTransferRedirect('https://app.example.com/auth/login', {
+    sessionTransferToken: 'stt with/special+chars',
+    issuedTokenType: SESSION_TRANSFER_TOKEN_TYPE,
+    expiresIn: 60,
+  });
+
+  expect(url.origin).toBe('https://app.example.com');
+  expect(url.pathname).toBe('/auth/login');
+  expect(url.searchParams.get('session_transfer_token')).toBe('stt with/special+chars');
+  // The raw query string must be percent-encoded.
+  expect(url.search).toContain('session_transfer_token=stt+with%2Fspecial%2Bchars');
+  expect(url.searchParams.get('organization')).toBeNull();
+});
+
+test('buildSessionTransferRedirect - includes organization when provided', () => {
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() },
+  });
+
+  const url = serverClient.buildSessionTransferRedirect(
+    'https://app.example.com/auth/login',
+    { sessionTransferToken: 'stt-123', issuedTokenType: SESSION_TRANSFER_TOKEN_TYPE, expiresIn: 60 },
+    { organization: 'org_globex' }
+  );
+
+  expect(url.searchParams.get('organization')).toBe('org_globex');
+  expect(url.searchParams.get('session_transfer_token')).toBe('stt-123');
+});
+
+test('buildSessionTransferRedirect - preserves existing query params on the target URL', () => {
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() },
+  });
+
+  const url = serverClient.buildSessionTransferRedirect('https://app.example.com/auth/login?returnTo=%2Fdashboard', {
+    sessionTransferToken: 'stt-123',
+    issuedTokenType: SESSION_TRANSFER_TOKEN_TYPE,
+    expiresIn: 60,
+  });
+
+  expect(url.searchParams.get('returnTo')).toBe('/dashboard');
+  expect(url.searchParams.get('session_transfer_token')).toBe('stt-123');
+});
+
+test('buildSessionTransferRedirect - allows http for localhost', () => {
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() },
+  });
+
+  const url = serverClient.buildSessionTransferRedirect('http://localhost:3000/auth/login', {
+    sessionTransferToken: 'stt-123',
+    issuedTokenType: SESSION_TRANSFER_TOKEN_TYPE,
+    expiresIn: 60,
+  });
+
+  expect(url.searchParams.get('session_transfer_token')).toBe('stt-123');
+});
+
+test('buildSessionTransferRedirect - rejects a non-https target (token leak protection)', () => {
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() },
+  });
+
+  expect(() =>
+    serverClient.buildSessionTransferRedirect('http://app.example.com/auth/login', {
+      sessionTransferToken: 'stt-123',
+      issuedTokenType: SESSION_TRANSFER_TOKEN_TYPE,
+      expiresIn: 60,
+    })
+  ).toThrowError(InvalidConfigurationError);
+});
+
+test('buildSessionTransferRedirect - rejects a non-absolute target URL', () => {
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() },
+  });
+
+  expect(() =>
+    serverClient.buildSessionTransferRedirect('/auth/login', {
+      sessionTransferToken: 'stt-123',
+      issuedTokenType: SESSION_TRANSFER_TOKEN_TYPE,
+      expiresIn: 60,
+    })
+  ).toThrowError(InvalidConfigurationError);
+});
+
+test('buildSessionTransferRedirect - rejects a blank organization', () => {
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() },
+  });
+
+  expect(() =>
+    serverClient.buildSessionTransferRedirect(
+      'https://app.example.com/auth/login',
+      { sessionTransferToken: 'stt-123', issuedTokenType: SESSION_TRANSFER_TOKEN_TYPE, expiresIn: 60 },
+      { organization: '   ' }
+    )
+  ).toThrowError(OrganizationValidationError);
+});
+
+test('buildSessionTransferRedirect - rejects a blank target URL', () => {
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() },
+  });
+
+  expect(() =>
+    serverClient.buildSessionTransferRedirect('   ', {
+      sessionTransferToken: 'stt-123',
+      issuedTokenType: SESSION_TRANSFER_TOKEN_TYPE,
+      expiresIn: 60,
+    })
+  ).toThrowError(MissingRequiredArgumentError);
 });

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -7362,6 +7362,49 @@ test('requestSessionTransferToken - parses the STT result and branches on issued
   expect((result as unknown as { accessToken?: string }).accessToken).toBeUndefined();
 });
 
+test('requestSessionTransferToken - surfaces a non-STT issuedTokenType unchanged (never fabricates the URN)', async () => {
+  // When the server responds with a different (or no) issued_token_type, the SDK must pass through
+  // exactly what it got rather than pretend the response is an STT. Callers branch on issuedTokenType
+  // themselves, so mislabelling a non-STT response as an STT would be a correctness bug.
+  const agentIdToken = await generateToken(domain, 'agent_123', '<client_id>');
+  const nonSttType = 'urn:ietf:params:oauth:token-type:access_token';
+  const exchangeSpy = vi
+    .spyOn(AuthClient.prototype, 'exchangeToken')
+    .mockResolvedValue(
+      Object.assign(new TokenResponse('<not-an-stt>', Date.now() / 1000 + 60), {
+        issuedTokenType: nonSttType,
+        tokenType: 'Bearer',
+      })
+    );
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: {
+      get: vi.fn().mockResolvedValue(sessionStateWith(agentIdToken, '<refresh_token>')),
+      set: vi.fn(),
+      delete: vi.fn(),
+      deleteByLogoutToken: vi.fn(),
+    },
+  });
+
+  try {
+    const result = await serverClient.requestSessionTransferToken({
+      subjectToken: 'customer-proof-token',
+      subjectTokenType: 'urn:acme:customer-subject',
+    });
+
+    // The type is surfaced verbatim, not coerced to the STT URN.
+    expect(result.issuedTokenType).toBe(nonSttType);
+    expect(result.issuedTokenType).not.toBe(SESSION_TRANSFER_TOKEN_TYPE);
+    expect(result.sessionTransferToken).toBe('<not-an-stt>');
+  } finally {
+    exchangeSpy.mockRestore();
+  }
+});
+
 test('requestSessionTransferToken - never persists the STT (stateless exchange)', async () => {
   const agentIdToken = await generateToken(domain, 'agent_123', '<client_id>');
   const mockStateStore = {
@@ -7619,9 +7662,57 @@ test('requestSessionTransferToken - throws ACTOR_UNAVAILABLE when the session be
   }
 });
 
-test('requestSessionTransferToken - throws SessionExpiredError and clears the session when the session_expiry ceiling is reached', async () => {
+test('requestSessionTransferToken - sources the actor from the session and exchanges when the resolved domain matches (resolver mode)', async () => {
+  // The negative resolver test above short-circuits before the exchange. This covers the opposite
+  // side: resolved domain matches the session's domain, so the real session read happens, the actor
+  // is sourced from the session ID token, and the exchange runs through to a minted STT.
   const agentIdToken = await generateToken(domain, 'agent_123', '<client_id>');
-  const exchangeSpy = vi.spyOn(AuthClient.prototype, 'exchangeToken');
+
+  // Capture the wire params so we can assert the actor came from the real session.
+  let capturedActorToken: string | null = null;
+  server.use(
+    http.post(mockOpenIdConfiguration.token_endpoint, async ({ request }) => {
+      const info = new URLSearchParams(await request.text());
+      capturedActorToken = info.get('actor_token');
+      return HttpResponse.json({
+        access_token: '<opaque-session-transfer-token>',
+        issued_token_type: SESSION_TRANSFER_TOKEN_TYPE,
+        token_type: 'N_A',
+        expires_in: 60,
+      });
+    })
+  );
+
+  const serverClient = new ServerClient({
+    // Resolver mode: the request resolves to the SAME domain as the session's.
+    domain: async () => domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: {
+      get: vi.fn().mockResolvedValue({ ...sessionStateWith(agentIdToken, '<refresh_token>'), domain }),
+      set: vi.fn(),
+      delete: vi.fn(),
+      deleteByLogoutToken: vi.fn(),
+    },
+  });
+
+  const result = await serverClient.requestSessionTransferToken({
+    subjectToken: 'customer-proof-token',
+    subjectTokenType: 'urn:acme:customer-subject',
+  });
+
+  expect(result.issuedTokenType).toBe(SESSION_TRANSFER_TOKEN_TYPE);
+  expect(result.sessionTransferToken).toBe('<opaque-session-transfer-token>');
+  // The actor token on the wire must be the session's ID token, not fabricated or empty.
+  expect(capturedActorToken).toBe(agentIdToken);
+});
+
+test('requestSessionTransferToken - is NOT capped by the session_expiry ceiling (CTE is out of scope for session_expiry)', async () => {
+  // The session_expiry ceiling is scoped to the Auth Code flow. STT actor sourcing is deliberately
+  // not gated on it, mirroring the Token Vault decision (connection tokens are also un-gated). A
+  // past-ceiling sessionExpiresAt must therefore still mint the STT rather than throw.
+  const agentIdToken = await generateToken(domain, 'agent_123', '<client_id>');
   const mockStateStore = {
     get: vi
       .fn()
@@ -7639,19 +7730,15 @@ test('requestSessionTransferToken - throws SessionExpiredError and clears the se
     stateStore: mockStateStore,
   });
 
-  try {
-    await expect(
-      serverClient.requestSessionTransferToken({
-        subjectToken: 'customer-proof-token',
-        subjectTokenType: 'urn:acme:customer-subject',
-      })
-    ).rejects.toThrowError(SessionExpiredError);
-    // The expired session must be cleared, and no exchange attempted.
-    expect(mockStateStore.delete).toHaveBeenCalled();
-    expect(exchangeSpy).not.toHaveBeenCalled();
-  } finally {
-    exchangeSpy.mockRestore();
-  }
+  const result = await serverClient.requestSessionTransferToken({
+    subjectToken: 'customer-proof-token',
+    subjectTokenType: 'urn:acme:customer-subject',
+  });
+
+  expect(result.issuedTokenType).toBe(SESSION_TRANSFER_TOKEN_TYPE);
+  expect(result.sessionTransferToken).toBe('<opaque-session-transfer-token>');
+  // The session must NOT be cleared for a past-ceiling value on this path.
+  expect(mockStateStore.delete).not.toHaveBeenCalled();
 });
 
 test('requestSessionTransferToken - refreshes an expired session ID token and uses the fresh one as actor', async () => {
@@ -7769,6 +7856,50 @@ test('requestSessionTransferToken - surfaces SETACTOR_REQUIRED as a TokenExchang
       name: 'TokenExchangeError',
       cause: expect.objectContaining({
         error_description: 'setActor is required when requesting a session transfer token via token exchange.',
+      }),
+    })
+  );
+});
+
+test('requestSessionTransferToken - surfaces SESSION_TRANSFER_DISABLED as a TokenExchangeError from the server', async () => {
+  const agentIdToken = await generateToken(domain, 'agent_123', '<client_id>');
+  // The tenant has the session-transfer feature disabled; the server rejects the exchange. This
+  // takes the same path as SETACTOR_REQUIRED, so both server errors need coverage.
+  server.use(
+    http.post(mockOpenIdConfiguration.token_endpoint, () =>
+      HttpResponse.json(
+        {
+          error: 'invalid_request',
+          error_description: 'Session transfer is not enabled for this tenant.',
+        },
+        { status: 400 }
+      )
+    )
+  );
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: {
+      get: vi.fn().mockResolvedValue(sessionStateWith(agentIdToken, '<refresh_token>')),
+      set: vi.fn(),
+      delete: vi.fn(),
+      deleteByLogoutToken: vi.fn(),
+    },
+  });
+
+  await expect(
+    serverClient.requestSessionTransferToken({
+      subjectToken: 'customer-proof-token',
+      subjectTokenType: 'urn:acme:customer-subject',
+    })
+  ).rejects.toThrowError(
+    expect.objectContaining({
+      name: 'TokenExchangeError',
+      cause: expect.objectContaining({
+        error_description: 'Session transfer is not enabled for this tenant.',
       }),
     })
   );

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -7273,6 +7273,64 @@ const sessionStateWith = (idToken: string, refreshToken?: string): StateData => 
   internal: { sid: '<sid>', createdAt: Math.floor(Date.now() / 1000) },
 });
 
+test('requestSessionTransferToken - throws MissingRequiredArgumentError for a blank subjectToken (before any session read or network call)', async () => {
+  const exchangeSpy = vi.spyOn(AuthClient.prototype, 'exchangeToken');
+  const mockStateStore = {
+    get: vi.fn().mockResolvedValue(sessionStateWith(await generateToken(domain, 'agent_123', '<client_id>'), '<refresh_token>')),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  try {
+    await expect(
+      serverClient.requestSessionTransferToken({ subjectToken: '   ', subjectTokenType: 'urn:acme:customer-subject' })
+    ).rejects.toThrowError(MissingRequiredArgumentError);
+    // Must fail client-side without reading the session, refreshing, or hitting the network.
+    expect(mockStateStore.get).not.toHaveBeenCalled();
+    expect(mockStateStore.set).not.toHaveBeenCalled();
+    expect(exchangeSpy).not.toHaveBeenCalled();
+  } finally {
+    exchangeSpy.mockRestore();
+  }
+});
+
+test('requestSessionTransferToken - throws MissingRequiredArgumentError for a blank subjectTokenType', async () => {
+  const exchangeSpy = vi.spyOn(AuthClient.prototype, 'exchangeToken');
+  const mockStateStore = {
+    get: vi.fn().mockResolvedValue(sessionStateWith(await generateToken(domain, 'agent_123', '<client_id>'), '<refresh_token>')),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  try {
+    await expect(
+      serverClient.requestSessionTransferToken({ subjectToken: 'customer-proof-token', subjectTokenType: '   ' })
+    ).rejects.toThrowError(MissingRequiredArgumentError);
+    expect(mockStateStore.get).not.toHaveBeenCalled();
+    expect(exchangeSpy).not.toHaveBeenCalled();
+  } finally {
+    exchangeSpy.mockRestore();
+  }
+});
+
 test('requestSessionTransferToken - parses the STT result and branches on issuedTokenType', async () => {
   const agentIdToken = await generateToken(domain, 'agent_123', '<client_id>');
   const mockStateStore = {
@@ -7425,6 +7483,40 @@ test('requestSessionTransferToken - defaults the explicit actor type to the ID t
     });
 
     expect(exchangeSpy).toHaveBeenCalledWith(expect.objectContaining({ actorTokenType: ID_TOKEN_TYPE }));
+  } finally {
+    exchangeSpy.mockRestore();
+  }
+});
+
+test('requestSessionTransferToken - throws ACTOR_UNAVAILABLE for a blank explicit actor token (no session fallback)', async () => {
+  const exchangeSpy = vi.spyOn(AuthClient.prototype, 'exchangeToken');
+  // A valid session exists — but an explicit (blank) actor must NOT silently fall back to it.
+  const mockStateStore = {
+    get: vi.fn().mockResolvedValue(sessionStateWith(await generateToken(domain, 'agent_123', '<client_id>'), '<refresh_token>')),
+    set: vi.fn(),
+    delete: vi.fn(),
+    deleteByLogoutToken: vi.fn(),
+  };
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: mockStateStore,
+  });
+
+  try {
+    await expect(
+      serverClient.requestSessionTransferToken({
+        subjectToken: 'customer-proof-token',
+        subjectTokenType: 'urn:acme:customer-subject',
+        actor: { token: '   ' },
+      })
+    ).rejects.toThrowError(expect.objectContaining({ name: 'TokenExchangeError', code: 'actor_unavailable' }));
+    // Must fail client-side without reading the session or hitting the network.
+    expect(mockStateStore.get).not.toHaveBeenCalled();
+    expect(exchangeSpy).not.toHaveBeenCalled();
   } finally {
     exchangeSpy.mockRestore();
   }
@@ -7757,6 +7849,42 @@ test('requestSessionTransferToken - forwards scope and extra params', async () =
   }
 });
 
+test('requestSessionTransferToken - reports expiresIn as 0 (not NaN) when the server omits expires_in', async () => {
+  const agentIdToken = await generateToken(domain, 'agent_123', '<client_id>');
+  // Simulate a response with no `expires_in`: TokenResponse.expiresAt is then NaN.
+  const exchangeSpy = vi.spyOn(AuthClient.prototype, 'exchangeToken').mockResolvedValue(
+    Object.assign(new TokenResponse('<stt>', NaN), {
+      issuedTokenType: SESSION_TRANSFER_TOKEN_TYPE,
+      tokenType: 'N_A',
+    })
+  );
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: {
+      get: vi.fn().mockResolvedValue(sessionStateWith(agentIdToken, '<refresh_token>')),
+      set: vi.fn(),
+      delete: vi.fn(),
+      deleteByLogoutToken: vi.fn(),
+    },
+  });
+
+  try {
+    const result = await serverClient.requestSessionTransferToken({
+      subjectToken: 'customer-proof-token',
+      subjectTokenType: 'urn:acme:customer-subject',
+    });
+
+    expect(result.expiresIn).toBe(0);
+    expect(Number.isNaN(result.expiresIn)).toBe(false);
+  } finally {
+    exchangeSpy.mockRestore();
+  }
+});
+
 test('buildSessionTransferRedirect - appends the URL-encoded STT as a query parameter', () => {
   const serverClient = new ServerClient({
     domain,
@@ -7828,6 +7956,42 @@ test('buildSessionTransferRedirect - allows http for localhost', () => {
   });
 
   const url = serverClient.buildSessionTransferRedirect('http://localhost:3000/auth/login', {
+    sessionTransferToken: 'stt-123',
+    issuedTokenType: SESSION_TRANSFER_TOKEN_TYPE,
+    expiresIn: 60,
+  });
+
+  expect(url.searchParams.get('session_transfer_token')).toBe('stt-123');
+});
+
+test('buildSessionTransferRedirect - allows http for the 127.0.0.1 loopback address', () => {
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() },
+  });
+
+  const url = serverClient.buildSessionTransferRedirect('http://127.0.0.1:3000/auth/login', {
+    sessionTransferToken: 'stt-123',
+    issuedTokenType: SESSION_TRANSFER_TOKEN_TYPE,
+    expiresIn: 60,
+  });
+
+  expect(url.searchParams.get('session_transfer_token')).toBe('stt-123');
+});
+
+test('buildSessionTransferRedirect - allows http for the [::1] IPv6 loopback address', () => {
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() },
+  });
+
+  const url = serverClient.buildSessionTransferRedirect('http://[::1]:3000/auth/login', {
     sessionTransferToken: 'stt-123',
     issuedTokenType: SESSION_TRANSFER_TOKEN_TYPE,
     expiresIn: 60,

--- a/packages/auth0-server-js/src/server-client.ts
+++ b/packages/auth0-server-js/src/server-client.ts
@@ -1303,6 +1303,7 @@ export class ServerClient<TStoreOptions = unknown> {
    * @throws {TokenExchangeError} With code `actor_unavailable` when no explicit actor is given and no usable session ID token can be resolved — no logged-in agent, a session that belongs to a different domain in resolver mode, or an expired ID token that cannot be refreshed (raised client-side, before any network call). With the default code when the exchange itself fails; a server-side `setactor_required` or `session_transfer_disabled` condition is surfaced via `cause.error` / `cause.error_description`.
    * @throws {SessionExpiredError} When the agent session's `session_expiry` ceiling has been reached; the session is cleared and re-authentication is required.
    * @throws {MissingClientAuthError} When client credentials are not configured (STT requires a confidential client).
+   * @throws {MissingRequiredArgumentError} When `subjectToken` or `subjectTokenType` is missing or blank (raised before any session read or network call).
    *
    * @returns A promise resolving to a {@link SessionTransferTokenResult} containing the STT and its metadata.
    */
@@ -1310,6 +1311,16 @@ export class ServerClient<TStoreOptions = unknown> {
     options: RequestSessionTransferTokenOptions,
     storeOptions?: TStoreOptions
   ): Promise<SessionTransferTokenResult> {
+    // Validate the developer-supplied subject up front, before any session read, refresh, or
+    // persist. A blank subject is a guaranteed client-side failure, so resolving the actor first
+    // would waste a refresh round-trip and a store write on a request that cannot succeed.
+    if (!options.subjectToken || !options.subjectToken.trim()) {
+      throw new MissingRequiredArgumentError('subjectToken');
+    }
+    if (!options.subjectTokenType || !options.subjectTokenType.trim()) {
+      throw new MissingRequiredArgumentError('subjectTokenType');
+    }
+
     const domain = await this.#resolveDomain(storeOptions);
 
     // Resolve the actor before anything else — an STT is only issued when an actor is set, and a
@@ -1332,7 +1343,11 @@ export class ServerClient<TStoreOptions = unknown> {
       // Surface exactly what the server returned — never fabricate the URN, so a non-STT
       // response is not mislabelled as an STT.
       issuedTokenType: response.issuedTokenType ?? '',
-      expiresIn: Math.max(0, Math.floor(response.expiresAt - Date.now() / 1000)),
+      // `expiresAt` is NaN when the server omitted `expires_in`; fall back to 0 rather than
+      // surfacing NaN to callers.
+      expiresIn: Number.isFinite(response.expiresAt)
+        ? Math.max(0, Math.floor(response.expiresAt - Date.now() / 1000))
+        : 0,
       tokenType: response.tokenType,
       scope: response.scope,
     };
@@ -1381,7 +1396,7 @@ export class ServerClient<TStoreOptions = unknown> {
     const isLoopback = url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '[::1]';
     if (url.protocol !== 'https:' && !(url.protocol === 'http:' && isLoopback)) {
       throw new InvalidConfigurationError(
-        'targetLoginUrl must use https (http is allowed only for localhost). The session transfer token is a single-use credential and must not be sent over an insecure or untrusted URL.'
+        'targetLoginUrl must use https (http is allowed only for localhost/loopback). The session transfer token is a single-use credential and must not be sent over an insecure or untrusted URL.'
       );
     }
 
@@ -1411,7 +1426,14 @@ export class ServerClient<TStoreOptions = unknown> {
     domain: string,
     storeOptions?: TStoreOptions
   ): Promise<{ token: string; type: string }> {
-    if (actor?.token && actor.token.trim()) {
+    // An explicit actor takes precedence. If one is supplied, it must be usable — a blank/whitespace
+    // token is a caller mistake, so fail loudly rather than silently falling back to the session.
+    if (actor !== undefined) {
+      if (!actor.token || !actor.token.trim()) {
+        throw actorUnavailableError(
+          'Unable to resolve an actor for the session transfer token: an explicit actor was provided but its token is blank. Pass a non-blank actor token, or omit `actor` to source it from the agent session.'
+        );
+      }
       return { token: actor.token, type: actor.type ?? ID_TOKEN_TYPE };
     }
 

--- a/packages/auth0-server-js/src/server-client.ts
+++ b/packages/auth0-server-js/src/server-client.ts
@@ -1301,7 +1301,6 @@ export class ServerClient<TStoreOptions = unknown> {
    * @param storeOptions Optional options used to read the agent session (for the actor) and resolve the request domain.
    *
    * @throws {TokenExchangeError} With code `actor_unavailable` when no explicit actor is given and no usable session ID token can be resolved — no logged-in agent, a session that belongs to a different domain in resolver mode, or an expired ID token that cannot be refreshed (raised client-side, before any network call). With the default code when the exchange itself fails; a server-side `setactor_required` or `session_transfer_disabled` condition is surfaced via `cause.error` / `cause.error_description`.
-   * @throws {SessionExpiredError} When the agent session's `session_expiry` ceiling has been reached; the session is cleared and re-authentication is required.
    * @throws {MissingClientAuthError} When client credentials are not configured (STT requires a confidential client).
    * @throws {MissingRequiredArgumentError} When `subjectToken` or `subjectTokenType` is missing or blank (raised before any session read or network call).
    *
@@ -1452,13 +1451,6 @@ export class ServerClient<TStoreOptions = unknown> {
       throw actorUnavailableError(
         'Unable to resolve an actor for the session transfer token: the agent session belongs to a different domain than the one resolved for this request. Pass an explicit actor or ensure the agent is logged in on this domain.'
       );
-    }
-
-    // A session past its `session_expiry` ceiling must not keep minting tokens; clear it and fail,
-    // mirroring getAccessToken / startLinkUser.
-    if (isSessionExpiryReached(stateData.sessionExpiresAt)) {
-      await this.#stateStore.delete(this.#stateStoreIdentifier, storeOptions);
-      throw new SessionExpiredError();
     }
 
     if (!isTokenExpired(stateData.idToken)) {

--- a/packages/auth0-server-js/src/server-client.ts
+++ b/packages/auth0-server-js/src/server-client.ts
@@ -1300,7 +1300,8 @@ export class ServerClient<TStoreOptions = unknown> {
    * @param options Options including the developer-supplied `subjectToken`/`subjectTokenType` and an optional explicit `actor`.
    * @param storeOptions Optional options used to read the agent session (for the actor) and resolve the request domain.
    *
-   * @throws {TokenExchangeError} With code `actor_unavailable` when no explicit actor is given and no usable session ID token can be resolved (raised client-side, before any network call). With the default code when the exchange itself fails; a server-side `setactor_required` or `session_transfer_disabled` condition is surfaced via `cause.error` / `cause.error_description`.
+   * @throws {TokenExchangeError} With code `actor_unavailable` when no explicit actor is given and no usable session ID token can be resolved — no logged-in agent, a session that belongs to a different domain in resolver mode, or an expired ID token that cannot be refreshed (raised client-side, before any network call). With the default code when the exchange itself fails; a server-side `setactor_required` or `session_transfer_disabled` condition is surfaced via `cause.error` / `cause.error_description`.
+   * @throws {SessionExpiredError} When the agent session's `session_expiry` ceiling has been reached; the session is cleared and re-authentication is required.
    * @throws {MissingClientAuthError} When client credentials are not configured (STT requires a confidential client).
    *
    * @returns A promise resolving to a {@link SessionTransferTokenResult} containing the STT and its metadata.
@@ -1419,6 +1420,23 @@ export class ServerClient<TStoreOptions = unknown> {
       throw actorUnavailableError(
         'Unable to resolve an actor for the session transfer token: no actor was provided and there is no logged-in agent session. Pass an explicit actor or ensure the agent is logged in.'
       );
+    }
+
+    // Apply the same session guards as the other session-consuming methods, so the actor is only
+    // sourced from a session that those methods would also accept.
+    // In resolver (multiple-custom-domain) mode, do not source the actor from a session that
+    // belongs to a different domain than the one resolved for this request.
+    if (this.#isResolverMode() && !(await this.#isSessionForCurrentDomain(stateData, storeOptions))) {
+      throw actorUnavailableError(
+        'Unable to resolve an actor for the session transfer token: the agent session belongs to a different domain than the one resolved for this request. Pass an explicit actor or ensure the agent is logged in on this domain.'
+      );
+    }
+
+    // A session past its `session_expiry` ceiling must not keep minting tokens; clear it and fail,
+    // mirroring getAccessToken / startLinkUser.
+    if (isSessionExpiryReached(stateData.sessionExpiresAt)) {
+      await this.#stateStore.delete(this.#stateStoreIdentifier, storeOptions);
+      throw new SessionExpiredError();
     }
 
     if (!isTokenExpired(stateData.idToken)) {

--- a/packages/auth0-server-js/src/server-client.ts
+++ b/packages/auth0-server-js/src/server-client.ts
@@ -1,5 +1,6 @@
 import {
   AccessTokenForConnectionOptions,
+  BuildSessionTransferRedirectOptions,
   ConnectionTokenSet,
   CustomTokenExchangeOptions,
   DomainResolver,
@@ -12,6 +13,9 @@ import {
   GetAccessTokenOptions,
   LogoutOptions,
   RevokeRefreshTokenOptions,
+  RequestSessionTransferTokenOptions,
+  SessionTransferActor,
+  SessionTransferTokenResult,
   ServerClientOptions,
   SessionData,
   StartInteractiveLoginOptions,
@@ -31,6 +35,7 @@ import {
   MissingSessionError,
   MissingTransactionError,
   SessionExpiredError,
+  TokenExchangeErrorCode,
 } from './errors.js';
 import {
   updateStateData,
@@ -47,6 +52,7 @@ import {
   PasswordlessVerifyError,
   TokenByRefreshTokenError,
   TokenByRefreshTokenOptions,
+  TokenExchangeError,
   TokenResponse,
 } from '@auth0/auth0-auth-js';
 import { compareScopes, ensureOpenIdScope } from './utils.js';
@@ -69,6 +75,36 @@ const decodeIssuer = (token: string) => {
     return typeof iss === 'string' ? iss : undefined;
   } catch {
     return undefined;
+  }
+};
+
+// RFC 8693 token-type URI for an ID token, used as the actor token type default.
+const ID_TOKEN_TYPE = 'urn:ietf:params:oauth:token-type:id_token';
+
+// A small skew so an ID token about to expire is treated as expired and refreshed, rather than
+// being sent as an actor token and rejected by the server on its `exp` check.
+const ID_TOKEN_EXPIRY_SKEW_SECONDS = 30;
+
+// Builds the client-side `actor_unavailable` failure for the Session Transfer Token flow. Reuses
+// the core `TokenExchangeError` (the same error the exchange surfaces) and stamps the STT-specific
+// code, so callers get a consistent error surface without a bespoke error class.
+const actorUnavailableError = (message: string): TokenExchangeError => {
+  const error = new TokenExchangeError(message);
+  error.code = TokenExchangeErrorCode.ACTOR_UNAVAILABLE;
+  return error;
+};
+
+// Returns true when the JWT is expired (or unparseable / missing `exp`). Used to decide whether the
+// agent session's ID token can be sent as the actor token or must be refreshed first.
+const isTokenExpired = (token: string): boolean => {
+  try {
+    const { exp } = decodeJwt(token);
+    if (typeof exp !== 'number') {
+      return true;
+    }
+    return exp <= Date.now() / 1000 + ID_TOKEN_EXPIRY_SKEW_SECONDS;
+  } catch {
+    return true;
   }
 };
 
@@ -1244,6 +1280,188 @@ export class ServerClient<TStoreOptions = unknown> {
     const domain = await this.#resolveDomain(storeOptions);
     const authClient = this.#getAuthClient(domain);
     return authClient.exchangeToken(options);
+  }
+
+  /**
+   * Requests a Session Transfer Token (STT) for impersonation via session transfer (RFC 8693).
+   *
+   * Performs a Custom Token Exchange against the `urn:{domain}:session_transfer` audience and
+   * returns the resulting STT. The audience is built from the SDK's resolved request domain, so
+   * it is correct under multiple custom domains. The returned STT is opaque and single-use — hand
+   * it to {@link ServerClient.buildSessionTransferRedirect} and do not decode, cache, or persist
+   * it. This method writes nothing to the state store for the STT itself; the `act` claim is not
+   * on the result — it only appears on the target session's tokens once the STT is redeemed.
+   *
+   * An actor is mandatory for an STT (this is what makes it auditable impersonation). It is
+   * resolved in this order: an explicit `options.actor` wins; otherwise the current agent
+   * session's ID token is used, refreshed when it has expired; if neither is available the method
+   * throws before any network call.
+   *
+   * @param options Options including the developer-supplied `subjectToken`/`subjectTokenType` and an optional explicit `actor`.
+   * @param storeOptions Optional options used to read the agent session (for the actor) and resolve the request domain.
+   *
+   * @throws {TokenExchangeError} With code `actor_unavailable` when no explicit actor is given and no usable session ID token can be resolved (raised client-side, before any network call). With the default code when the exchange itself fails; a server-side `setactor_required` or `session_transfer_disabled` condition is surfaced via `cause.error` / `cause.error_description`.
+   * @throws {MissingClientAuthError} When client credentials are not configured (STT requires a confidential client).
+   *
+   * @returns A promise resolving to a {@link SessionTransferTokenResult} containing the STT and its metadata.
+   */
+  public async requestSessionTransferToken(
+    options: RequestSessionTransferTokenOptions,
+    storeOptions?: TStoreOptions
+  ): Promise<SessionTransferTokenResult> {
+    const domain = await this.#resolveDomain(storeOptions);
+
+    // Resolve the actor before anything else — an STT is only issued when an actor is set, and a
+    // missing actor is a client-side failure that must not reach the network.
+    const actor = await this.#resolveSessionTransferActor(options.actor, domain, storeOptions);
+
+    const authClient = this.#getAuthClient(domain);
+    const response = await authClient.exchangeToken({
+      subjectToken: options.subjectToken,
+      subjectTokenType: options.subjectTokenType,
+      audience: `urn:${domain}:session_transfer`,
+      scope: options.scope,
+      actorToken: actor.token,
+      actorTokenType: actor.type,
+      extra: options.extra,
+    });
+
+    return {
+      sessionTransferToken: response.accessToken,
+      // Surface exactly what the server returned — never fabricate the URN, so a non-STT
+      // response is not mislabelled as an STT.
+      issuedTokenType: response.issuedTokenType ?? '',
+      expiresIn: Math.max(0, Math.floor(response.expiresAt - Date.now() / 1000)),
+      tokenType: response.tokenType,
+      scope: response.scope,
+    };
+  }
+
+  /**
+   * Builds the redirect URL that hands a Session Transfer Token (STT) to the target app's login URL.
+   *
+   * Returns `targetLoginUrl` with `session_transfer_token` (and `organization`, when provided)
+   * appended as query parameters, URL-encoded. This performs no network call and writes nothing
+   * to the session — it only builds a string. The developer hands the returned URL to their
+   * framework's redirect.
+   *
+   * `targetLoginUrl` attaches a single-use credential, so it must be a trusted, app-controlled
+   * value — never derived from untrusted input (e.g. a `returnTo`), or the token could leak to an
+   * attacker host. To harden against that, the URL must be absolute and use `https:` (an `http:`
+   * URL is accepted only for `localhost` / loopback, to support local development).
+   *
+   * @param targetLoginUrl The target app's login URL (absolute, https).
+   * @param result The {@link SessionTransferTokenResult} from {@link ServerClient.requestSessionTransferToken}.
+   * @param options Optional options, e.g. the `organization` to forward when the STT is org-scoped.
+   *
+   * @throws {MissingRequiredArgumentError} When `targetLoginUrl` is missing or blank.
+   * @throws {InvalidConfigurationError} When `targetLoginUrl` is not an absolute URL, or does not use `https:` (except for loopback hosts).
+   *
+   * @returns A {@link URL} with the STT (and optional organization) as query parameters.
+   */
+  public buildSessionTransferRedirect(
+    targetLoginUrl: string,
+    result: SessionTransferTokenResult,
+    options?: BuildSessionTransferRedirectOptions
+  ): URL {
+    if (!targetLoginUrl || !targetLoginUrl.trim()) {
+      throw new MissingRequiredArgumentError('targetLoginUrl');
+    }
+
+    let url: URL;
+    try {
+      url = new URL(targetLoginUrl);
+    } catch {
+      throw new InvalidConfigurationError(
+        'targetLoginUrl must be an absolute URL (e.g. https://app.example.com/auth/login).'
+      );
+    }
+
+    const isLoopback = url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '[::1]';
+    if (url.protocol !== 'https:' && !(url.protocol === 'http:' && isLoopback)) {
+      throw new InvalidConfigurationError(
+        'targetLoginUrl must use https (http is allowed only for localhost). The session transfer token is a single-use credential and must not be sent over an insecure or untrusted URL.'
+      );
+    }
+
+    url.searchParams.set('session_transfer_token', result.sessionTransferToken);
+    if (options?.organization !== undefined) {
+      // Mirror the up-front blank check on the interactive-login path, so a blank organization
+      // fails fast rather than being forwarded as an empty `organization=` query parameter.
+      if (!options.organization.trim()) {
+        throw new OrganizationValidationError('organization must not be blank');
+      }
+      url.searchParams.set('organization', options.organization);
+    }
+
+    return url;
+  }
+
+  /**
+   * Resolves the actor token for a Session Transfer Token request.
+   *
+   * An explicit actor wins. Otherwise the agent session's ID token is used, refreshed when it has
+   * expired (and the refreshed session is persisted so the agent session stays coherent). If no
+   * usable ID token can be obtained, throws a `TokenExchangeError` with code `actor_unavailable`
+   * before any exchange is attempted.
+   */
+  async #resolveSessionTransferActor(
+    actor: SessionTransferActor | undefined,
+    domain: string,
+    storeOptions?: TStoreOptions
+  ): Promise<{ token: string; type: string }> {
+    if (actor?.token && actor.token.trim()) {
+      return { token: actor.token, type: actor.type ?? ID_TOKEN_TYPE };
+    }
+
+    const stateData = await this.#stateStore.get(this.#stateStoreIdentifier, storeOptions);
+    if (!stateData || !stateData.idToken) {
+      throw actorUnavailableError(
+        'Unable to resolve an actor for the session transfer token: no actor was provided and there is no logged-in agent session. Pass an explicit actor or ensure the agent is logged in.'
+      );
+    }
+
+    if (!isTokenExpired(stateData.idToken)) {
+      return { token: stateData.idToken, type: ID_TOKEN_TYPE };
+    }
+
+    // The session ID token has expired. The server rejects an expired actor token, so refresh it
+    // when a refresh token is available; otherwise the actor cannot be resolved.
+    if (!stateData.refreshToken) {
+      throw actorUnavailableError(
+        'Unable to resolve an actor for the session transfer token: the agent session ID token has expired and no refresh token is available to refresh it. Pass an explicit actor or re-authenticate the agent.'
+      );
+    }
+
+    const sessionDomain = this.#getSessionDomain(stateData) ?? domain;
+    let tokenEndpointResponse: TokenResponse;
+    try {
+      tokenEndpointResponse = await this.#getAuthClient(sessionDomain).getTokenByRefreshToken({
+        refreshToken: stateData.refreshToken,
+      });
+    } catch {
+      throw actorUnavailableError(
+        'Unable to resolve an actor for the session transfer token: refreshing the agent session ID token failed. Pass an explicit actor or re-authenticate the agent.'
+      );
+    }
+
+    if (!tokenEndpointResponse.idToken) {
+      throw actorUnavailableError(
+        'Unable to resolve an actor for the session transfer token: refreshing the agent session did not return an ID token. Pass an explicit actor or re-authenticate the agent.'
+      );
+    }
+
+    // Persist the refreshed tokens so the agent's own session stays coherent (refresh-token
+    // rotation would otherwise invalidate the stored refresh token). This is a refresh of the
+    // agent session — it does not persist anything about the STT.
+    const audience = this.#options.authorizationParams?.audience ?? 'default';
+    const existingStateData = await this.#stateStore.get(this.#stateStoreIdentifier, storeOptions);
+    const updatedStateData = updateStateData(audience, existingStateData, tokenEndpointResponse, {
+      domain: sessionDomain,
+    });
+    await this.#stateStore.set(this.#stateStoreIdentifier, updatedStateData, false, storeOptions);
+
+    return { token: tokenEndpointResponse.idToken, type: ID_TOKEN_TYPE };
   }
 
   /**

--- a/packages/auth0-server-js/src/test-utils/tokens.ts
+++ b/packages/auth0-server-js/src/test-utils/tokens.ts
@@ -26,7 +26,8 @@ export const generateToken = async (
   userId: string,
   audience?: string,
   issuer?: string | false,
-  claims?: Record<string, unknown>
+  claims?: Record<string, unknown>,
+  expirationTime: string | number = '2h'
 ) => {
   const privateKey = await jose.importJWK(jwk, alg);
 
@@ -39,5 +40,5 @@ export const generateToken = async (
   if (audience) {
     jwtBuilder = jwtBuilder.setAudience(audience);
   }
-  return await jwtBuilder.setSubject(userId).setExpirationTime('2h').sign(privateKey);
+  return await jwtBuilder.setSubject(userId).setExpirationTime(expirationTime).sign(privateKey);
 };

--- a/packages/auth0-server-js/src/types.ts
+++ b/packages/auth0-server-js/src/types.ts
@@ -1,4 +1,4 @@
-import type { AuthorizationDetails, DiscoveryCacheOptions, ExchangeProfileOptions, TelemetryConfig } from '@auth0/auth0-auth-js';
+import type { ActClaim, AuthorizationDetails, DiscoveryCacheOptions, ExchangeProfileOptions, TelemetryConfig } from '@auth0/auth0-auth-js';
 
 export type {
   DiscoveryCacheOptions,
@@ -82,6 +82,13 @@ export interface UserClaims {
   email_verified?: boolean;
   org_id?: string;
   org_name?: string;
+
+  /**
+   * The actor (`act`) claim, present when the session was established via impersonation
+   * (e.g. Custom Token Exchange Session Transfer). Identifies the acting party — read it
+   * to drive UI such as an impersonation banner.
+   */
+  act?: ActClaim;
 
   [key: string]: unknown;
 }

--- a/packages/auth0-server-js/src/types.ts
+++ b/packages/auth0-server-js/src/types.ts
@@ -476,6 +476,112 @@ export interface LoginWithCustomTokenExchangeResult {
   authorizationDetails?: AuthorizationDetails[];
 }
 
+/**
+ * An explicit actor (the acting party) for a Session Transfer Token request.
+ *
+ * Supplying this overrides the default behaviour of sourcing the actor from the
+ * current agent session's ID token.
+ */
+export interface SessionTransferActor {
+  /**
+   * The actor token — for the default flow this is the agent's ID token.
+   */
+  token: string;
+  /**
+   * The actor token type URI. Defaults to the ID token URN when omitted
+   * (`urn:ietf:params:oauth:token-type:id_token`).
+   */
+  type?: string;
+}
+
+/**
+ * Options for requesting a Session Transfer Token (STT) for impersonation via
+ * session transfer (Custom Token Exchange Release 2).
+ *
+ * The SDK fills in the protocol plumbing (audience, grant type, and the actor token
+ * pair). The `subjectToken` is always developer-supplied — it is your own proof of
+ * which customer to impersonate, validated only by your Action.
+ *
+ * @see {@link https://www.rfc-editor.org/rfc/rfc8693 RFC 8693: OAuth 2.0 Token Exchange}
+ */
+export interface RequestSessionTransferTokenOptions {
+  /**
+   * Your proof of which customer to impersonate — opaque to Auth0 and validated by
+   * your Action (which then calls `setUserById`). The SDK never produces it.
+   */
+  subjectToken: string;
+  /**
+   * A URI identifying the type of the subject token, routing the request to your
+   * Token Exchange Profile / Action.
+   */
+  subjectTokenType: string;
+  /**
+   * An explicit actor to override the default (the agent session's ID token).
+   *
+   * Resolution order: this explicit `actor` wins; otherwise the agent session's ID
+   * token is used (refreshed when expired); if neither is available the request fails
+   * client-side with a `TokenExchangeError` whose code is `actor_unavailable`, before
+   * any network call.
+   */
+  actor?: SessionTransferActor;
+  /**
+   * Space-separated list of OAuth 2.0 scopes to request for the session's tokens.
+   */
+  scope?: string;
+  /**
+   * Additional custom parameters forwarded to the token endpoint (and thus to your
+   * Action via `event.request.body`). Cannot override reserved OAuth parameters.
+   */
+  extra?: Record<string, string | string[]>;
+}
+
+/**
+ * Options for {@link ServerClient.buildSessionTransferRedirect}.
+ */
+export interface BuildSessionTransferRedirectOptions {
+  /**
+   * The organization identifier to forward to the target's `/authorize` (as the
+   * `organization` query parameter). Required only when the STT was issued in an
+   * organization context.
+   */
+  organization?: string;
+}
+
+/**
+ * The result of requesting a Session Transfer Token (STT) for impersonation via
+ * session transfer (Custom Token Exchange).
+ *
+ * The STT is opaque, single-use, and short-lived (~60s). Hand it to
+ * {@link ServerClient.buildSessionTransferRedirect} and do not decode, cache, or persist
+ * it. The `act` claim is deliberately not on this result — it only appears on the tokens
+ * of the session established after the STT is redeemed at `/authorize`.
+ */
+export interface SessionTransferTokenResult {
+  /**
+   * The opaque, single-use Session Transfer Token. Never decode, cache, or persist it.
+   */
+  sessionTransferToken: string;
+  /**
+   * The issued token type URI — the session-transfer URN
+   * (`urn:auth0:params:oauth:token-type:session_transfer_token`). Branch on this,
+   * never on {@link SessionTransferTokenResult.tokenType}.
+   */
+  issuedTokenType: string;
+  /**
+   * The token lifetime in seconds (typically ~60).
+   */
+  expiresIn: number;
+  /**
+   * The token type as returned by the server (typically `"N_A"`). Informational only —
+   * never branch on it.
+   */
+  tokenType?: string;
+  /**
+   * The granted scopes, when returned by the server.
+   */
+  scope?: string;
+}
+
 export interface SessionCookieOptions {
   /**
    * The name of the session cookie.


### PR DESCRIPTION
## What this does

This adds `Session Transfer Token` (STT) support to `auth0-server-js` for Custom Token Exchange impersonation. It lets a support or admin app log an agent into a target web app `as a customer`, so the agent can see and reproduce the customer's exact experience without knowing their password. The agent is recorded in the `act` claim, so every
impersonation is auditable.

There are two roles in the flow. The `initiator` (your app, using this SDK) requests a short lived, single use STT and redirects the agent's browser to the target app. The `target` (the customer's app) forwards the token to `/authorize`, where Auth0 redeems it and starts a session as the customer.

## What was added

Two new methods on `ServerClient`:
- `requestSessionTransferToken(options, storeOptions)` mints the STT by running a token exchange against the `urn:{domain}:session_transfer` audience. The audience is built from the resolved request domain, so it stays correct when multiple custom domains are in use.
- `buildSessionTransferRedirect(targetLoginUrl, result, options)` builds the redirect URL that carries the STT (and an optional `organization`) to the target app's login URL.

New types and error codes:

- `SessionTransferTokenResult`, `RequestSessionTransferTokenOptions`, `SessionTransferActor`,  and `BuildSessionTransferRedirectOptions`.
- A `TokenExchangeErrorCode` constant with `actor_unavailable`, `setactor_required`, and `session_transfer_disabled`.

## Key behavior

- The `actor` is required, because that is what makes this auditable impersonation instead of a silent takeover. It is resolved in this order: an explicit `actor` you pass wins, otherwise the agent session's ID token is used. If the session ID token has expired, the SDK refreshes it first, because Auth0 rejects an expired actor token.
- If no actor can be resolved, the method throws a `TokenExchangeError` with code `actor_unavailable` `before any network call`.
- The STT is `opaque`, single use, and lives about 60 seconds. The SDK never decodes it, never caches it, and never writes it to the session store. The exchange is stateless.
- `buildSessionTransferRedirect` only accepts an absolute `https` URL (plain `http` is allowed for `localhost` only). This stops the single use token from leaking to an untrusted host.
- The two server side error codes (`setactor_required` and `session_transfer_disabled`) are surfaced through the error's raw `cause`, so you get Auth0's exact message.

## Scope

- All changes live `in auth0-server-js only`. There are no changes to `auth0-auth-js` and no dependency bump. This ships as a single, additive minor release.
- The target side needs no new SDK code. You forward `session_transfer_token` (and `organization` when present) through the existing `startInteractiveLogin` call, and read `act` off the session user with `getSession`.

## Prerequisites

These are tenant settings configured outside the SDK. The feature flag `cte_session_transfer_token` must be on. The issuing client needs `can_create_session_transfer_token`,  and the redeeming client needs `allow_delegated_access` with `query` in its allowed authentication methods.

## Testing

- Added tests covering actor sourcing from the session, explicit actor override, ID token refresh on expiry, the `actor_unavailable` client side failure, the multi custom domain audience, the stateless exchange, redirect URL encoding and hardening, and server error surfacing.
- `auth0-server-js`: 381 tests pass. `auth0-auth-js`: 356 tests pass and stays unchanged. Build and lint are clean on both.
- Added an "Impersonation via Session Transfer" guide to `EXAMPLES.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Session Transfer Token (STT) support, including server-side token requests and session-transfer redirect URL generation with organization support and strict validation.
  * Added actor-resolution logic with handling for expired actor ID tokens via refresh, and STT-specific error-code mapping.
  * Exposed STT token-exchange error codes directly from the package entry point.

* **Documentation**
  * Expanded examples with an “Impersonation via Session Transfer” end-to-end flow, including expected `act`-claim usage.

* **Tests**
  * Added comprehensive STT test coverage for validation, parsing, redirect construction, actor/refresh scenarios, and failure mapping.
  * Enhanced token test utilities with configurable expiration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->