### PR TITLE
feat(auth0-server-js): add revokeRefreshToken and logout revocation support

### DIFF
--- a/examples/example-express-web/src/auth0.ts
+++ b/examples/example-express-web/src/auth0.ts
@@ -84,5 +84,10 @@ export function auth0(options: Auth0ExpressOptions) {
     response.redirect(logoutUrl.href);
   });
 
+  router.post('/auth/revoke', async (request: Request, response: Response) => {
+    await request.auth0Client.revokeRefreshToken({}, { request, response });
+    response.redirect('/private');
+  });
+
   return router;
 }

--- a/examples/example-express-web/views/private.ejs
+++ b/examples/example-express-web/views/private.ejs
@@ -1,1 +1,5 @@
 This is a private page.
+
+<form method="POST" action="/auth/revoke" class="mt-3">
+  <button type="submit" class="btn btn-warning">Revoke Refresh Token</button>
+</form>

--- a/packages/auth0-server-js/EXAMPLES.md
+++ b/packages/auth0-server-js/EXAMPLES.md
@@ -58,6 +58,10 @@
   - [Passing `StoreOptions`](#passing-storeoptions-9)
 - [Retrieving an Access Token for a Connection](#retrieving-an-access-token-for-a-connection)
   - [Passing `StoreOptions`](#passing-storeoptions-10)
+- [Revoking a Refresh Token](#revoking-a-refresh-token)
+  - [Revoking the session token](#revoking-the-session-token)
+  - [Revoking an explicit token](#revoking-an-explicit-token)
+  - [Revoking on logout](#revoking-on-logout)
 - [Logout](#logout)
   - [Passing the `returnTo` parameter](#passing-the-returnto-parameter)
   - [Passing `StoreOptions`](#passing-storeoptions-11)
@@ -1472,6 +1476,45 @@ Once an enterprise connection has the option enabled, `getSession()` / `getUser(
 
 - The connection must be an `okta` or `oidc` enterprise connection with `id_token_session_expiry_supported: true` (Dashboard toggle "Use ID Token for Session Expiry", Management API, or Terraform).
 - Authorization Code flow.
+
+## Revoking a Refresh Token
+
+Revoking a refresh token invalidates it at Auth0 so it can no longer be used to obtain new access tokens.
+This is useful when implementing secure logout flows or when a user's session needs to be forcibly terminated.
+
+Revocation requires the application to have been granted `offline_access` scope so Auth0 issues a refresh token, and the target API must have **Allow Offline Access** enabled.
+
+> **Note:** Revocation does not affect access tokens that have already been issued. They remain valid until their expiry. For immediate session termination, combine revocation with `logout()`.
+
+### Revoking the session token
+
+When called without arguments, `revokeRefreshToken()` reads the refresh token directly from the current session:
+
+```ts
+await serverClient.revokeRefreshToken();
+```
+
+If no session exists or the session has no refresh token, a `MissingSessionError` is thrown.
+
+### Revoking an explicit token
+
+A specific token can be passed via `options.token`, bypassing the session lookup:
+
+```ts
+await serverClient.revokeRefreshToken({ token: '<refresh_token>' });
+```
+
+### Revoking on logout
+
+`logout()` automatically revokes the session's refresh token before clearing the local session.
+Revocation is best-effort: if it fails for any reason (network error, token already revoked, misconfiguration), logout still proceeds. In resolver mode, both revocation and local session deletion only occur when the stored session domain matches the resolved domain — if they differ, the session belongs to a different tenant and is left untouched.
+
+```ts
+const logoutUrl = await serverClient.logout({
+  returnTo: 'http://localhost:3000',
+});
+// Redirect user to logoutUrl
+```
 
 ## Logout
 

--- a/packages/auth0-server-js/src/index.ts
+++ b/packages/auth0-server-js/src/index.ts
@@ -2,7 +2,7 @@ export { ServerClient } from './server-client.js';
 export { AbstractStateStore } from './store/abstract-state-store.js';
 export { AbstractTransactionStore } from './store/abstract-transaction-store.js';
 export type { TokenResponse, ActClaim } from '@auth0/auth0-auth-js';
-export { TokenExchangeError, MissingClientAuthError, OrganizationValidationError } from '@auth0/auth0-auth-js';
+export { TokenExchangeError, TokenRevocationError, MissingClientAuthError, OrganizationValidationError } from '@auth0/auth0-auth-js';
 
 export type { CookieHandler, CookieSerializeOptions } from './store/cookie-handler.js';
 export { CookieTransactionStore } from './store/cookie-transaction-store.js';

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -6,7 +6,7 @@ import {
   MissingTransactionError,
   SessionExpiredError,
 } from './errors.js';
-import { AuthClient, TokenResponse, isMfaRequiredError, OrganizationValidationError } from '@auth0/auth0-auth-js';
+import { AuthClient, TokenResponse, TokenRevocationError, isMfaRequiredError, OrganizationValidationError } from '@auth0/auth0-auth-js';
 
 import * as Auth0AuthJs from '@auth0/auth0-auth-js';
 
@@ -2457,6 +2457,7 @@ test('customTokenExchange - should return act claim when actor token is used', a
       domain,
       clientId: '<client_id>',
       clientSecret: '<client_secret>',
+      discoveryCache: { ttl: 0 },
       transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
       stateStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() },
     });
@@ -2492,6 +2493,7 @@ test('loginWithCustomTokenExchange - should persist act claim on session user wh
       domain,
       clientId: '<client_id>',
       clientSecret: '<client_secret>',
+      discoveryCache: { ttl: 0 },
       transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
       stateStore: new DefaultStateStore({ secret: '<secret>' }),
     });
@@ -6773,4 +6775,403 @@ test('changePassword resolves the domain in resolver mode (T4.3)', async () => {
   const msg = await sc.database.changePassword({ email: 'a@b.com', connection: 'db' });
   expect(msg).toContain('reset your password');
   expect(host).toBe(domain);
+});
+describe('revokeRefreshToken', () => {
+  const revocationEndpoint = `https://${domain}/oauth/revoke`;
+
+  const setupRevocation = (handler?: Parameters<typeof http.post>[1]) => {
+    server.use(
+      http.get(`https://${domain}/.well-known/openid-configuration`, () =>
+        HttpResponse.json({ ...mockOpenIdConfiguration, revocation_endpoint: revocationEndpoint })
+      ),
+      http.post(revocationEndpoint, handler ?? (() => new HttpResponse(null, { status: 200 })))
+    );
+  };
+
+  test('should revoke the refresh token from the session', async () => {
+    setupRevocation();
+    const mockStateStore = {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+      deleteByLogoutToken: vi.fn(),
+    };
+
+    const stateData: StateData = {
+      user: { sub: '<sub>' },
+      idToken: '<id_token>',
+      refreshToken: '<refresh_token>',
+      tokenSets: [],
+      internal: { sid: '<sid>', createdAt: Date.now() },
+    };
+
+    mockStateStore.get.mockResolvedValue(stateData);
+
+    const serverClient = new ServerClient({
+      domain,
+      clientId: '<client_id>',
+      clientSecret: '<client_secret>',
+      discoveryCache: { ttl: 0 },
+      transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+      stateStore: mockStateStore,
+    });
+
+    await expect(serverClient.revokeRefreshToken()).resolves.toBeUndefined();
+  });
+
+  test('should revoke an explicitly provided token', async () => {
+    let capturedToken: string | null = null;
+    setupRevocation(async ({ request }) => {
+      const body = await request.formData();
+      capturedToken = body.get('token') as string;
+      return new HttpResponse(null, { status: 200 });
+    });
+
+    const serverClient = new ServerClient({
+      domain,
+      clientId: '<client_id>',
+      clientSecret: '<client_secret>',
+      discoveryCache: { ttl: 0 },
+      transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+      stateStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() },
+    });
+
+    await serverClient.revokeRefreshToken({ token: '<explicit_token>' });
+    expect(capturedToken).toBe('<explicit_token>');
+  });
+
+  test('should throw MissingSessionError when no refresh token in session and none provided', async () => {
+    setupRevocation();
+    const mockStateStore = {
+      get: vi.fn().mockResolvedValue(null),
+      set: vi.fn(),
+      delete: vi.fn(),
+      deleteByLogoutToken: vi.fn(),
+    };
+
+    const serverClient = new ServerClient({
+      domain,
+      clientId: '<client_id>',
+      clientSecret: '<client_secret>',
+      discoveryCache: { ttl: 0 },
+      transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+      stateStore: mockStateStore,
+    });
+
+    await expect(serverClient.revokeRefreshToken()).rejects.toThrowError(MissingSessionError);
+  });
+
+  test('should throw MissingSessionError when session exists but has no refresh token', async () => {
+    setupRevocation();
+    const stateData: StateData = {
+      user: { sub: '<sub>' },
+      idToken: '<id_token>',
+      refreshToken: undefined,
+      tokenSets: [],
+      internal: { sid: '<sid>', createdAt: Date.now() },
+    };
+
+    const mockStateStore = {
+      get: vi.fn().mockResolvedValue(stateData),
+      set: vi.fn(),
+      delete: vi.fn(),
+      deleteByLogoutToken: vi.fn(),
+    };
+
+    const serverClient = new ServerClient({
+      domain,
+      clientId: '<client_id>',
+      clientSecret: '<client_secret>',
+      discoveryCache: { ttl: 0 },
+      transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+      stateStore: mockStateStore,
+    });
+
+    await expect(serverClient.revokeRefreshToken()).rejects.toThrowError(MissingSessionError);
+  });
+
+  test('should throw TokenRevocationError when revocation request fails', async () => {
+    setupRevocation(() =>
+      HttpResponse.json({ error: '<error_code>', error_description: '<error_description>' }, { status: 400 })
+    );
+
+    const mockStateStore = {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+      deleteByLogoutToken: vi.fn(),
+    };
+
+    const stateData: StateData = {
+      user: { sub: '<sub>' },
+      idToken: '<id_token>',
+      refreshToken: '<refresh_token>',
+      tokenSets: [],
+      internal: { sid: '<sid>', createdAt: Date.now() },
+    };
+
+    mockStateStore.get.mockResolvedValue(stateData);
+
+    const serverClient = new ServerClient({
+      domain,
+      clientId: '<client_id>',
+      clientSecret: '<client_secret>',
+      discoveryCache: { ttl: 0 },
+      transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+      stateStore: mockStateStore,
+    });
+
+    await expect(serverClient.revokeRefreshToken()).rejects.toThrowError(TokenRevocationError);
+  });
+
+  test('should use session domain in resolver mode', async () => {
+    // Resolver returns a different domain than the one stored in the session.
+    // The revoke handler is only registered on the session domain (session.local)
+    // so the test will fail with a network error if the resolver domain
+    // (resolver.local) is used instead - proving session domain takes precedence.
+    const domainResolver = vi.fn().mockResolvedValue('resolver.local');
+
+    let sessionDomainRevokeCalled = false;
+
+    server.use(
+      http.get('https://session.local/.well-known/openid-configuration', () => {
+        return HttpResponse.json({
+          issuer: 'https://session.local/',
+          authorization_endpoint: 'https://session.local/authorize',
+          token_endpoint: 'https://session.local/token',
+          end_session_endpoint: 'https://session.local/logout',
+          revocation_endpoint: 'https://session.local/oauth/revoke',
+          jwks_uri: 'https://session.local/.well-known/jwks.json',
+        });
+      }),
+      http.post('https://session.local/oauth/revoke', () => {
+        sessionDomainRevokeCalled = true;
+        return new HttpResponse(null, { status: 200 });
+      })
+    );
+
+    const mockStateStore = {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+      deleteByLogoutToken: vi.fn(),
+    };
+
+    const stateData: StateData = {
+      user: { sub: '<sub>' },
+      idToken: '<id_token>',
+      refreshToken: '<refresh_token>',
+      tokenSets: [],
+      domain: 'session.local',
+      internal: { sid: '<sid>', createdAt: Date.now() },
+    };
+
+    mockStateStore.get.mockResolvedValue(stateData);
+
+    const serverClient = new ServerClient({
+      domain: domainResolver,
+      clientId: '<client_id>',
+      clientSecret: '<client_secret>',
+      discoveryCache: { ttl: 0 },
+      transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+      stateStore: mockStateStore,
+    });
+
+    await expect(serverClient.revokeRefreshToken()).resolves.toBeUndefined();
+    expect(sessionDomainRevokeCalled).toBe(true);
+    expect(domainResolver).not.toHaveBeenCalled();
+  });
+});
+
+describe('logout revocation', () => {
+  const revocationEndpoint = `https://${domain}/oauth/revoke`;
+
+  const setupRevocation = (handler?: Parameters<typeof http.post>[1]) => {
+    server.use(
+      http.get(`https://${domain}/.well-known/openid-configuration`, () =>
+        HttpResponse.json({ ...mockOpenIdConfiguration, revocation_endpoint: revocationEndpoint })
+      ),
+      http.post(revocationEndpoint, handler ?? (() => new HttpResponse(null, { status: 200 })))
+    );
+  };
+
+  test('should revoke refresh token before clearing session on logout', async () => {
+    let revocationCalled = false;
+    setupRevocation(() => {
+      revocationCalled = true;
+      return new HttpResponse(null, { status: 200 });
+    });
+
+    const mockStateStore = {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+      deleteByLogoutToken: vi.fn(),
+    };
+
+    const stateData: StateData = {
+      user: { sub: '<sub>' },
+      idToken: '<id_token>',
+      refreshToken: '<refresh_token>',
+      tokenSets: [],
+      internal: { sid: '<sid>', createdAt: Date.now() },
+    };
+
+    mockStateStore.get.mockResolvedValue(stateData);
+
+    const serverClient = new ServerClient({
+      domain,
+      clientId: '<client_id>',
+      clientSecret: '<client_secret>',
+      discoveryCache: { ttl: 0 },
+      transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+      stateStore: mockStateStore,
+    });
+
+    await serverClient.logout({ returnTo: '/after-logout' });
+
+    expect(revocationCalled).toBe(true);
+    expect(mockStateStore.delete).toHaveBeenCalled();
+  });
+
+  test('should continue with logout even if revocation fails', async () => {
+    setupRevocation(() => HttpResponse.json({ error: 'server_error' }, { status: 500 }));
+
+    const mockStateStore = {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+      deleteByLogoutToken: vi.fn(),
+    };
+
+    const stateData: StateData = {
+      user: { sub: '<sub>' },
+      idToken: '<id_token>',
+      refreshToken: '<refresh_token>',
+      tokenSets: [],
+      internal: { sid: '<sid>', createdAt: Date.now() },
+    };
+
+    mockStateStore.get.mockResolvedValue(stateData);
+
+    const serverClient = new ServerClient({
+      domain,
+      clientId: '<client_id>',
+      clientSecret: '<client_secret>',
+      discoveryCache: { ttl: 0 },
+      transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+      stateStore: mockStateStore,
+    });
+
+    const url = await serverClient.logout({ returnTo: '/after-logout' });
+
+    expect(url).toBeDefined();
+    expect(mockStateStore.delete).toHaveBeenCalled();
+  });
+
+  test('should revoke and delete session in resolver mode when session domain matches resolved domain', async () => {
+    const matchedDomain = 'matched.local';
+    const revocationEndpointMatched = `https://${matchedDomain}/oauth/revoke`;
+
+    let revokeCalled = false;
+    server.use(
+      http.get(`https://${matchedDomain}/.well-known/openid-configuration`, () =>
+        HttpResponse.json({
+          issuer: `https://${matchedDomain}/`,
+          authorization_endpoint: `https://${matchedDomain}/authorize`,
+          token_endpoint: `https://${matchedDomain}/token`,
+          end_session_endpoint: `https://${matchedDomain}/logout`,
+          revocation_endpoint: revocationEndpointMatched,
+          jwks_uri: `https://${matchedDomain}/.well-known/jwks.json`,
+        })
+      ),
+      http.post(revocationEndpointMatched, () => {
+        revokeCalled = true;
+        return new HttpResponse(null, { status: 200 });
+      })
+    );
+
+    const mockStateStore = {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+      deleteByLogoutToken: vi.fn(),
+    };
+
+    const stateData: StateData = {
+      user: { sub: '<sub>' },
+      idToken: '<id_token>',
+      refreshToken: '<refresh_token>',
+      tokenSets: [],
+      domain: matchedDomain,
+      internal: { sid: '<sid>', createdAt: Date.now() },
+    };
+
+    mockStateStore.get.mockResolvedValue(stateData);
+
+    const serverClient = new ServerClient({
+      domain: vi.fn().mockResolvedValue(matchedDomain),
+      clientId: '<client_id>',
+      clientSecret: '<client_secret>',
+      discoveryCache: { ttl: 0 },
+      transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+      stateStore: mockStateStore,
+    });
+
+    const url = await serverClient.logout({ returnTo: '/after-logout' });
+
+    expect(revokeCalled).toBe(true);
+    expect(mockStateStore.delete).toHaveBeenCalled();
+    expect(url).toBeDefined();
+  });
+
+  test('should skip revocation and session deletion in resolver mode when session domain does not match resolved domain', async () => {
+    const sessionDomain = 'session.local';
+    const resolverDomain = 'resolver.local';
+
+    server.use(
+      http.get(`https://${resolverDomain}/.well-known/openid-configuration`, () =>
+        HttpResponse.json({
+          issuer: `https://${resolverDomain}/`,
+          authorization_endpoint: `https://${resolverDomain}/authorize`,
+          token_endpoint: `https://${resolverDomain}/token`,
+          end_session_endpoint: `https://${resolverDomain}/logout`,
+          revocation_endpoint: `https://${resolverDomain}/oauth/revoke`,
+          jwks_uri: `https://${resolverDomain}/.well-known/jwks.json`,
+        })
+      )
+    );
+
+    const mockStateStore = {
+      get: vi.fn(),
+      set: vi.fn(),
+      delete: vi.fn(),
+      deleteByLogoutToken: vi.fn(),
+    };
+
+    const stateData: StateData = {
+      user: { sub: '<sub>' },
+      idToken: '<id_token>',
+      refreshToken: '<refresh_token>',
+      tokenSets: [],
+      domain: sessionDomain,
+      internal: { sid: '<sid>', createdAt: Date.now() },
+    };
+
+    mockStateStore.get.mockResolvedValue(stateData);
+
+    const serverClient = new ServerClient({
+      domain: vi.fn().mockResolvedValue(resolverDomain),
+      clientId: '<client_id>',
+      clientSecret: '<client_secret>',
+      discoveryCache: { ttl: 0 },
+      transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+      stateStore: mockStateStore,
+    });
+
+    const url = await serverClient.logout({ returnTo: '/after-logout' });
+
+    expect(mockStateStore.delete).not.toHaveBeenCalled();
+    expect(url).toBeDefined();
+  });
 });

--- a/packages/auth0-server-js/src/server-client.ts
+++ b/packages/auth0-server-js/src/server-client.ts
@@ -11,6 +11,7 @@ import {
   CompletePasswordlessResult,
   GetAccessTokenOptions,
   LogoutOptions,
+  RevokeRefreshTokenOptions,
   ServerClientOptions,
   SessionData,
   StartInteractiveLoginOptions,
@@ -1078,6 +1079,49 @@ export class ServerClient<TStoreOptions = unknown> {
   }
 
   /**
+   * Revokes the refresh token stored in the current session, or an explicitly supplied token.
+   *
+   * @param options Optionally supply a token to revoke instead of reading from the session.
+   * @param storeOptions Optional options passed to the StateStore.
+   *
+   * @throws {MissingSessionError} If no refresh token is found in the session and none was provided.
+   * @throws {TokenRevocationError} If the revocation request fails.
+   */
+  public async revokeRefreshToken(
+    options: RevokeRefreshTokenOptions = {},
+    storeOptions?: TStoreOptions
+  ): Promise<void> {
+    let refreshToken = options.token;
+
+    // Skip the store read when a token is supplied and we are in static mode:
+    // stateData is only needed to look up the session token (when none is
+    // supplied) or to determine the per-session domain (resolver mode only).
+    const needsStateData = !refreshToken || this.#isResolverMode();
+    const stateData = needsStateData
+      ? await this.#stateStore.get(this.#stateStoreIdentifier, storeOptions)
+      : undefined;
+
+    if (!refreshToken) {
+      refreshToken = stateData?.refreshToken;
+    }
+
+    if (!refreshToken) {
+      throw new MissingSessionError('Unable to revoke refresh token: no refresh token found in session.');
+    }
+
+    let authClient: AuthClient;
+    if (this.#isResolverMode()) {
+      const sessionDomain = stateData ? this.#getSessionDomain(stateData) : undefined;
+      const domain = sessionDomain ?? (await this.#resolveDomain(storeOptions));
+      authClient = this.#getAuthClient(domain);
+    } else {
+      authClient = this.authClient;
+    }
+
+    await authClient.revokeToken({ token: refreshToken, tokenTypeHint: 'refresh_token' });
+  }
+
+  /**
    * Logs the user out and returns a URL to redirect the user-agent to after they log out.
    * @param options Options used to configure the logout process.
    * @param storeOptions Optional options used to pass to the Transaction and State Store.
@@ -1085,6 +1129,12 @@ export class ServerClient<TStoreOptions = unknown> {
    */
   public async logout(options: LogoutOptions, storeOptions?: TStoreOptions) {
     if (!this.#isResolverMode()) {
+      try {
+        await this.revokeRefreshToken({}, storeOptions);
+      } catch (e) {
+        // best-effort: revocation failure must not block logout
+        console.warn('revokeRefreshToken failed during logout (swallowed):', e);
+      }
       await this.#stateStore.delete(this.#stateStoreIdentifier, storeOptions);
       return this.authClient.buildLogoutUrl(options);
     }
@@ -1092,14 +1142,22 @@ export class ServerClient<TStoreOptions = unknown> {
     const resolvedDomain = await this.#resolveDomain(storeOptions);
     const authClient = this.#getAuthClient(resolvedDomain);
     const stateData = await this.#stateStore.get(this.#stateStoreIdentifier, storeOptions);
-    const sessionDomain = stateData ? this.#getSessionDomain(stateData) : undefined;
 
     if (!stateData) {
       // No local session, still return a logout URL for the current domain.
       return authClient.buildLogoutUrl(options);
     }
 
-    if (sessionDomain && sessionDomain === resolvedDomain) {
+    const sessionDomain = this.#getSessionDomain(stateData);
+    const domainMatches = sessionDomain === resolvedDomain;
+
+    if (domainMatches) {
+      try {
+        await this.revokeRefreshToken({}, storeOptions);
+      } catch (e) {
+        // best-effort: revocation failure must not block logout
+        console.warn('revokeRefreshToken failed during logout (swallowed):', e);
+      }
       await this.#stateStore.delete(this.#stateStoreIdentifier, storeOptions);
     }
 

--- a/packages/auth0-server-js/src/types.ts
+++ b/packages/auth0-server-js/src/types.ts
@@ -381,6 +381,14 @@ export interface GetAccessTokenOptions {
   scope?: string;
 }
 
+export interface RevokeRefreshTokenOptions {
+  /**
+   * Explicitly provide a refresh token to revoke.
+   * If omitted, the token stored in the current session is used.
+   */
+  token?: string;
+}
+
 export interface LogoutOptions {
   returnTo: string;
 }


### PR DESCRIPTION
## Summary

- Adds `ServerClient.revokeRefreshToken()` — reads the refresh token from the session and delegates to `AuthClient.revokeToken()`, wrapping errors in `TokenRevocationError`
- `logout()` now always attempts revocation best-effort before clearing the session; revocation failure never blocks logout
- In resolver mode, both revocation and session deletion are gated by a domain-match guard (session domain must match resolved domain)
- Re-exports `TokenRevocationError` from the server-js public surface
- Adds `/auth/revoke` route to the Express example app
- Documents revocation behavior in EXAMPLES.md

## Depends on

Requires auth0-auth-js#217 to be merged and released first (`revokeToken()` and `TokenRevocationError` are defined there).

## Test plan

- [ ] `revokeRefreshToken` — success, missing session, missing refresh token, wraps error as `TokenRevocationError`
- [ ] `logout` (static mode) — revokes then deletes session; revocation failure does not block logout
- [ ] `logout` (resolver mode) — revokes and deletes when domains match; skips both when domains differ

Closes SDK-8850 (server-js portion)