### PR TITLE
feat(auth0-server-js): send organization on the STT mint request

### DIFF
--- a/packages/auth0-server-js/EXAMPLES.md
+++ b/packages/auth0-server-js/EXAMPLES.md
@@ -1230,7 +1230,7 @@ Because you are now supplying the token yourself, it is on you to supply a valid
 
 An ID token from the agent's own session on this client satisfies all of these. A token that fails any of them comes back as a `TokenExchangeError` from the token endpoint.
 
-If the customer belongs to an organization, pass it in **both** places — on the mint and on the redirect:
+If the customer belongs to an organization, `organization` can be passed on the mint, on the redirect, or both:
 
 ```ts
 const result = await serverClient.requestSessionTransferToken(
@@ -1247,7 +1247,9 @@ const url = serverClient.buildSessionTransferRedirect('https://app.example.com/a
 });
 ```
 
-The two serve different purposes. On the mint, the tenant validates the organization while issuing the STT, so a disallowed organization (or one the client's `organization_usage` forbids) fails at that call rather than later at the target's `/authorize`. On the redirect, it is what actually scopes the target session. Passing it on the mint alone does not scope the session, so set both. An `organization` the tenant rejects surfaces as a `TokenExchangeError`; a blank one throws `OrganizationValidationError` before the session is read or any network call is made.
+The two are separate parameters on separate requests. On the mint, the tenant validates the organization against the client's organization settings while issuing the STT, so an organization the client is not allowed to use fails at that call instead of the STT being issued without it. On the redirect, it is forwarded to the target's `/authorize` as part of a normal interactive login, the same as any other org-scoped login.
+
+The example above sets both, which is the safe default: the mint gets validated, and the target's login is explicitly org-scoped. An `organization` the tenant rejects surfaces as a `TokenExchangeError`; a blank one throws `OrganizationValidationError` before the session is read or any network call is made.
 
 > [!NOTE]
 > `buildSessionTransferRedirect` attaches a single-use credential to the URL, so `targetLoginUrl` **must be a trusted, app-controlled value** and use `https` (`http` is allowed only for the loopback hosts `localhost`, `127.0.0.1`, and `[::1]`). Never derive it from untrusted input such as a `returnTo` parameter, or the token could leak to an attacker-controlled host.

--- a/packages/auth0-server-js/EXAMPLES.md
+++ b/packages/auth0-server-js/EXAMPLES.md
@@ -1230,7 +1230,7 @@ Because you are now supplying the token yourself, it is on you to supply a valid
 
 An ID token from the agent's own session on this client satisfies all of these. A token that fails any of them comes back as a `TokenExchangeError` from the token endpoint.
 
-If the customer belongs to an organization, `organization` can be passed on the mint, on the redirect, or both:
+If the customer belongs to an organization, there is an `organization` on both calls. They do different things, so pick based on what you need:
 
 ```ts
 const result = await serverClient.requestSessionTransferToken(
@@ -1247,9 +1247,14 @@ const url = serverClient.buildSessionTransferRedirect('https://app.example.com/a
 });
 ```
 
-The two are separate parameters on separate requests. On the mint, the tenant validates the organization against the client's organization settings while issuing the STT, so an organization the client is not allowed to use fails at that call instead of the STT being issued without it. On the redirect, it is forwarded to the target's `/authorize` as part of a normal interactive login, the same as any other org-scoped login.
+These are two separate parameters on two separate requests, and one does not imply the other:
 
-The example above sets both, which is the safe default: the mint gets validated, and the target's login is explicitly org-scoped. An `organization` the tenant rejects surfaces as a `TokenExchangeError`; a blank one throws `OrganizationValidationError` before the session is read or any network call is made.
+- On the mint, the tenant validates the organization against the client's organization settings while issuing the STT. An organization the client is not allowed to use fails at that call, instead of the STT being issued without it.
+- On the redirect, it is forwarded to the target's `/authorize` as part of a normal interactive login, the same as any other org-scoped login.
+
+The redirect one is what scopes the session the target ends up with. Passing `organization` only on the mint gets you the validation, but it does not org-scope the target's session, so pass it on the redirect as well when you need that.
+
+An `organization` the tenant rejects surfaces as a `TokenExchangeError`. A blank one throws `OrganizationValidationError` before the session is read or any network call is made.
 
 > [!NOTE]
 > `buildSessionTransferRedirect` attaches a single-use credential to the URL, so `targetLoginUrl` **must be a trusted, app-controlled value** and use `https` (`http` is allowed only for the loopback hosts `localhost`, `127.0.0.1`, and `[::1]`). Never derive it from untrusted input such as a `returnTo` parameter, or the token could leak to an attacker-controlled host.

--- a/packages/auth0-server-js/EXAMPLES.md
+++ b/packages/auth0-server-js/EXAMPLES.md
@@ -1205,7 +1205,10 @@ const url = serverClient.buildSessionTransferRedirect('https://app.example.com/a
 // Hand the URL to your framework's redirect (e.g. Fastify: reply.redirect(url.toString())).
 ```
 
-By default the actor is the agent session's ID token. To supply the acting party explicitly, pass `actor`:
+> [!IMPORTANT]
+> An **actor is mandatory** for an STT — that is what makes this auditable impersonation ("X acting as Y") rather than a silent takeover. If no explicit `actor` is passed and no usable session ID token can be resolved (no logged-in agent, or an expired ID token with no refresh token), the SDK throws a `TokenExchangeError` with code `actor_unavailable` **before any network call**.
+
+By default the actor is the agent session's ID token, and the SDK refreshes it automatically when it has expired and a refresh token is available. To supply the acting party explicitly, pass `actor`. An explicit `actor` takes precedence and **the session is not read at all** — the SDK never touches the state store, so this also works where there is no logged-in agent:
 
 ```ts
 const result = await serverClient.requestSessionTransferToken(
@@ -1218,16 +1221,33 @@ const result = await serverClient.requestSessionTransferToken(
 );
 ```
 
-If the customer belongs to an organization, forward it on the redirect so it reaches the target's `/authorize`:
+Because you are now supplying the token yourself, it is on you to supply a valid one. When the actor token type is the ID token URN — which it is by default — Auth0 validates the token, so it must be an **unexpired, asymmetrically-signed Auth0 ID token**:
+
+- Signed with **RS256 or PS256**. `HS256` is rejected because it uses a shared secret.
+- Unexpired, and carrying `sub`, `iss`, `exp`, and `iat`.
+- Issued to the **same client** that is making the exchange (its `aud` must be this client's ID).
+- Belonging to a user who still exists and is not blocked.
+
+An ID token from the agent's own session on this client satisfies all of these. A token that fails any of them comes back as a `TokenExchangeError` from the token endpoint.
+
+If the customer belongs to an organization, pass it in **both** places — on the mint and on the redirect:
 
 ```ts
+const result = await serverClient.requestSessionTransferToken(
+  {
+    subjectToken,
+    subjectTokenType: 'urn:acme:customer-subject',
+    organization: 'org_globex',
+  },
+  storeOptions
+);
+
 const url = serverClient.buildSessionTransferRedirect('https://app.example.com/auth/login', result, {
   organization: 'org_globex',
 });
 ```
 
-> [!IMPORTANT]
-> An **actor is mandatory** for an STT — that is what makes this auditable impersonation ("X acting as Y") rather than a silent takeover. If no explicit `actor` is passed and no usable session ID token can be resolved (no logged-in agent, or an expired ID token with no refresh token), the SDK throws a `TokenExchangeError` with code `actor_unavailable` **before any network call**. The agent's session ID token must also be unexpired; the SDK refreshes it automatically when a refresh token is available.
+The two serve different purposes. On the mint, the tenant validates the organization while issuing the STT, so a disallowed organization (or one the client's `organization_usage` forbids) fails at that call rather than later at the target's `/authorize`. On the redirect, it is what actually scopes the target session. Passing it on the mint alone does not scope the session, so set both. An `organization` the tenant rejects surfaces as a `TokenExchangeError`; a blank one throws `OrganizationValidationError` before the session is read or any network call is made.
 
 > [!NOTE]
 > `buildSessionTransferRedirect` attaches a single-use credential to the URL, so `targetLoginUrl` **must be a trusted, app-controlled value** and use `https` (`http` is allowed only for the loopback hosts `localhost`, `127.0.0.1`, and `[::1]`). Never derive it from untrusted input such as a `returnTo` parameter, or the token could leak to an attacker-controlled host.

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -8038,8 +8038,8 @@ test('requestSessionTransferToken - omits organization when not provided', async
     });
 
     expect(exchangeSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        organization: undefined,
+      expect.not.objectContaining({
+        organization: expect.anything(),
       })
     );
   } finally {

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -7980,6 +7980,137 @@ test('requestSessionTransferToken - forwards scope and extra params', async () =
   }
 });
 
+test('requestSessionTransferToken - forwards organization on the mint request', async () => {
+  const agentIdToken = await generateToken(domain, 'agent_123', '<client_id>');
+  const exchangeSpy = vi.spyOn(AuthClient.prototype, 'exchangeToken');
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: {
+      get: vi.fn().mockResolvedValue(sessionStateWith(agentIdToken, '<refresh_token>')),
+      set: vi.fn(),
+      delete: vi.fn(),
+      deleteByLogoutToken: vi.fn(),
+    },
+  });
+
+  try {
+    await serverClient.requestSessionTransferToken({
+      subjectToken: 'customer-proof-token',
+      subjectTokenType: 'urn:acme:customer-subject',
+      organization: 'org_abc123',
+    });
+
+    expect(exchangeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organization: 'org_abc123',
+      })
+    );
+  } finally {
+    exchangeSpy.mockRestore();
+  }
+});
+
+test('requestSessionTransferToken - omits organization when not provided', async () => {
+  const agentIdToken = await generateToken(domain, 'agent_123', '<client_id>');
+  const exchangeSpy = vi.spyOn(AuthClient.prototype, 'exchangeToken');
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: {
+      get: vi.fn().mockResolvedValue(sessionStateWith(agentIdToken, '<refresh_token>')),
+      set: vi.fn(),
+      delete: vi.fn(),
+      deleteByLogoutToken: vi.fn(),
+    },
+  });
+
+  try {
+    await serverClient.requestSessionTransferToken({
+      subjectToken: 'customer-proof-token',
+      subjectTokenType: 'urn:acme:customer-subject',
+    });
+
+    expect(exchangeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organization: undefined,
+      })
+    );
+  } finally {
+    exchangeSpy.mockRestore();
+  }
+});
+
+test('requestSessionTransferToken - throws when organization is blank', async () => {
+  const agentIdToken = await generateToken(domain, 'agent_123', '<client_id>');
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: {
+      get: vi.fn().mockResolvedValue(sessionStateWith(agentIdToken, '<refresh_token>')),
+      set: vi.fn(),
+      delete: vi.fn(),
+      deleteByLogoutToken: vi.fn(),
+    },
+  });
+
+  await expect(
+    serverClient.requestSessionTransferToken({
+      subjectToken: 'customer-proof-token',
+      subjectTokenType: 'urn:acme:customer-subject',
+      organization: '   ',
+    })
+  ).rejects.toThrowError(OrganizationValidationError);
+});
+
+test('requestSessionTransferToken - rejects a blank organization before refreshing the agent session', async () => {
+  // An already-expired session ID token: resolving the actor would refresh it, hitting the network
+  // and persisting the rotated tokens. A blank organization must be caught before any of that.
+  const expiredAgentIdToken = await generateToken(domain, 'agent_123', '<client_id>', undefined, undefined, 0);
+  const stateStoreSet = vi.fn();
+  const refreshSpy = vi.spyOn(AuthClient.prototype, 'getTokenByRefreshToken');
+  const exchangeSpy = vi.spyOn(AuthClient.prototype, 'exchangeToken');
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: {
+      get: vi.fn().mockResolvedValue(sessionStateWith(expiredAgentIdToken, '<refresh_token>')),
+      set: stateStoreSet,
+      delete: vi.fn(),
+      deleteByLogoutToken: vi.fn(),
+    },
+  });
+
+  try {
+    await expect(
+      serverClient.requestSessionTransferToken({
+        subjectToken: 'customer-proof-token',
+        subjectTokenType: 'urn:acme:customer-subject',
+        organization: '   ',
+      })
+    ).rejects.toThrowError(OrganizationValidationError);
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+    expect(exchangeSpy).not.toHaveBeenCalled();
+    expect(stateStoreSet).not.toHaveBeenCalled();
+  } finally {
+    refreshSpy.mockRestore();
+    exchangeSpy.mockRestore();
+  }
+});
+
 test('requestSessionTransferToken - reports expiresIn as 0 (not NaN) when the server omits expires_in', async () => {
   const agentIdToken = await generateToken(domain, 'agent_123', '<client_id>');
   // Simulate a response with no `expires_in`: TokenResponse.expiresAt is then NaN.

--- a/packages/auth0-server-js/src/server-client.ts
+++ b/packages/auth0-server-js/src/server-client.ts
@@ -1300,8 +1300,9 @@ export class ServerClient<TStoreOptions = unknown> {
    * {@link SessionTransferActor.token}.
    *
    * When `organization` is provided it is sent on the exchange, so the tenant validates it while
-   * minting. The organization that scopes the target session is still the one passed to
-   * {@link ServerClient.buildSessionTransferRedirect}.
+   * minting. This is a separate parameter from the `organization` passed to
+   * {@link ServerClient.buildSessionTransferRedirect}, which is forwarded to the target's
+   * `/authorize` on the redirect.
    *
    * @param options Options including the developer-supplied `subjectToken`/`subjectTokenType` and an optional explicit `actor`.
    * @param storeOptions Optional options used to read the agent session (for the actor) and resolve the request domain.
@@ -1328,7 +1329,7 @@ export class ServerClient<TStoreOptions = unknown> {
     }
 
     // Blank-check the organization here too, for the same reason. The core validates it, but only
-    // once the exchange is already underway — by then resolving the actor may have refreshed the
+    // once the exchange is already underway - by then resolving the actor may have refreshed the
     // agent session (a network call) and persisted the rotated tokens.
     if (options.organization !== undefined && !options.organization.trim()) {
       throw new OrganizationValidationError('organization must not be blank');
@@ -1348,10 +1349,10 @@ export class ServerClient<TStoreOptions = unknown> {
       scope: options.scope,
       actorToken: actor.token,
       actorTokenType: actor.type,
-      // Forwarded so the tenant validates the organization while minting (including the
-      // client's `organization_usage`), rather than deferring the failure to the target's
-      // `/authorize`. The organization that scopes the target session is the one passed to
-      // `buildSessionTransferRedirect`; this does not replace it.
+      // Forwarded so the tenant validates the organization against the client's organization
+      // settings while minting, rather than the STT being issued without it. Separate from the
+      // `organization` on `buildSessionTransferRedirect`, which goes to the target's
+      // `/authorize`; neither implies the other.
       organization: options.organization,
       extra: options.extra,
     });

--- a/packages/auth0-server-js/src/server-client.ts
+++ b/packages/auth0-server-js/src/server-client.ts
@@ -1293,16 +1293,23 @@ export class ServerClient<TStoreOptions = unknown> {
    * on the result — it only appears on the target session's tokens once the STT is redeemed.
    *
    * An actor is mandatory for an STT (this is what makes it auditable impersonation). It is
-   * resolved in this order: an explicit `options.actor` wins; otherwise the current agent
-   * session's ID token is used, refreshed when it has expired; if neither is available the method
-   * throws before any network call.
+   * resolved in this order: an explicit `options.actor` wins, in which case the session is not
+   * read at all; otherwise the current agent session's ID token is used, refreshed when it has
+   * expired; if neither is available the method throws before any network call. An explicit actor
+   * token carrying the default ID token type must satisfy Auth0's own validation — see
+   * {@link SessionTransferActor.token}.
+   *
+   * When `organization` is provided it is sent on the exchange, so the tenant validates it while
+   * minting. The organization that scopes the target session is still the one passed to
+   * {@link ServerClient.buildSessionTransferRedirect}.
    *
    * @param options Options including the developer-supplied `subjectToken`/`subjectTokenType` and an optional explicit `actor`.
    * @param storeOptions Optional options used to read the agent session (for the actor) and resolve the request domain.
    *
-   * @throws {TokenExchangeError} With code `actor_unavailable` when no explicit actor is given and no usable session ID token can be resolved — no logged-in agent, a session that belongs to a different domain in resolver mode, or an expired ID token that cannot be refreshed (raised client-side, before any network call). With the default code when the exchange itself fails; a server-side `setactor_required` or `session_transfer_disabled` condition is surfaced via `cause.error` / `cause.error_description`.
+   * @throws {TokenExchangeError} With code `actor_unavailable` when no explicit actor is given and no usable session ID token can be resolved — no logged-in agent, a session that belongs to a different domain in resolver mode, or an expired ID token that cannot be refreshed (raised client-side, before any network call). With the default code when the exchange itself fails; a server-side `setactor_required` or `session_transfer_disabled` condition is surfaced via `cause.error` / `cause.error_description`. An organization the tenant rejects also surfaces here.
    * @throws {MissingClientAuthError} When client credentials are not configured (STT requires a confidential client).
    * @throws {MissingRequiredArgumentError} When `subjectToken` or `subjectTokenType` is missing or blank (raised before any session read or network call).
+   * @throws {OrganizationValidationError} When `organization` is provided but blank (raised before any session read or network call).
    *
    * @returns A promise resolving to a {@link SessionTransferTokenResult} containing the STT and its metadata.
    */
@@ -1320,6 +1327,13 @@ export class ServerClient<TStoreOptions = unknown> {
       throw new MissingRequiredArgumentError('subjectTokenType');
     }
 
+    // Blank-check the organization here too, for the same reason. The core validates it, but only
+    // once the exchange is already underway — by then resolving the actor may have refreshed the
+    // agent session (a network call) and persisted the rotated tokens.
+    if (options.organization !== undefined && !options.organization.trim()) {
+      throw new OrganizationValidationError('organization must not be blank');
+    }
+
     const domain = await this.#resolveDomain(storeOptions);
 
     // Resolve the actor before anything else — an STT is only issued when an actor is set, and a
@@ -1334,6 +1348,11 @@ export class ServerClient<TStoreOptions = unknown> {
       scope: options.scope,
       actorToken: actor.token,
       actorTokenType: actor.type,
+      // Forwarded so the tenant validates the organization while minting (including the
+      // client's `organization_usage`), rather than deferring the failure to the target's
+      // `/authorize`. The organization that scopes the target session is the one passed to
+      // `buildSessionTransferRedirect`; this does not replace it.
+      organization: options.organization,
       extra: options.extra,
     });
 

--- a/packages/auth0-server-js/src/types.ts
+++ b/packages/auth0-server-js/src/types.ts
@@ -546,14 +546,13 @@ export interface RequestSessionTransferTokenOptions {
   /**
    * The organization (ID or name) to mint the STT in the context of.
    *
-   * Sending it here has the tenant validate the organization while minting — a
-   * disallowed organization, or one whose `organization_usage` the client forbids,
-   * fails at this call instead of later at the target's `/authorize`. It is also
-   * recorded on the issued STT.
+   * Sending it here has the tenant validate the organization against the client's
+   * organization settings while minting, so an organization the client is not allowed
+   * to use fails at this call instead of the STT being issued without it.
    *
-   * This is independent of {@link BuildSessionTransferRedirectOptions.organization},
-   * which is what actually scopes the target session. Set both to the same value when
-   * minting in an organization context.
+   * This is a separate parameter from {@link BuildSessionTransferRedirectOptions.organization},
+   * which is forwarded to the target's `/authorize` on the redirect. They are sent on
+   * different requests and neither implies the other.
    */
   organization?: string;
   /**

--- a/packages/auth0-server-js/src/types.ts
+++ b/packages/auth0-server-js/src/types.ts
@@ -487,11 +487,19 @@ export interface LoginWithCustomTokenExchangeResult {
  * An explicit actor (the acting party) for a Session Transfer Token request.
  *
  * Supplying this overrides the default behaviour of sourcing the actor from the
- * current agent session's ID token.
+ * current agent session's ID token. The session is not read at all when this is
+ * given, so it also works where there is no logged-in agent.
  */
 export interface SessionTransferActor {
   /**
    * The actor token — for the default flow this is the agent's ID token.
+   *
+   * When {@link SessionTransferActor.type} is the ID token URN (the default), Auth0
+   * validates this token and requires an unexpired, asymmetrically-signed Auth0 ID
+   * token: signed with `RS256` or `PS256` (`HS256` is rejected, as it uses a shared
+   * secret), carrying `sub`, `iss`, `exp` and `iat`, issued to the same client making
+   * the exchange, and belonging to a user who still exists and is not blocked. A token
+   * failing any of these fails the exchange with a `TokenExchangeError`.
    */
   token: string;
   /**
@@ -525,16 +533,29 @@ export interface RequestSessionTransferTokenOptions {
   /**
    * An explicit actor to override the default (the agent session's ID token).
    *
-   * Resolution order: this explicit `actor` wins; otherwise the agent session's ID
-   * token is used (refreshed when expired); if neither is available the request fails
-   * client-side with a `TokenExchangeError` whose code is `actor_unavailable`, before
-   * any network call.
+   * Resolution order: this explicit `actor` wins, and the session is not read at all;
+   * otherwise the agent session's ID token is used (refreshed when expired); if neither
+   * is available the request fails client-side with a `TokenExchangeError` whose code is
+   * `actor_unavailable`, before any network call.
    */
   actor?: SessionTransferActor;
   /**
    * Space-separated list of OAuth 2.0 scopes to request for the session's tokens.
    */
   scope?: string;
+  /**
+   * The organization (ID or name) to mint the STT in the context of.
+   *
+   * Sending it here has the tenant validate the organization while minting — a
+   * disallowed organization, or one whose `organization_usage` the client forbids,
+   * fails at this call instead of later at the target's `/authorize`. It is also
+   * recorded on the issued STT.
+   *
+   * This is independent of {@link BuildSessionTransferRedirectOptions.organization},
+   * which is what actually scopes the target session. Set both to the same value when
+   * minting in an organization context.
+   */
+  organization?: string;
   /**
    * Additional custom parameters forwarded to the token endpoint (and thus to your
    * Action via `event.request.body`). Cannot override reserved OAuth parameters.

--- a/packages/auth0-server-js/src/types.ts
+++ b/packages/auth0-server-js/src/types.ts
@@ -552,7 +552,9 @@ export interface RequestSessionTransferTokenOptions {
    *
    * This is a separate parameter from {@link BuildSessionTransferRedirectOptions.organization},
    * which is forwarded to the target's `/authorize` on the redirect. They are sent on
-   * different requests and neither implies the other.
+   * different requests and neither implies the other. The one on the redirect is what
+   * org-scopes the session the target establishes, so setting only this one validates the
+   * organization without scoping that session.
    */
   organization?: string;
   /**


### PR DESCRIPTION
## What this does
`requestSessionTransferToken` was not sending the `organization` parameter, so there was no way to mint an STT in an organization context. Auth0 accepts `organization` on the token exchange, we just were not passing it through.

This adds an optional `organization` to `RequestSessionTransferTokenOptions`, forwarded on the mint request.

## Key behavior
- `buildSessionTransferRedirect` already took an `organization`. That one scopes the target session, so both should be set when minting in an organization context. Passing it on the mint alone does not scope the session.
- A blank `organization` throws `OrganizationValidationError` before the agent session is read or refreshed. This matters because resolving the actor can refresh an expired session ID token, which is a network call plus a state store write. Failing after that on a client side validation error would rotate the caller's refresh token for a request that could never succeed.

## Scope
All changes are in `auth0-server-js`. `auth0-auth-js` already accepted `organization` on `exchangeToken`, so there is no lower layer change and no dependency bump. `auth0-fastify` passes options through and picks the option up on its next dependency bump.

## Not a breaking change

The option is optional, and calls that omit it send the same request as before. `organization` is on the core `PARAM_DENYLIST`, so anyone who tried passing it through `extra` was having it silently dropped and is unaffected.

## Testing

- Added tests for forwarding `organization` on the mint, omitting it when not provided, rejecting a blank value, and rejecting a blank value before the session refresh happens.
- Verified the tests are not vacuous by removing each guard and confirming a real failure.
- `auth0-server-js`: 408 tests pass. Build and lint clean across all 13 turbo tasks.
- Documented the mint vs redirect distinction in `EXAMPLES.md`, along with the actor token requirements (`RS256`/`PS256`, unexpired, issued to the same client) and that an explicit `actor` skips the session read entirely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Session Transfer Token requests can now include an optional organization.
  - Organization context is forwarded during token creation and redirect flows, with validation for blank or invalid values.
  - Actor selection now supports automatic resolution from the agent session or explicit actor precedence.
  - Added validation requirements for actor tokens and documented behavior when no session lookup is needed.

- **Documentation**
  - Expanded examples and guidance for organization scoping, actor resolution, validation, and related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->