### PR TITLE
fix: bump Node version in release workflow from 20 to 22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         uses: ./.github/actions/release
         with:
           package: ${{ matrix.package }}
-          node-version: 20
+          node-version: 22
           require-build: true
           release-directory: ./
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The release workflow was failing with:

```
npm error notsup Not compatible with your version of node/npm: npm@12.0.1
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

The `npm-publish` action runs `npm install -g npm@latest`, and `npm@latest` (v12+) now requires Node 22+. The workflow was pinned to Node 20, causing every release to fail since npm v12 was released.

## Fix

Bump `node-version` from `20` to `22` in the release workflow.

## Test plan

- [ ] Merge this PR, then re-run or re-trigger the `Release auth0-auth-js v1.12.0` release workflow to confirm the publish succeeds