### PR TITLE
fix(auth0-auth-js): send client credentials on passkey register/challenge

### DIFF
--- a/packages/auth0-auth-js/EXAMPLES.md
+++ b/packages/auth0-auth-js/EXAMPLES.md
@@ -139,7 +139,7 @@ const tokenResponse = await auth0.getTokenByClientCredentials({
 
 - **Client Certificate**: Your application must have a valid client certificate issued by a Certificate Authority (CA) that Auth0 trusts.
 - **Domain Configuration**: Your Auth0 tenant must be configured to support mTLS endpoints.
-- **No Additional Auth**: When `useMtls: true`, you don't need `clientSecret` or `clientAssertionSigningKey`.
+- **No Additional Auth**: When `useMtls: true`, you don't need `clientSecret` or `clientAssertionSigningKey`. The one exception is `passkey.register()` / `passkey.challenge()`, which are not served on the mTLS endpoint aliases and accept only a `clientSecret`. See [Using Passkeys](#using-passkeys).
 - **Custom Fetch Required**: You must provide a `customFetch` implementation that includes the client certificate in the TLS handshake.
 
 > [!IMPORTANT]  
@@ -1108,7 +1108,7 @@ The SDK is platform-agnostic — it does not call WebAuthn browser APIs directly
 > **Client authentication differs across the passkey methods:**
 > - `register()` and `challenge()` work with both **public clients** (e.g. SPAs / native apps, which authenticate with `client_id` alone) and **confidential clients**. For a confidential client, configure a `clientSecret` and the SDK sends it as `client_secret` on these requests.
 >
->   These two endpoints accept `client_secret` as their only body-level credential, so it is the only way to authenticate a confidential client on them. They do **not** accept `client_assertion`. A client configured with only a `clientAssertionSigningKey` (private key JWT), or with only `useMtls`, has no credential the SDK can send here: the request goes out with `client_id` alone and Auth0 rejects it with `unauthorized_client`. To use these two endpoints, configure the application for client secret authentication and pass a `clientSecret`. The limitation is specific to them, so `getTokenByPasskey()` still works with `clientAssertionSigningKey` or mTLS.
+>   These two endpoints accept `client_secret` as their only body-level credential, so it is the only way to authenticate a confidential client on them. They do **not** accept `client_assertion`, and they are **not** served on the mTLS endpoint aliases. A client configured with only a `clientAssertionSigningKey` (private key JWT), or with only `useMtls`, therefore has no credential the SDK can send here: the request goes out with `client_id` alone and Auth0 rejects it. To use these two endpoints, configure the application for client secret authentication and pass a `clientSecret`. The limitation is specific to them, so `getTokenByPasskey()` still works with `clientAssertionSigningKey` or mTLS.
 > - `getTokenByPasskey()` performs the token exchange and **requires a confidential client**. You must configure a `clientSecret`, a `clientAssertionSigningKey` (private key JWT), or mTLS. Because it goes through the token endpoint, it supports every client-authentication method. Called on a public client (no credentials), it throws a `PasskeyGetTokenError` whose `cause.message` is `'The client secret or client assertion signing key must be provided.'`. No request is made in that case, so `cause.error` and `cause.error_description` are empty.
 
 Learn more: [Passkeys](https://auth0.com/docs/authenticate/database-connections/passkeys) | [Native Passkeys API](https://auth0.com/docs/authenticate/database-connections/passkeys/native-passkeys-api)
@@ -1409,13 +1409,15 @@ try {
 > See [Handling the MFA Required Response](#handling-the-mfa-required-response) for the full flow.
 
 > [!NOTE]
-> If a confidential client has no `clientSecret` configured, because it uses only a `clientAssertionSigningKey` (private key JWT) or only `useMtls`, then `register()` and `challenge()` fail with `unauthorized_client`:
+> If a confidential client has no `clientSecret` configured, because it uses only a `clientAssertionSigningKey` (private key JWT) or only `useMtls`, then `register()` and `challenge()` fail. Auth0 rejects the request and the SDK surfaces its response unchanged:
 >
 > ```ts
-> // error.code           -> 'passkey_register_error' | 'passkey_challenge_error'
-> // error.cause?.error   -> 'unauthorized_client'
-> // error.cause?.error_description -> 'Invalid client credentials'
+> // error.code                     -> 'passkey_register_error' | 'passkey_challenge_error'
+> // error.cause?.error             -> the error code Auth0 returned
+> // error.cause?.error_description -> the matching description from Auth0
 > ```
+>
+> The SDK does not interpret or normalize these values, and the exact code depends on how the application is configured in the Auth0 Dashboard. Log `error.cause` rather than branching on it.
 >
 > Retrying will not help, since the SDK has no credential these endpoints accept. To fix it, set the application's authentication method to **Client Secret** in the Auth0 Dashboard, then pass that secret as `clientSecret` on the `AuthClient`. See [Using Passkeys](#using-passkeys) for the full explanation.
 >

--- a/packages/auth0-auth-js/EXAMPLES.md
+++ b/packages/auth0-auth-js/EXAMPLES.md
@@ -1106,8 +1106,10 @@ The SDK is platform-agnostic — it does not call WebAuthn browser APIs directly
 
 > [!IMPORTANT]
 > **Client authentication differs across the passkey methods:**
-> - `register()` and `challenge()` request a challenge using only the `client_id`, so they work with **public clients** (e.g. SPAs / native apps) as well as confidential clients.
-> - `getTokenByPasskey()` performs the token exchange and **requires a confidential client** — you must configure either a `clientSecret` or a `clientAssertionSigningKey` (private key JWT). Called on a public client (no credentials), it throws (a `PasskeyGetTokenError` whose `cause` reports that a client secret or client assertion signing key must be provided).
+> - `register()` and `challenge()` work with both **public clients** (e.g. SPAs / native apps, which authenticate with `client_id` alone) and **confidential clients**. For a confidential client, configure a `clientSecret` and the SDK sends it as `client_secret` on these requests.
+>
+>   These two endpoints accept `client_secret` as their only body-level credential, so it is the only way to authenticate a confidential client on them. They do **not** accept `client_assertion`. A client configured with only a `clientAssertionSigningKey` (private key JWT), or with only `useMtls`, has no credential the SDK can send here: the request goes out with `client_id` alone and Auth0 rejects it with `unauthorized_client`. To use these two endpoints, configure the application for client secret authentication and pass a `clientSecret`. The limitation is specific to them, so `getTokenByPasskey()` still works with `clientAssertionSigningKey` or mTLS.
+> - `getTokenByPasskey()` performs the token exchange and **requires a confidential client**. You must configure a `clientSecret`, a `clientAssertionSigningKey` (private key JWT), or mTLS. Because it goes through the token endpoint, it supports every client-authentication method. Called on a public client (no credentials), it throws a `PasskeyGetTokenError` whose `cause.message` is `'The client secret or client assertion signing key must be provided.'`. No request is made in that case, so `cause.error` and `cause.error_description` are empty.
 
 Learn more: [Passkeys](https://auth0.com/docs/authenticate/database-connections/passkeys) | [Native Passkeys API](https://auth0.com/docs/authenticate/database-connections/passkeys/native-passkeys-api)
 
@@ -1222,7 +1224,7 @@ const challenge = await authClient.passkey.challenge({
 After the user completes the WebAuthn ceremony (either signup or login), exchange the credential response for Auth0 tokens.
 
 > [!IMPORTANT]
-> Unlike `register()` and `challenge()`, `getTokenByPasskey()` **requires a confidential client**. Configure the `AuthClient` with a `clientSecret` or a `clientAssertionSigningKey`:
+> Unlike `register()` and `challenge()`, `getTokenByPasskey()` **requires a confidential client**. Configure the `AuthClient` with a `clientSecret`, a `clientAssertionSigningKey`, or mTLS:
 >
 > ```ts
 > const authClient = new AuthClient({
@@ -1405,6 +1407,19 @@ try {
 > ```
 >
 > See [Handling the MFA Required Response](#handling-the-mfa-required-response) for the full flow.
+
+> [!NOTE]
+> If a confidential client has no `clientSecret` configured, because it uses only a `clientAssertionSigningKey` (private key JWT) or only `useMtls`, then `register()` and `challenge()` fail with `unauthorized_client`:
+>
+> ```ts
+> // error.code           -> 'passkey_register_error' | 'passkey_challenge_error'
+> // error.cause?.error   -> 'unauthorized_client'
+> // error.cause?.error_description -> 'Invalid client credentials'
+> ```
+>
+> Retrying will not help, since the SDK has no credential these endpoints accept. To fix it, set the application's authentication method to **Client Secret** in the Auth0 Dashboard, then pass that secret as `clientSecret` on the `AuthClient`. See [Using Passkeys](#using-passkeys) for the full explanation.
+>
+> `getTokenByPasskey()` is unaffected and works with `clientAssertionSigningKey` or mTLS, since it goes through the token endpoint.
 
 ## Custom Token Exchange
 

--- a/packages/auth0-auth-js/README.md
+++ b/packages/auth0-auth-js/README.md
@@ -295,7 +295,7 @@ const tokens = await authClient.passkey.getTokenByPasskey({
 ```
 
 > [!IMPORTANT]
-> `getTokenByPasskey()` requires a **confidential client** (`clientSecret` or `clientAssertionSigningKey`); only `register()` and `challenge()` work with public clients. Passkeys also require the following prerequisites:
+> `getTokenByPasskey()` requires a **confidential client** (`clientSecret`, `clientAssertionSigningKey`, or mTLS); only `register()` and `challenge()` work with public clients. On a confidential client, `register()` and `challenge()` need a `clientSecret` specifically: they accept no other credential, and reject `client_assertion`. Passkeys also require the following prerequisites:
 > - A [custom domain](https://auth0.com/docs/customize/custom-domains) configured on your Auth0 tenant (e.g., `auth.example.com`, not `example.auth0.com`). The custom domain serves as the WebAuthn Relying Party (RP) ID, which must match or be a registrable domain suffix of your application's origin.
 > - A database connection with the `passkey` authentication method enabled.
 > - Your application must be served over HTTPS on a domain that aligns with the configured RP ID.

--- a/packages/auth0-auth-js/src/auth-client.spec.ts
+++ b/packages/auth0-auth-js/src/auth-client.spec.ts
@@ -3697,14 +3697,12 @@ describe('passkey register / challenge client authentication', () => {
   test('sends no credential for a private_key_jwt-only client, surfacing the Auth0 rejection', async () => {
     const clientAssertionSigningKey = await generateClientAssertionSigningKey();
 
+    const rejection = { error: 'unauthorized_client', error_description: 'Invalid client credentials' };
     const captured: { body?: Record<string, unknown> } = {};
     server.use(
       http.post(`https://${domain}/passkey/challenge`, async ({ request }) => {
         captured.body = (await request.json()) as Record<string, unknown>;
-        return HttpResponse.json(
-          { error: 'unauthorized_client', error_description: 'Invalid client credentials' },
-          { status: 403 }
-        );
+        return HttpResponse.json(rejection, { status: 403 });
       })
     );
     const authClient = new AuthClient({ domain, clientId: '<client_id>', clientAssertionSigningKey });
@@ -3718,23 +3716,23 @@ describe('passkey register / challenge client authentication', () => {
     expect('client_assertion' in captured.body!).toBe(false);
     expect('client_secret' in captured.body!).toBe(false);
     expect(error).toBeInstanceOf(PasskeyChallengeError);
-    expect(error.cause?.error).toBe('unauthorized_client');
+    expect(error.cause?.error).toBe(rejection.error);
   });
 
   // These two endpoints are not served on the mTLS endpoint aliases, so a client
-  // relying on mTLS alone has no credential for them: the request goes to the
-  // regular host with `client_id` only and Auth0 rejects it. Documented in
-  // EXAMPLES.md rather than pre-empted here, for the same forward-compatibility
-  // reason as the private_key_jwt-only case.
-  test('sends client_id only to the regular host for an mTLS-only client', async () => {
+  // relying on mTLS has no credential for them: the request goes to the regular
+  // host with `client_id` only, where the certificate headers are absent and Auth0
+  // rejects it. The SDK does not interpret that rejection, so this asserts the
+  // response is surfaced as-is rather than pinning a particular error code.
+  test('sends client_id only to the regular host for an mTLS-only client, surfacing the Auth0 rejection', async () => {
+    const rejection = { error: 'invalid_client', error_description: 'Unauthorized' };
     const requests: string[] = [];
+    const captured: { body?: Record<string, unknown> } = {};
     server.use(
       http.post(`https://${domain}/passkey/challenge`, async ({ request }) => {
         requests.push(request.url);
-        return HttpResponse.json({
-          auth_session: 'auth-session-abc',
-          authn_params_public_key: { challenge: 'challenge-abc', rpId: domain },
-        });
+        captured.body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(rejection, { status: 401 });
       })
     );
     const authClient = new AuthClient({
@@ -3744,10 +3742,14 @@ describe('passkey register / challenge client authentication', () => {
       customFetch: (...args) => fetch(...args),
     });
 
-    await authClient.passkey.challenge();
+    const error = await authClient.passkey.challenge().catch((e) => e);
 
     expect(requests[0]).toBe(`https://${domain}/passkey/challenge`);
     expect(requests[0]).not.toContain('mtls.');
+    expect('client_secret' in captured.body!).toBe(false);
+    expect(error).toBeInstanceOf(PasskeyChallengeError);
+    expect(error.cause?.error).toBe(rejection.error);
+    expect(error.cause?.error_description).toBe(rejection.error_description);
   });
 
   test('forwards clientSecret on register as well as challenge', async () => {
@@ -3779,14 +3781,12 @@ describe('passkey register / challenge client authentication', () => {
   test('sends no credential on register for a private_key_jwt-only client, surfacing the Auth0 rejection', async () => {
     const clientAssertionSigningKey = await generateClientAssertionSigningKey();
 
+    const rejection = { error: 'unauthorized_client', error_description: 'Invalid client credentials' };
     const captured: { body?: Record<string, unknown> } = {};
     server.use(
       http.post(`https://${domain}/passkey/register`, async ({ request }) => {
         captured.body = (await request.json()) as Record<string, unknown>;
-        return HttpResponse.json(
-          { error: 'unauthorized_client', error_description: 'Invalid client credentials' },
-          { status: 403 }
-        );
+        return HttpResponse.json(rejection, { status: 403 });
       })
     );
     const authClient = new AuthClient({ domain, clientId: '<client_id>', clientAssertionSigningKey });
@@ -3796,7 +3796,7 @@ describe('passkey register / challenge client authentication', () => {
     expect('client_assertion' in captured.body!).toBe(false);
     expect('client_secret' in captured.body!).toBe(false);
     expect(error).toBeInstanceOf(PasskeyRegisterError);
-    expect(error.cause?.error).toBe('unauthorized_client');
+    expect(error.cause?.error).toBe(rejection.error);
   });
 });
 

--- a/packages/auth0-auth-js/src/auth-client.spec.ts
+++ b/packages/auth0-auth-js/src/auth-client.spec.ts
@@ -3,7 +3,7 @@ import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
 import { AuthClient } from './auth-client.js';
 import { NotSupportedError, isMfaRequiredError, TokenByPasswordError, OrganizationValidationError } from './errors.js';
-import { PasskeyGetTokenError } from './passkey/errors.js';
+import { PasskeyGetTokenError, PasskeyChallengeError, PasskeyRegisterError } from './passkey/errors.js';
 import { PasswordlessVerifyError } from './passwordless/errors.js';
 import { ExchangeProfileOptions } from './types.js';
 
@@ -3598,6 +3598,205 @@ describe('getTokenByPasskey (WebAuthn grant)', () => {
     await expect(
       authClient.passkey.getTokenByPasskey({ authSession: 'expired', credential })
     ).rejects.toMatchObject({ name: 'PasskeyGetTokenError' });
+  });
+});
+
+describe('passkey register / challenge client authentication', () => {
+  /**
+   * Captures the body of the next `/passkey/challenge` request.
+   *
+   * These endpoints are called directly (not through the token endpoint), so this
+   * pins the client-auth options `AuthClient` hands to its `PasskeyClient`.
+   */
+  const mockPasskeyChallengeEndpoint = () => {
+    const captured: { body?: Record<string, unknown> } = {};
+    server.use(
+      http.post(`https://${domain}/passkey/challenge`, async ({ request }) => {
+        captured.body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          auth_session: 'auth-session-abc',
+          authn_params_public_key: { challenge: 'challenge-abc', rpId: domain },
+        });
+      })
+    );
+    return captured;
+  };
+
+  /**
+   * Captures the body of the next `/passkey/register` request.
+   */
+  const mockPasskeyRegisterEndpoint = () => {
+    const captured: { body?: Record<string, unknown> } = {};
+    server.use(
+      http.post(`https://${domain}/passkey/register`, async ({ request }) => {
+        captured.body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          auth_session: 'auth-session-abc',
+          authn_params_public_key: {
+            challenge: 'challenge-abc',
+            rp: { id: domain, name: 'My App' },
+            user: { id: 'dXNlcg', name: 'user@example.com', displayName: 'user@example.com' },
+            pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+          },
+        });
+      })
+    );
+    return captured;
+  };
+
+  /**
+   * Generates a PEM-encoded RSA private key for `private_key_jwt` clients.
+   */
+  const generateClientAssertionSigningKey = async () => {
+    const { privateKey } = await crypto.subtle.generateKey(
+      { name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+      true,
+      ['sign', 'verify']
+    );
+    return exportPrivateKeyToPem(privateKey);
+  };
+
+  test('forwards clientSecret so confidential clients authenticate', async () => {
+    const captured = mockPasskeyChallengeEndpoint();
+    const authClient = new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });
+
+    await authClient.passkey.challenge();
+
+    expect(captured.body!.client_id).toBe('<client_id>');
+    expect(captured.body!.client_secret).toBe('<client_secret>');
+  });
+
+  test('sends client_id only for public clients', async () => {
+    const captured = mockPasskeyChallengeEndpoint();
+    const authClient = new AuthClient({ domain, clientId: '<client_id>' });
+
+    await authClient.passkey.challenge();
+
+    expect(captured.body!.client_id).toBe('<client_id>');
+    expect('client_secret' in captured.body!).toBe(false);
+  });
+
+  test('omits client_secret when mTLS is enabled', async () => {
+    const captured = mockPasskeyChallengeEndpoint();
+    // mTLS requires a custom fetch; the certificate it supplies is the credential,
+    // and Auth0 rejects a request that also carries a body-level credential.
+    const authClient = new AuthClient({
+      domain,
+      clientId: '<client_id>',
+      clientSecret: '<client_secret>',
+      useMtls: true,
+      customFetch: (...args) => fetch(...args),
+    });
+
+    await authClient.passkey.challenge();
+
+    expect(captured.body!.client_id).toBe('<client_id>');
+    expect('client_secret' in captured.body!).toBe(false);
+  });
+
+  test('sends no credential for a private_key_jwt-only client, surfacing the Auth0 rejection', async () => {
+    const clientAssertionSigningKey = await generateClientAssertionSigningKey();
+
+    const captured: { body?: Record<string, unknown> } = {};
+    server.use(
+      http.post(`https://${domain}/passkey/challenge`, async ({ request }) => {
+        captured.body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(
+          { error: 'unauthorized_client', error_description: 'Invalid client credentials' },
+          { status: 403 }
+        );
+      })
+    );
+    const authClient = new AuthClient({ domain, clientId: '<client_id>', clientAssertionSigningKey });
+
+    // These endpoints accept `client_secret` only, so the signing key is not usable
+    // here and no credential is sent. The SDK does not pre-empt Auth0's answer: if
+    // these endpoints later accept `client_assertion`, refusing here would block a
+    // configuration the server had begun supporting.
+    const error = await authClient.passkey.challenge().catch((e) => e);
+
+    expect('client_assertion' in captured.body!).toBe(false);
+    expect('client_secret' in captured.body!).toBe(false);
+    expect(error).toBeInstanceOf(PasskeyChallengeError);
+    expect(error.cause?.error).toBe('unauthorized_client');
+  });
+
+  // These two endpoints are not served on the mTLS endpoint aliases, so a client
+  // relying on mTLS alone has no credential for them: the request goes to the
+  // regular host with `client_id` only and Auth0 rejects it. Documented in
+  // EXAMPLES.md rather than pre-empted here, for the same forward-compatibility
+  // reason as the private_key_jwt-only case.
+  test('sends client_id only to the regular host for an mTLS-only client', async () => {
+    const requests: string[] = [];
+    server.use(
+      http.post(`https://${domain}/passkey/challenge`, async ({ request }) => {
+        requests.push(request.url);
+        return HttpResponse.json({
+          auth_session: 'auth-session-abc',
+          authn_params_public_key: { challenge: 'challenge-abc', rpId: domain },
+        });
+      })
+    );
+    const authClient = new AuthClient({
+      domain,
+      clientId: '<client_id>',
+      useMtls: true,
+      customFetch: (...args) => fetch(...args),
+    });
+
+    await authClient.passkey.challenge();
+
+    expect(requests[0]).toBe(`https://${domain}/passkey/challenge`);
+    expect(requests[0]).not.toContain('mtls.');
+  });
+
+  test('forwards clientSecret on register as well as challenge', async () => {
+    const captured = mockPasskeyRegisterEndpoint();
+    const authClient = new AuthClient({ domain, clientId: '<client_id>', clientSecret: '<client_secret>' });
+
+    await authClient.passkey.register({ email: 'user@example.com' });
+
+    expect(captured.body!.client_id).toBe('<client_id>');
+    expect(captured.body!.client_secret).toBe('<client_secret>');
+  });
+
+  test('omits client_secret on register when mTLS is enabled', async () => {
+    const captured = mockPasskeyRegisterEndpoint();
+    const authClient = new AuthClient({
+      domain,
+      clientId: '<client_id>',
+      clientSecret: '<client_secret>',
+      useMtls: true,
+      customFetch: (...args) => fetch(...args),
+    });
+
+    await authClient.passkey.register({ email: 'user@example.com' });
+
+    expect(captured.body!.client_id).toBe('<client_id>');
+    expect('client_secret' in captured.body!).toBe(false);
+  });
+
+  test('sends no credential on register for a private_key_jwt-only client, surfacing the Auth0 rejection', async () => {
+    const clientAssertionSigningKey = await generateClientAssertionSigningKey();
+
+    const captured: { body?: Record<string, unknown> } = {};
+    server.use(
+      http.post(`https://${domain}/passkey/register`, async ({ request }) => {
+        captured.body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(
+          { error: 'unauthorized_client', error_description: 'Invalid client credentials' },
+          { status: 403 }
+        );
+      })
+    );
+    const authClient = new AuthClient({ domain, clientId: '<client_id>', clientAssertionSigningKey });
+
+    const error = await authClient.passkey.register({ email: 'user@example.com' }).catch((e) => e);
+
+    expect('client_assertion' in captured.body!).toBe(false);
+    expect('client_secret' in captured.body!).toBe(false);
+    expect(error).toBeInstanceOf(PasskeyRegisterError);
+    expect(error.cause?.error).toBe('unauthorized_client');
   });
 });
 

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -316,9 +316,18 @@ export class AuthClient {
       getConfiguration: async () => (await this.#discover()).configuration,
     });
 
+    // `/passkey/register` and `/passkey/challenge` require body-level client
+    // authentication for confidential clients, so the sub-client receives the
+    // client secret and the mTLS flag. Those endpoints accept `client_secret`
+    // only, so no `clientAssertionSigningKey` is passed: they reject
+    // `client_assertion`. The passkey token exchange is a standard OAuth grant
+    // and authenticates via `grantRequest` instead, which supports every
+    // client-authentication method.
     this.passkey = new PasskeyClient({
       domain: this.#options.domain,
       clientId: this.#options.clientId,
+      clientSecret: this.#options.clientSecret,
+      useMtls: this.#options.useMtls,
       customFetch: this.#customFetch,
       grantRequest: async (grantType, params) => {
         // The passkey token exchange authenticates the client like any other

--- a/packages/auth0-auth-js/src/passkey/passkey-client.spec.ts
+++ b/packages/auth0-auth-js/src/passkey/passkey-client.spec.ts
@@ -29,12 +29,19 @@ function createMockGrantRequest(): GrantRequestFn {
   return async () => createMockTokenResponse();
 }
 
-function createClient(overrides?: { customFetch?: typeof fetch; grantRequest?: GrantRequestFn }) {
+function createClient(overrides?: {
+  customFetch?: typeof fetch;
+  grantRequest?: GrantRequestFn;
+  clientSecret?: string;
+  useMtls?: boolean;
+}) {
   return new PasskeyClient({
     domain,
     clientId,
     grantRequest: overrides?.grantRequest ?? createMockGrantRequest(),
     ...(overrides?.customFetch && { customFetch: overrides.customFetch }),
+    ...(overrides?.clientSecret !== undefined && { clientSecret: overrides.clientSecret }),
+    ...(overrides?.useMtls !== undefined && { useMtls: overrides.useMtls }),
   });
 }
 
@@ -271,6 +278,122 @@ describe('PasskeyClient', () => {
 
       expect(capturedBody.client_id).toBe(clientId);
       expect(capturedBody.user_profile).toEqual({ email: 'user@example.com' });
+    });
+
+    test('sends client_secret in the request body for a confidential client', async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`https://${domain}/passkey/register`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(mockSignupChallengeResponse);
+        })
+      );
+
+      const client = createClient({ clientSecret: 'test-client-secret' });
+      await client.register({ email: 'user@example.com' });
+
+      expect(capturedBody.client_id).toBe(clientId);
+      expect(capturedBody.client_secret).toBe('test-client-secret');
+      expect(capturedBody.user_profile).toEqual({ email: 'user@example.com' });
+    });
+
+    test('does not include client_secret for a public client', async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`https://${domain}/passkey/register`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(mockSignupChallengeResponse);
+        })
+      );
+
+      const client = createClient();
+      await client.register({ email: 'user@example.com' });
+
+      expect(capturedBody).not.toHaveProperty('client_secret');
+    });
+
+    // mTLS authenticates via the client certificate on the TLS connection, and the
+    // Auth0 mTLS strategy rejects the request outright ("Multiple authentication
+    // methods provided") if a body-level credential is also present.
+    test('does not include client_secret when mTLS is enabled', async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`https://${domain}/passkey/register`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(mockSignupChallengeResponse);
+        })
+      );
+
+      const client = createClient({ clientSecret: 'test-client-secret', useMtls: true });
+      await client.register({ email: 'user@example.com' });
+
+      expect(capturedBody.client_id).toBe(clientId);
+      expect(capturedBody).not.toHaveProperty('client_secret');
+    });
+
+    // The passkey endpoints do not accept `client_assertion`: the Auth0 request
+    // schema rejects any unknown field with `invalid_request`, and that validation
+    // runs before client authentication. A private_key_jwt client therefore never
+    // sends an assertion on these endpoints.
+    test('does not add a client_assertion alongside client_secret', async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`https://${domain}/passkey/register`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(mockSignupChallengeResponse);
+        })
+      );
+
+      const client = createClient({ clientSecret: 'test-client-secret' });
+      await client.register({ email: 'user@example.com' });
+
+      expect(capturedBody).not.toHaveProperty('client_assertion');
+      expect(capturedBody).not.toHaveProperty('client_assertion_type');
+    });
+
+    // A client configured only with a `clientAssertionSigningKey` has no credential
+    // this endpoint accepts, so the SDK sends none and surfaces Auth0's rejection
+    // as-is. It deliberately does not reject the call itself: if Auth0 later starts
+    // accepting `client_assertion` here, an SDK-side refusal would block a config
+    // the server had begun supporting.
+    test('surfaces the Auth0 rejection when no acceptable credential is configured', async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`https://${domain}/passkey/register`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(
+            { error: 'unauthorized_client', error_description: 'Invalid client credentials' },
+            { status: 403 }
+          );
+        })
+      );
+
+      const client = createClient();
+      const error = await client.register({ email: 'user@example.com' }).catch((e) => e);
+
+      expect(capturedBody).not.toHaveProperty('client_secret');
+      expect(capturedBody).not.toHaveProperty('client_assertion');
+      expect(error).toBeInstanceOf(PasskeyRegisterError);
+      expect(error.code).toBe('passkey_register_error');
+      expect(error.cause?.error).toBe('unauthorized_client');
+    });
+
+    // Auth0 validates `client_secret` as a non-empty string, so sending `''` would
+    // fail the request with `invalid_request` instead of falling back to public-client
+    // authentication.
+    test('omits an empty client_secret rather than sending a blank value', async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`https://${domain}/passkey/register`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(mockSignupChallengeResponse);
+        })
+      );
+
+      const client = createClient({ clientSecret: '' });
+      await client.register({ email: 'user@example.com' });
+
+      expect(capturedBody).not.toHaveProperty('client_secret');
     });
 
     test('includes all provided user_profile fields (email, name, phoneNumber, username)', async () => {
@@ -638,6 +761,121 @@ describe('PasskeyClient', () => {
       await client.challenge();
 
       expect(capturedBody.client_id).toBe(clientId);
+    });
+
+    test('sends client_secret in the request body for a confidential client', async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`https://${domain}/passkey/challenge`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(mockLoginChallengeResponse);
+        })
+      );
+
+      const client = createClient({ clientSecret: 'test-client-secret' });
+      await client.challenge();
+
+      expect(capturedBody.client_id).toBe(clientId);
+      expect(capturedBody.client_secret).toBe('test-client-secret');
+    });
+
+    test('does not include client_secret for a public client', async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`https://${domain}/passkey/challenge`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(mockLoginChallengeResponse);
+        })
+      );
+
+      const client = createClient();
+      await client.challenge();
+
+      expect(capturedBody).not.toHaveProperty('client_secret');
+    });
+
+    // mTLS authenticates via the client certificate on the TLS connection, and the
+    // Auth0 mTLS strategy rejects the request outright ("Multiple authentication
+    // methods provided") if a body-level credential is also present.
+    test('does not include client_secret when mTLS is enabled', async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`https://${domain}/passkey/challenge`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(mockLoginChallengeResponse);
+        })
+      );
+
+      const client = createClient({ clientSecret: 'test-client-secret', useMtls: true });
+      await client.challenge();
+
+      expect(capturedBody.client_id).toBe(clientId);
+      expect(capturedBody).not.toHaveProperty('client_secret');
+    });
+
+    // The passkey endpoints do not accept `client_assertion`: the Auth0 request
+    // schema rejects any unknown field with `invalid_request`, and that validation
+    // runs before client authentication. A private_key_jwt client therefore never
+    // sends an assertion on these endpoints.
+    test('does not add a client_assertion alongside client_secret', async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`https://${domain}/passkey/challenge`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(mockLoginChallengeResponse);
+        })
+      );
+
+      const client = createClient({ clientSecret: 'test-client-secret' });
+      await client.challenge();
+
+      expect(capturedBody).not.toHaveProperty('client_assertion');
+      expect(capturedBody).not.toHaveProperty('client_assertion_type');
+    });
+
+    // A client configured only with a `clientAssertionSigningKey` has no credential
+    // this endpoint accepts, so the SDK sends none and surfaces Auth0's rejection
+    // as-is. It deliberately does not reject the call itself: if Auth0 later starts
+    // accepting `client_assertion` here, an SDK-side refusal would block a config
+    // the server had begun supporting.
+    test('surfaces the Auth0 rejection when no acceptable credential is configured', async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`https://${domain}/passkey/challenge`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(
+            { error: 'unauthorized_client', error_description: 'Invalid client credentials' },
+            { status: 403 }
+          );
+        })
+      );
+
+      const client = createClient();
+      const error = await client.challenge().catch((e) => e);
+
+      expect(capturedBody).not.toHaveProperty('client_secret');
+      expect(capturedBody).not.toHaveProperty('client_assertion');
+      expect(error).toBeInstanceOf(PasskeyChallengeError);
+      expect(error.code).toBe('passkey_challenge_error');
+      expect(error.cause?.error).toBe('unauthorized_client');
+    });
+
+    // Auth0 validates `client_secret` as a non-empty string, so sending `''` would
+    // fail the request with `invalid_request` instead of falling back to public-client
+    // authentication.
+    test('omits an empty client_secret rather than sending a blank value', async () => {
+      let capturedBody: Record<string, unknown> = {};
+      server.use(
+        http.post(`https://${domain}/passkey/challenge`, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(mockLoginChallengeResponse);
+        })
+      );
+
+      const client = createClient({ clientSecret: '' });
+      await client.challenge();
+
+      expect(capturedBody).not.toHaveProperty('client_secret');
     });
 
     test('works without any options (options parameter is undefined)', async () => {

--- a/packages/auth0-auth-js/src/passkey/passkey-client.spec.ts
+++ b/packages/auth0-auth-js/src/passkey/passkey-client.spec.ts
@@ -357,14 +357,12 @@ describe('PasskeyClient', () => {
     // accepting `client_assertion` here, an SDK-side refusal would block a config
     // the server had begun supporting.
     test('surfaces the Auth0 rejection when no acceptable credential is configured', async () => {
+      const rejection = { error: 'unauthorized_client', error_description: 'Invalid client credentials' };
       let capturedBody: Record<string, unknown> = {};
       server.use(
         http.post(`https://${domain}/passkey/register`, async ({ request }) => {
           capturedBody = (await request.json()) as Record<string, unknown>;
-          return HttpResponse.json(
-            { error: 'unauthorized_client', error_description: 'Invalid client credentials' },
-            { status: 403 }
-          );
+          return HttpResponse.json(rejection, { status: 403 });
         })
       );
 
@@ -375,7 +373,8 @@ describe('PasskeyClient', () => {
       expect(capturedBody).not.toHaveProperty('client_assertion');
       expect(error).toBeInstanceOf(PasskeyRegisterError);
       expect(error.code).toBe('passkey_register_error');
-      expect(error.cause?.error).toBe('unauthorized_client');
+      expect(error.cause?.error).toBe(rejection.error);
+      expect(error.cause?.error_description).toBe(rejection.error_description);
     });
 
     // Auth0 validates `client_secret` as a non-empty string, so sending `''` would
@@ -839,14 +838,12 @@ describe('PasskeyClient', () => {
     // accepting `client_assertion` here, an SDK-side refusal would block a config
     // the server had begun supporting.
     test('surfaces the Auth0 rejection when no acceptable credential is configured', async () => {
+      const rejection = { error: 'unauthorized_client', error_description: 'Invalid client credentials' };
       let capturedBody: Record<string, unknown> = {};
       server.use(
         http.post(`https://${domain}/passkey/challenge`, async ({ request }) => {
           capturedBody = (await request.json()) as Record<string, unknown>;
-          return HttpResponse.json(
-            { error: 'unauthorized_client', error_description: 'Invalid client credentials' },
-            { status: 403 }
-          );
+          return HttpResponse.json(rejection, { status: 403 });
         })
       );
 
@@ -857,7 +854,8 @@ describe('PasskeyClient', () => {
       expect(capturedBody).not.toHaveProperty('client_assertion');
       expect(error).toBeInstanceOf(PasskeyChallengeError);
       expect(error.code).toBe('passkey_challenge_error');
-      expect(error.cause?.error).toBe('unauthorized_client');
+      expect(error.cause?.error).toBe(rejection.error);
+      expect(error.cause?.error_description).toBe(rejection.error_description);
     });
 
     // Auth0 validates `client_secret` as a non-empty string, so sending `''` would

--- a/packages/auth0-auth-js/src/passkey/passkey-client.ts
+++ b/packages/auth0-auth-js/src/passkey/passkey-client.ts
@@ -19,8 +19,10 @@ import {
   type PasskeyApiErrorResponse,
 } from './errors.js';
 import {
+  buildClientAuthBody,
   transformSignupChallengeResponse,
   transformLoginChallengeResponse,
+  type ClientAuthOptions,
 } from './utils.js';
 
 /**
@@ -33,6 +35,7 @@ export const PASSKEY_GRANT_TYPE = 'urn:okta:params:oauth:grant-type:webauthn';
 export class PasskeyClient {
   #baseUrl: string;
   #clientId: string;
+  #clientAuthOptions: ClientAuthOptions;
   #customFetch: typeof fetch;
   #grantRequest: GrantRequestFn;
 
@@ -42,6 +45,10 @@ export class PasskeyClient {
   constructor(options: PasskeyClientOptions) {
     this.#baseUrl = `https://${options.domain}`;
     this.#clientId = options.clientId;
+    this.#clientAuthOptions = {
+      clientSecret: options.clientSecret,
+      useMtls: options.useMtls,
+    };
     this.#customFetch = options.customFetch ?? ((...args) => fetch(...args));
     this.#grantRequest = options.grantRequest;
   }
@@ -93,6 +100,7 @@ export class PasskeyClient {
 
     const body: Record<string, unknown> = {
       client_id: this.#clientId,
+      ...buildClientAuthBody(this.#clientAuthOptions),
       user_profile: userProfile,
     };
 
@@ -138,6 +146,7 @@ export class PasskeyClient {
 
     const body: Record<string, unknown> = {
       client_id: this.#clientId,
+      ...buildClientAuthBody(this.#clientAuthOptions),
     };
 
     if (options?.realm) body.realm = options.realm;
@@ -166,11 +175,15 @@ export class PasskeyClient {
    * `navigator.credentials.get()` for login), using the challenge obtained from
    * `register()` or `challenge()`.
    *
-   * Unlike `register()` and `challenge()` (which work with public clients), this
-   * token exchange requires a **confidential client** — the `AuthClient` must be
-   * configured with a `clientSecret` or a `clientAssertionSigningKey`. Without
-   * client credentials it throws a `PasskeyGetTokenError` whose `cause` reports
-   * that a client secret or client assertion signing key is required.
+   * Unlike `register()` and `challenge()` (which also work with public clients),
+   * this token exchange requires a **confidential client**. The `AuthClient` must
+   * be configured with a `clientSecret`, a `clientAssertionSigningKey`, or mTLS.
+   * Without client credentials it throws a `PasskeyGetTokenError` whose `cause`
+   * reports that a client secret or client assertion signing key is required.
+   *
+   * This exchange runs through the token endpoint, so it supports every
+   * client-authentication method, including `private_key_jwt`, which the
+   * `register()` / `challenge()` endpoints do not accept.
    *
    * When `organization` is provided, the returned ID token's organization claim is
    * validated against it (an `org_` prefix is matched exactly against `org_id`,

--- a/packages/auth0-auth-js/src/passkey/types.ts
+++ b/packages/auth0-auth-js/src/passkey/types.ts
@@ -22,6 +22,24 @@ export interface PasskeyClientOptions {
    */
   clientId: string;
   /**
+   * Client secret, used to authenticate confidential clients on `/passkey/register`
+   * and `/passkey/challenge` via `client_secret_post`.
+   *
+   * Omitted for public clients (e.g. SPAs / native apps), which authenticate with
+   * `client_id` alone. Ignored when {@link PasskeyClientOptions.useMtls} is set.
+   */
+  clientSecret?: string;
+  /**
+   * Whether the client authenticates with mTLS. When set, no body-level client
+   * credential is sent, because Auth0 rejects a request that carries both a
+   * certificate and a body credential.
+   *
+   * `/passkey/register` and `/passkey/challenge` are not served on the mTLS
+   * endpoint aliases, so a client relying on mTLS alone has no credential for
+   * them and gets `unauthorized_client`. Configure a `clientSecret` to use them.
+   */
+  useMtls?: boolean;
+  /**
    * Optional, custom Fetch implementation to use.
    */
   customFetch?: typeof fetch;

--- a/packages/auth0-auth-js/src/passkey/types.ts
+++ b/packages/auth0-auth-js/src/passkey/types.ts
@@ -32,11 +32,13 @@ export interface PasskeyClientOptions {
   /**
    * Whether the client authenticates with mTLS. When set, no body-level client
    * credential is sent, because Auth0 rejects a request that carries both a
-   * certificate and a body credential.
+   * certificate and a body credential. This takes precedence over
+   * {@link PasskeyClientOptions.clientSecret}, which is not used when both are set.
    *
    * `/passkey/register` and `/passkey/challenge` are not served on the mTLS
-   * endpoint aliases, so a client relying on mTLS alone has no credential for
-   * them and gets `unauthorized_client`. Configure a `clientSecret` to use them.
+   * endpoint aliases, so a client relying on mTLS has no credential for them and
+   * is rejected once the certificate headers turn out to be absent. Only a
+   * `clientSecret` authenticates a confidential client here.
    */
   useMtls?: boolean;
   /**

--- a/packages/auth0-auth-js/src/passkey/utils.ts
+++ b/packages/auth0-auth-js/src/passkey/utils.ts
@@ -1,9 +1,41 @@
 import type {
+  PasskeyClientOptions,
   PasskeySignupChallengeResponse,
   PasskeySignupChallengeApiResponse,
   PasskeyLoginChallengeResponse,
   PasskeyLoginChallengeApiResponse,
 } from './types.js';
+
+/**
+ * Subset of {@link PasskeyClientOptions} carrying the client-authentication fields.
+ * @internal
+ */
+export type ClientAuthOptions = Pick<PasskeyClientOptions, 'clientSecret' | 'useMtls'>;
+
+/**
+ * Builds the client-authentication fields for the `/passkey/register` and
+ * `/passkey/challenge` request bodies.
+ *
+ * These endpoints accept `client_secret` as their only body-level credential, so a
+ * `clientAssertionSigningKey` cannot be used with them. Under mTLS nothing is added,
+ * because Auth0 rejects a request that also carries a credential in the body. Public
+ * clients authenticate with `client_id` alone.
+ *
+ * @internal
+ */
+export function buildClientAuthBody(options: ClientAuthOptions): Record<string, string> {
+  if (options.useMtls) {
+    return {};
+  }
+
+  if (options.clientSecret) {
+    return { client_secret: options.clientSecret };
+  }
+
+  // Public clients, and clients holding only a `clientAssertionSigningKey`, have no
+  // credential to send here. The latter get `unauthorized_client` back from Auth0.
+  return {};
+}
 
 /**
  * Transforms API signup challenge response to SDK format.

--- a/packages/auth0-auth-js/src/passkey/utils.ts
+++ b/packages/auth0-auth-js/src/passkey/utils.ts
@@ -33,7 +33,8 @@ export function buildClientAuthBody(options: ClientAuthOptions): Record<string, 
   }
 
   // Public clients, and clients holding only a `clientAssertionSigningKey`, have no
-  // credential to send here. The latter get `unauthorized_client` back from Auth0.
+  // credential to send here. The latter are rejected by Auth0, whose response the
+  // caller surfaces unchanged.
   return {};
 }
 


### PR DESCRIPTION
## Why we are raising this PR
`register()` and `challenge()` were **broken for confidential clients**. Both methods send only `client_id` in the request body. Auth0 requires a **`client_secret`** in the body when the application is a confidential client, so every such call was rejected as an unauthorized client. Only public clients worked.

## What changed
`PasskeyClient` now sends the client credential that these two endpoints accept.

- New `buildClientAuthBody()` in `src/passkey/utils.ts` builds the client authentication fields for the request body. `register()` and `challenge()` both spread it in.
- `AuthClient` passes `clientSecret` and `useMtls` down to `PasskeyClient`.
- Behaviour by configuration:

| Configuration | Request body |
|---|---|
| Public client | `{ client_id }` |
| `clientSecret` | `{ client_id, client_secret }` |
| Empty `clientSecret` | `{ client_id }` |
| `useMtls` | `{ client_id }` |
| `useMtls` and `clientSecret` | `{ client_id }` |

`useMtls` takes **precedence** over `clientSecret`. Sending both would put a certificate and a body credential in the same request, which Auth0 rejects.

`getTokenByPasskey()` is **unchanged**. It goes through the token endpoint and already authenticated correctly.

## No breaking changes
Public clients send a **byte identical** request body to before this change. This was checked against the built `dist` through the public `AuthClient` API, so SPAs and regular web apps that work today keep working.

This PR also adds **zero public API**. `src/passkey/errors.ts` and `src/passkey/index.ts` are byte identical to `main`, and the new helper and its type do not appear in `dist/index.d.ts`.

## Why no new error class for private key JWT
These endpoints accept `client_secret` as their **only** body level credential. A client configured with only a `clientAssertionSigningKey` has no credential the SDK can send.

We deliberately **do not throw** an SDK side error for this case. If Auth0 later starts accepting `client_assertion` here, a client side refusal would block a configuration the server had begun supporting, and removing the error class would then be a **breaking change**. Adding public symbols to an SDK is easy, removing them is not. So the SDK sends what it can and lets Auth0's answer through unchanged. The limitation is **documented** in `EXAMPLES.md` and `README.md` instead.

The same reasoning covers clients that rely on mTLS alone. These two endpoints are not served on the mTLS endpoint aliases, so such a client also has no credential the SDK can send.

The SDK does **not** interpret, normalize, or document the error code Auth0 returns in either case, because it does not handle these errors. It puts the response on `error.cause` untouched. The docs describe that **shape** and tell readers to log it rather than branch on a specific code, since the code depends on how the application is configured in the Dashboard.

## Testing
- New tests cover, for **both** `register()` and `challenge()`: confidential client, public client, mTLS, empty secret, no `client_assertion` added, and the rejection when no acceptable credential is configured, surfaced as is.
- Integration tests in `auth-client.spec.ts` confirm `AuthClient` forwards the right options, and that an mTLS only client sends `client_id` alone to the regular host.