### PR TITLE
feat(auth0-auth-js): add anonymous sessions support

### DIFF
--- a/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.spec.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.spec.ts
@@ -70,16 +70,7 @@ const restHandlers = [
     });
   }),
 
-  http.post(`https://${domain}/anonymous/logout`, async ({ request }) => {
-    const body = (await request.json()) as Record<string, unknown>;
-
-    if (body.session_token === 'unknown-session-token') {
-      return HttpResponse.json(
-        { error: 'invalid_session_token', error_description: 'Session token not found' },
-        { status: 400 }
-      );
-    }
-
+  http.post(`https://${domain}/anonymous/logout`, () => {
     return new HttpResponse(null, { status: 204 });
   }),
 ];
@@ -226,21 +217,57 @@ describe('createSession', () => {
       code: 'server_error',
     });
   });
+
+  test('throws AnonymousSessionError when expires_in is missing from response', async () => {
+    server.use(
+      http.post(`https://${domain}/anonymous/token`, () =>
+        HttpResponse.json({
+          access_token: accessToken,
+          token_type: 'Bearer',
+          // expires_in intentionally omitted
+          session_token: sessionToken,
+        })
+      )
+    );
+
+    const client = makeClient();
+    await expect(client.createSession()).rejects.toMatchObject({
+      code: 'server_error',
+    });
+  });
+
+  test('throws AnonymousSessionError with code metadata_too_large when metadata exceeds 1 KB', async () => {
+    const client = makeClient();
+    const largeMetadata = { data: 'x'.repeat(1025) };
+
+    await expect(client.createSession({ metadata: largeMetadata })).rejects.toMatchObject({
+      name: 'AnonymousSessionError',
+      code: 'metadata_too_large',
+    });
+  });
 });
 
-// ─── getToken ─────────────────────────────────────────────────────────────────
+// ─── getTokenSilently ─────────────────────────────────────────────────────────
 
-describe('getToken', () => {
-  test('re-mints access token using existing session token', async () => {
+describe('getTokenSilently', () => {
+  test('creates a new session when no sessionToken is provided', async () => {
     const client = makeClient();
-    const session = await client.getToken(sessionToken);
+    const session = await client.getTokenSilently();
+
+    expect(session.sessionToken).toBe(sessionToken);
+    expect(session.accessToken).toBe(accessToken);
+  });
+
+  test('re-mints access token when sessionToken is provided', async () => {
+    const client = makeClient();
+    const session = await client.getTokenSilently({ sessionToken });
 
     expect(session.accessToken).toBe('renewed-access-token');
-    expect(session.sessionToken).toBe(sessionToken); // session token unchanged
+    expect(session.sessionToken).toBe(sessionToken);
     expect(session.expiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
   });
 
-  test('sends the session_token in the request body', async () => {
+  test('sends sessionToken, audience and scope in the request body', async () => {
     let capturedBody: Record<string, unknown> = {};
 
     server.use(
@@ -255,134 +282,15 @@ describe('getToken', () => {
     );
 
     const client = makeClient();
-    await client.getToken('my-session-token', { audience: 'https://api.example.com' });
+    await client.getTokenSilently({ sessionToken: 'my-session-token', audience: 'https://api.example.com', scope: 'openid' });
 
     expect(capturedBody.session_token).toBe('my-session-token');
     expect(capturedBody.audience).toBe('https://api.example.com');
+    expect(capturedBody.scope).toBe('openid');
     expect(capturedBody.client_id).toBe(clientId);
   });
 
-  test('throws AnonymousSessionError with session_expired code', async () => {
-    const client = makeClient();
-
-    await expect(client.getToken('expired-session-token')).rejects.toMatchObject({
-      name: 'AnonymousSessionError',
-      code: 'session_expired',
-    });
-  });
-
-  test('throws AnonymousSessionError with invalid_session_token code', async () => {
-    const client = makeClient();
-
-    await expect(client.getToken('invalid-session-token')).rejects.toMatchObject({
-      name: 'AnonymousSessionError',
-      code: 'invalid_session_token',
-    });
-  });
-});
-
-// ─── getTokenSilently ─────────────────────────────────────────────────────────
-
-describe('getTokenSilently', () => {
-  test('creates a new session when called with null', async () => {
-    const client = makeClient();
-    const session = await client.getTokenSilently(null);
-
-    expect(session.sessionToken).toBe(sessionToken);
-    expect(session.accessToken).toBe(accessToken);
-  });
-
-  test('returns the existing session unchanged when access token is still valid', async () => {
-    const client = makeClient();
-    const fetchSpy = vi.fn();
-    server.use(
-      http.post(`https://${domain}/anonymous/token`, () => {
-        fetchSpy();
-        return HttpResponse.json({});
-      })
-    );
-
-    const futureExpiry = Math.floor(Date.now() / 1000) + 3600;
-    const existingSession = {
-      sessionToken,
-      accessToken,
-      expiresAt: futureExpiry,
-    };
-
-    const result = await client.getTokenSilently(existingSession);
-
-    expect(result).toBe(existingSession); // same reference
-    expect(fetchSpy).not.toHaveBeenCalled();
-  });
-
-  test('renews access token when it is expired', async () => {
-    const client = makeClient();
-    const expiredSession = {
-      sessionToken,
-      accessToken: 'old-access-token',
-      expiresAt: Math.floor(Date.now() / 1000) - 60, // expired 1 minute ago
-    };
-
-    const result = await client.getTokenSilently(expiredSession);
-
-    expect(result.accessToken).toBe('renewed-access-token');
-    expect(result.sessionToken).toBe(sessionToken); // session token unchanged
-  });
-
-  test('silently creates a new session when session_expired is encountered during renewal', async () => {
-    const client = makeClient();
-    const expiredSession = {
-      sessionToken: 'expired-session-token',
-      accessToken: 'old-access-token',
-      expiresAt: Math.floor(Date.now() / 1000) - 60,
-    };
-
-    // Should silently fall back to createSession and succeed
-    const result = await client.getTokenSilently(expiredSession);
-
-    expect(result.sessionToken).toBe(sessionToken); // fresh session
-    expect(result.accessToken).toBe(accessToken);
-  });
-
-  test('silently creates a new session when invalid_session_token is encountered during renewal', async () => {
-    const client = makeClient();
-    const invalidSession = {
-      sessionToken: 'invalid-session-token',
-      accessToken: 'old-access-token',
-      expiresAt: Math.floor(Date.now() / 1000) - 60,
-    };
-
-    const result = await client.getTokenSilently(invalidSession);
-
-    expect(result.sessionToken).toBe(sessionToken);
-    expect(result.accessToken).toBe(accessToken);
-  });
-
-  test('propagates non-session errors to the caller', async () => {
-    const client = makeClient();
-    const expiredSession = {
-      sessionToken,
-      accessToken: 'old-access-token',
-      expiresAt: Math.floor(Date.now() / 1000) - 60,
-    };
-
-    // Override to return a non-recoverable error
-    server.use(
-      http.post(`https://${domain}/anonymous/token`, () =>
-        HttpResponse.json(
-          { error: 'invalid_scope', error_description: 'Requested scope not allowed' },
-          { status: 400 }
-        )
-      )
-    );
-
-    await expect(client.getTokenSilently(expiredSession)).rejects.toMatchObject({
-      name: 'AnonymousSessionError',
-      code: 'invalid_scope',
-    });
-  });
-
-  test('passes audience and scope options through to createSession when called with null', async () => {
+  test('passes audience and scope through when creating a new session', async () => {
     let capturedBody: Record<string, unknown> = {};
 
     server.use(
@@ -398,10 +306,44 @@ describe('getTokenSilently', () => {
     );
 
     const client = makeClient();
-    await client.getTokenSilently(null, { audience: 'https://api.example.com', scope: 'openid' });
+    await client.getTokenSilently({ audience: 'https://api.example.com', scope: 'openid' });
 
     expect(capturedBody.audience).toBe('https://api.example.com');
     expect(capturedBody.scope).toBe('openid');
+    expect(capturedBody.session_token).toBeUndefined();
+  });
+
+  test('silently creates a new session when session_expired is encountered', async () => {
+    const client = makeClient();
+    const result = await client.getTokenSilently({ sessionToken: 'expired-session-token' });
+
+    expect(result.sessionToken).toBe(sessionToken);
+    expect(result.accessToken).toBe(accessToken);
+  });
+
+  test('silently creates a new session when invalid_session_token is encountered', async () => {
+    const client = makeClient();
+    const result = await client.getTokenSilently({ sessionToken: 'invalid-session-token' });
+
+    expect(result.sessionToken).toBe(sessionToken);
+    expect(result.accessToken).toBe(accessToken);
+  });
+
+  test('propagates non-session errors to the caller', async () => {
+    server.use(
+      http.post(`https://${domain}/anonymous/token`, () =>
+        HttpResponse.json(
+          { error: 'invalid_scope', error_description: 'Requested scope not allowed' },
+          { status: 400 }
+        )
+      )
+    );
+
+    const client = makeClient();
+    await expect(client.getTokenSilently({ sessionToken })).rejects.toMatchObject({
+      name: 'AnonymousSessionError',
+      code: 'invalid_scope',
+    });
   });
 });
 
@@ -410,10 +352,10 @@ describe('getTokenSilently', () => {
 describe('logout', () => {
   test('ends the anonymous session', async () => {
     const client = makeClient();
-    await expect(client.logout(sessionToken)).resolves.toBeUndefined();
+    await expect(client.logout()).resolves.toBeUndefined();
   });
 
-  test('sends client_id and session_token in the request body', async () => {
+  test('sends client_id in the request body', async () => {
     let capturedBody: Record<string, unknown> = {};
 
     server.use(
@@ -424,16 +366,24 @@ describe('logout', () => {
     );
 
     const client = makeClient();
-    await client.logout('my-session-token');
+    await client.logout();
 
     expect(capturedBody.client_id).toBe(clientId);
-    expect(capturedBody.session_token).toBe('my-session-token');
+    expect(capturedBody.session_token).toBeUndefined();
   });
 
-  test('throws AnonymousSessionError when session is not found', async () => {
-    const client = makeClient();
+  test('throws AnonymousSessionError when server returns an error', async () => {
+    server.use(
+      http.post(`https://${domain}/anonymous/logout`, () =>
+        HttpResponse.json(
+          { error: 'invalid_session_token', error_description: 'Session token not found' },
+          { status: 400 }
+        )
+      )
+    );
 
-    await expect(client.logout('unknown-session-token')).rejects.toMatchObject({
+    const client = makeClient();
+    await expect(client.logout()).rejects.toMatchObject({
       name: 'AnonymousSessionError',
       code: 'invalid_session_token',
     });
@@ -447,7 +397,7 @@ describe('logout', () => {
     );
 
     const client = makeClient();
-    const error = await client.logout(sessionToken).catch((e) => e);
+    const error = await client.logout().catch((e) => e);
 
     expect(error).toBeInstanceOf(AnonymousSessionError);
     expect(error.code).toBe('server_error');

--- a/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.spec.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.spec.ts
@@ -1,0 +1,485 @@
+import { expect, test, describe, beforeAll, afterAll, afterEach, vi } from 'vitest';
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+import { AnonymousSessionClient } from './anonymous-session-client.js';
+import { AnonymousSessionError } from './errors.js';
+
+const domain = 'auth0.local';
+const clientId = 'test-client-id';
+const sessionToken = 'test-session-token';
+const accessToken = 'test-access-token';
+
+const makeClient = (overrides?: Partial<ConstructorParameters<typeof AnonymousSessionClient>[0]>) =>
+  new AnonymousSessionClient({ domain, clientId, ...overrides });
+
+// ─── MSW server ──────────────────────────────────────────────────────────────
+
+const restHandlers = [
+  http.post(`https://${domain}/anonymous/token`, async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>;
+
+    // Simulate session_expired when a known expired token is passed
+    if (body.session_token === 'expired-session-token') {
+      return HttpResponse.json(
+        { error: 'session_expired', error_description: 'The session has expired' },
+        { status: 400 }
+      );
+    }
+
+    // Simulate invalid_session_token
+    if (body.session_token === 'invalid-session-token') {
+      return HttpResponse.json(
+        { error: 'invalid_session_token', error_description: 'The session token is invalid' },
+        { status: 400 }
+      );
+    }
+
+    // Simulate feature_not_enabled
+    if (body.client_id === 'disabled-client') {
+      return HttpResponse.json(
+        { error: 'feature_not_enabled', error_description: 'Anonymous sessions are not enabled for this tenant' },
+        { status: 403 }
+      );
+    }
+
+    // Simulate metadata_too_large
+    if (body.metadata && JSON.stringify(body.metadata).length > 1024) {
+      return HttpResponse.json(
+        { error: 'metadata_too_large', error_description: 'Metadata exceeds 1 KB limit' },
+        { status: 400 }
+      );
+    }
+
+    // Re-mint: session_token present → return only access_token (no session_token in response)
+    if (body.session_token) {
+      return HttpResponse.json({
+        access_token: 'renewed-access-token',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        scope: body.scope ?? 'openid',
+      });
+    }
+
+    // Create: no session_token → return both tokens
+    return HttpResponse.json({
+      access_token: accessToken,
+      token_type: 'Bearer',
+      expires_in: 3600,
+      scope: body.scope ?? 'openid',
+      session_token: sessionToken,
+    });
+  }),
+
+  http.post(`https://${domain}/anonymous/logout`, async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>;
+
+    if (body.session_token === 'unknown-session-token') {
+      return HttpResponse.json(
+        { error: 'invalid_session_token', error_description: 'Session token not found' },
+        { status: 400 }
+      );
+    }
+
+    return new HttpResponse(null, { status: 204 });
+  }),
+];
+
+const server = setupServer(...restHandlers);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+// ─── createSession ────────────────────────────────────────────────────────────
+
+describe('createSession', () => {
+  test('creates a new anonymous session and returns session + access token', async () => {
+    const client = makeClient();
+    const session = await client.createSession();
+
+    expect(session.sessionToken).toBe(sessionToken);
+    expect(session.accessToken).toBe(accessToken);
+    expect(session.expiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+
+  test('sends audience and scope when provided', async () => {
+    let capturedBody: Record<string, unknown> = {};
+
+    server.use(
+      http.post(`https://${domain}/anonymous/token`, async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          access_token: accessToken,
+          token_type: 'Bearer',
+          expires_in: 3600,
+          session_token: sessionToken,
+        });
+      })
+    );
+
+    const client = makeClient();
+    await client.createSession({ audience: 'https://api.example.com', scope: 'openid profile' });
+
+    expect(capturedBody.audience).toBe('https://api.example.com');
+    expect(capturedBody.scope).toBe('openid profile');
+    expect(capturedBody.client_id).toBe(clientId);
+  });
+
+  test('sends metadata when provided', async () => {
+    let capturedBody: Record<string, unknown> = {};
+
+    server.use(
+      http.post(`https://${domain}/anonymous/token`, async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          access_token: accessToken,
+          token_type: 'Bearer',
+          expires_in: 3600,
+          session_token: sessionToken,
+        });
+      })
+    );
+
+    const client = makeClient();
+    await client.createSession({ metadata: { source: 'landing-page', referral: 'newsletter' } });
+
+    expect(capturedBody.metadata).toEqual({ source: 'landing-page', referral: 'newsletter' });
+  });
+
+  test('does not include session_token in the request body', async () => {
+    let capturedBody: Record<string, unknown> = {};
+
+    server.use(
+      http.post(`https://${domain}/anonymous/token`, async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          access_token: accessToken,
+          token_type: 'Bearer',
+          expires_in: 3600,
+          session_token: sessionToken,
+        });
+      })
+    );
+
+    const client = makeClient();
+    await client.createSession();
+
+    expect(capturedBody.session_token).toBeUndefined();
+  });
+
+  test('sends request with credentials: include', async () => {
+    let capturedRequest: Request | null = null;
+
+    server.use(
+      http.post(`https://${domain}/anonymous/token`, async ({ request }) => {
+        capturedRequest = request;
+        return HttpResponse.json({
+          access_token: accessToken,
+          token_type: 'Bearer',
+          expires_in: 3600,
+          session_token: sessionToken,
+        });
+      })
+    );
+
+    const client = makeClient();
+    await client.createSession();
+
+    // credentials: 'include' is a fetch init option — verify the request was made
+    expect(capturedRequest).not.toBeNull();
+  });
+
+  test('throws AnonymousSessionError when feature is not enabled', async () => {
+    const client = new AnonymousSessionClient({ domain, clientId: 'disabled-client' });
+
+    await expect(client.createSession()).rejects.toMatchObject({
+      name: 'AnonymousSessionError',
+      code: 'feature_not_enabled',
+    });
+  });
+
+  test('throws AnonymousSessionError with cause when API returns an error', async () => {
+    const client = new AnonymousSessionClient({ domain, clientId: 'disabled-client' });
+
+    const error = await client.createSession().catch((e) => e);
+
+    expect(error).toBeInstanceOf(AnonymousSessionError);
+    expect(error.cause).toMatchObject({
+      error: 'feature_not_enabled',
+      error_description: expect.any(String),
+    });
+  });
+
+  test('throws AnonymousSessionError when server returns non-JSON error', async () => {
+    server.use(
+      http.post(`https://${domain}/anonymous/token`, () =>
+        new HttpResponse('Internal Server Error', { status: 500, headers: { 'Content-Type': 'text/plain' } })
+      )
+    );
+
+    const client = makeClient();
+    const error = await client.createSession().catch((e) => e);
+
+    expect(error).toBeInstanceOf(AnonymousSessionError);
+    expect(error.code).toBe('server_error');
+  });
+
+  test('throws AnonymousSessionError when session_token is missing from response', async () => {
+    server.use(
+      http.post(`https://${domain}/anonymous/token`, () =>
+        HttpResponse.json({
+          access_token: accessToken,
+          token_type: 'Bearer',
+          expires_in: 3600,
+          // session_token intentionally omitted
+        })
+      )
+    );
+
+    const client = makeClient();
+    await expect(client.createSession()).rejects.toMatchObject({
+      code: 'server_error',
+    });
+  });
+});
+
+// ─── getToken ─────────────────────────────────────────────────────────────────
+
+describe('getToken', () => {
+  test('re-mints access token using existing session token', async () => {
+    const client = makeClient();
+    const session = await client.getToken(sessionToken);
+
+    expect(session.accessToken).toBe('renewed-access-token');
+    expect(session.sessionToken).toBe(sessionToken); // session token unchanged
+    expect(session.expiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+
+  test('sends the session_token in the request body', async () => {
+    let capturedBody: Record<string, unknown> = {};
+
+    server.use(
+      http.post(`https://${domain}/anonymous/token`, async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          access_token: 'renewed-access-token',
+          token_type: 'Bearer',
+          expires_in: 3600,
+        });
+      })
+    );
+
+    const client = makeClient();
+    await client.getToken('my-session-token', { audience: 'https://api.example.com' });
+
+    expect(capturedBody.session_token).toBe('my-session-token');
+    expect(capturedBody.audience).toBe('https://api.example.com');
+    expect(capturedBody.client_id).toBe(clientId);
+  });
+
+  test('throws AnonymousSessionError with session_expired code', async () => {
+    const client = makeClient();
+
+    await expect(client.getToken('expired-session-token')).rejects.toMatchObject({
+      name: 'AnonymousSessionError',
+      code: 'session_expired',
+    });
+  });
+
+  test('throws AnonymousSessionError with invalid_session_token code', async () => {
+    const client = makeClient();
+
+    await expect(client.getToken('invalid-session-token')).rejects.toMatchObject({
+      name: 'AnonymousSessionError',
+      code: 'invalid_session_token',
+    });
+  });
+});
+
+// ─── getTokenSilently ─────────────────────────────────────────────────────────
+
+describe('getTokenSilently', () => {
+  test('creates a new session when called with null', async () => {
+    const client = makeClient();
+    const session = await client.getTokenSilently(null);
+
+    expect(session.sessionToken).toBe(sessionToken);
+    expect(session.accessToken).toBe(accessToken);
+  });
+
+  test('returns the existing session unchanged when access token is still valid', async () => {
+    const client = makeClient();
+    const fetchSpy = vi.fn();
+    server.use(
+      http.post(`https://${domain}/anonymous/token`, () => {
+        fetchSpy();
+        return HttpResponse.json({});
+      })
+    );
+
+    const futureExpiry = Math.floor(Date.now() / 1000) + 3600;
+    const existingSession = {
+      sessionToken,
+      accessToken,
+      expiresAt: futureExpiry,
+    };
+
+    const result = await client.getTokenSilently(existingSession);
+
+    expect(result).toBe(existingSession); // same reference
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test('renews access token when it is expired', async () => {
+    const client = makeClient();
+    const expiredSession = {
+      sessionToken,
+      accessToken: 'old-access-token',
+      expiresAt: Math.floor(Date.now() / 1000) - 60, // expired 1 minute ago
+    };
+
+    const result = await client.getTokenSilently(expiredSession);
+
+    expect(result.accessToken).toBe('renewed-access-token');
+    expect(result.sessionToken).toBe(sessionToken); // session token unchanged
+  });
+
+  test('silently creates a new session when session_expired is encountered during renewal', async () => {
+    const client = makeClient();
+    const expiredSession = {
+      sessionToken: 'expired-session-token',
+      accessToken: 'old-access-token',
+      expiresAt: Math.floor(Date.now() / 1000) - 60,
+    };
+
+    // Should silently fall back to createSession and succeed
+    const result = await client.getTokenSilently(expiredSession);
+
+    expect(result.sessionToken).toBe(sessionToken); // fresh session
+    expect(result.accessToken).toBe(accessToken);
+  });
+
+  test('silently creates a new session when invalid_session_token is encountered during renewal', async () => {
+    const client = makeClient();
+    const invalidSession = {
+      sessionToken: 'invalid-session-token',
+      accessToken: 'old-access-token',
+      expiresAt: Math.floor(Date.now() / 1000) - 60,
+    };
+
+    const result = await client.getTokenSilently(invalidSession);
+
+    expect(result.sessionToken).toBe(sessionToken);
+    expect(result.accessToken).toBe(accessToken);
+  });
+
+  test('propagates non-session errors to the caller', async () => {
+    const client = makeClient();
+    const expiredSession = {
+      sessionToken,
+      accessToken: 'old-access-token',
+      expiresAt: Math.floor(Date.now() / 1000) - 60,
+    };
+
+    // Override to return a non-recoverable error
+    server.use(
+      http.post(`https://${domain}/anonymous/token`, () =>
+        HttpResponse.json(
+          { error: 'invalid_scope', error_description: 'Requested scope not allowed' },
+          { status: 400 }
+        )
+      )
+    );
+
+    await expect(client.getTokenSilently(expiredSession)).rejects.toMatchObject({
+      name: 'AnonymousSessionError',
+      code: 'invalid_scope',
+    });
+  });
+
+  test('passes audience and scope options through to createSession when called with null', async () => {
+    let capturedBody: Record<string, unknown> = {};
+
+    server.use(
+      http.post(`https://${domain}/anonymous/token`, async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          access_token: accessToken,
+          token_type: 'Bearer',
+          expires_in: 3600,
+          session_token: sessionToken,
+        });
+      })
+    );
+
+    const client = makeClient();
+    await client.getTokenSilently(null, { audience: 'https://api.example.com', scope: 'openid' });
+
+    expect(capturedBody.audience).toBe('https://api.example.com');
+    expect(capturedBody.scope).toBe('openid');
+  });
+});
+
+// ─── logout ───────────────────────────────────────────────────────────────────
+
+describe('logout', () => {
+  test('ends the anonymous session', async () => {
+    const client = makeClient();
+    await expect(client.logout(sessionToken)).resolves.toBeUndefined();
+  });
+
+  test('sends client_id and session_token in the request body', async () => {
+    let capturedBody: Record<string, unknown> = {};
+
+    server.use(
+      http.post(`https://${domain}/anonymous/logout`, async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return new HttpResponse(null, { status: 204 });
+      })
+    );
+
+    const client = makeClient();
+    await client.logout('my-session-token');
+
+    expect(capturedBody.client_id).toBe(clientId);
+    expect(capturedBody.session_token).toBe('my-session-token');
+  });
+
+  test('throws AnonymousSessionError when session is not found', async () => {
+    const client = makeClient();
+
+    await expect(client.logout('unknown-session-token')).rejects.toMatchObject({
+      name: 'AnonymousSessionError',
+      code: 'invalid_session_token',
+    });
+  });
+
+  test('throws AnonymousSessionError when server returns non-JSON error on logout', async () => {
+    server.use(
+      http.post(`https://${domain}/anonymous/logout`, () =>
+        new HttpResponse('Service Unavailable', { status: 503, headers: { 'Content-Type': 'text/plain' } })
+      )
+    );
+
+    const client = makeClient();
+    const error = await client.logout(sessionToken).catch((e) => e);
+
+    expect(error).toBeInstanceOf(AnonymousSessionError);
+    expect(error.code).toBe('server_error');
+  });
+});
+
+// ─── expiresAt calculation ────────────────────────────────────────────────────
+
+describe('expiresAt', () => {
+  test('sets expiresAt to approximately now + expires_in seconds', async () => {
+    const client = makeClient();
+    const before = Math.floor(Date.now() / 1000);
+    const session = await client.createSession();
+    const after = Math.floor(Date.now() / 1000);
+
+    // expires_in is 3600 in the mock
+    expect(session.expiresAt).toBeGreaterThanOrEqual(before + 3600);
+    expect(session.expiresAt).toBeLessThanOrEqual(after + 3600);
+  });
+});

--- a/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.spec.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.spec.ts
@@ -168,25 +168,10 @@ describe('createSession', () => {
   });
 
   test('sends request with credentials: include', async () => {
-    let capturedRequest: Request | null = null;
-
-    server.use(
-      http.post(`https://${domain}/anonymous/token`, async ({ request }) => {
-        capturedRequest = request;
-        return HttpResponse.json({
-          access_token: accessToken,
-          token_type: 'Bearer',
-          expires_in: 3600,
-          session_token: sessionToken,
-        });
-      })
-    );
-
-    const client = makeClient();
+    const spy = vi.fn((...args: Parameters<typeof fetch>) => fetch(...args));
+    const client = makeClient({ customFetch: spy });
     await client.createSession();
-
-    // credentials: 'include' is a fetch init option — verify the request was made
-    expect(capturedRequest).not.toBeNull();
+    expect(spy.mock.calls[0][1]).toMatchObject({ credentials: 'include' });
   });
 
   test('throws AnonymousSessionError when feature is not enabled', async () => {

--- a/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.spec.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.spec.ts
@@ -218,6 +218,24 @@ describe('createSession', () => {
     });
   });
 
+  test('throws AnonymousSessionError when access_token is missing from response', async () => {
+    server.use(
+      http.post(`https://${domain}/anonymous/token`, () =>
+        HttpResponse.json({
+          // access_token intentionally omitted
+          token_type: 'Bearer',
+          expires_in: 3600,
+          session_token: sessionToken,
+        })
+      )
+    );
+
+    const client = makeClient();
+    await expect(client.createSession()).rejects.toMatchObject({
+      code: 'server_error',
+    });
+  });
+
   test('throws AnonymousSessionError when expires_in is missing from response', async () => {
     server.use(
       http.post(`https://${domain}/anonymous/token`, () =>

--- a/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
@@ -79,12 +79,13 @@ async function parseErrorResponse(response: Response): Promise<AnonymousSessionA
  * });
  *
  * // End the session
- * await authClient.anonymous.logout(updatedSession.sessionToken);
+ * await authClient.anonymous.logout();
  * ```
  */
 export class AnonymousSessionClient {
   readonly #baseUrl: string;
   readonly #clientId: string;
+  readonly #clientSecret?: string;
   readonly #customFetch: typeof fetch;
 
   /**
@@ -93,6 +94,7 @@ export class AnonymousSessionClient {
   constructor(options: AnonymousSessionClientOptions) {
     this.#baseUrl = `https://${options.domain}`;
     this.#clientId = options.clientId;
+    this.#clientSecret = options.clientSecret;
     this.#customFetch = options.customFetch ?? ((...args) => fetch(...args));
   }
 
@@ -152,28 +154,64 @@ export class AnonymousSessionClient {
   }
 
   /**
-   * Obtains a new access token for an existing anonymous session.
+   * Returns a valid anonymous session, creating or renewing it as needed.
    *
-   * Calls `POST /anonymous/token` with the current session token to re-mint a
-   * short-lived access token. The anonymous identity and session token remain
-   * unchanged. Metadata cannot be passed on re-mint.
+   * This is the primary entry point for obtaining an anonymous access token.
+   * The calling SDK (auth0-spa-js, auth0-server-js) is responsible for checking
+   * token expiry and deciding when to call this method.
    *
-   * @param sessionToken - The session token from a previously created anonymous session
-   * @param options - Options for the renewed token
+   * Behaviour:
+   * 1. No `sessionToken` — creates a fresh anonymous session.
+   * 2. `sessionToken` provided — re-mints the access token for the existing session.
+   * 3. If the session token has expired (`session_expired` or `invalid_session_token`)
+   *    — silently creates a fresh anonymous session instead.
+   *    **Any metadata previously attached to the session is permanently lost.**
+   * 4. For all other errors — throws an {@link AnonymousSessionError}.
+   *
+   * @param options - Options for the token request
+   * @param options.sessionToken - The session token from an existing anonymous session.
+   *   Omit to create a new session.
    * @param options.audience - The API audience to scope the access token to
    * @param options.scope - Space-separated list of scopes to request
-   * @returns An updated session with a fresh access token and the same session token
-   * @throws {AnonymousSessionError} When the request fails, including `session_expired`
-   *   or `invalid_session_token` if the session token is no longer valid
+   * @returns A valid anonymous session (may be newly created or renewed)
+   * @throws {AnonymousSessionError} For non-recoverable errors
    *
    * @example
    * ```typescript
-   * const refreshed = await authClient.anonymous.getToken(session.sessionToken, {
+   * // First visit — no session yet
+   * const session = await authClient.anonymous.getTokenSilently({
+   *   audience: 'https://api.example.com',
+   * });
+   *
+   * // Subsequent visit — renew existing session token
+   * const renewed = await authClient.anonymous.getTokenSilently({
+   *   sessionToken: storedSessionToken,
    *   audience: 'https://api.example.com',
    * });
    * ```
    */
-  async getToken(sessionToken: string, options?: GetAnonymousTokenSilentlyOptions): Promise<AnonymousSession> {
+  async getTokenSilently(options?: GetAnonymousTokenSilentlyOptions): Promise<AnonymousSession> {
+    if (!options?.sessionToken) {
+      return this.createSession({ audience: options?.audience, scope: options?.scope });
+    }
+
+    try {
+      return await this.#mintToken(options.sessionToken, options);
+    } catch (e) {
+      if (e instanceof AnonymousSessionError && SESSION_INVALIDATION_CODES.has(e.code)) {
+        // Session token expired or invalid — silently start a fresh session.
+        // Any metadata attached to the old session is permanently lost.
+        return this.createSession({ audience: options?.audience, scope: options?.scope });
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Re-mints an access token for an existing anonymous session.
+   * Internal — callers use {@link getTokenSilently} instead.
+   */
+  async #mintToken(sessionToken: string, options?: GetAnonymousTokenSilentlyOptions): Promise<AnonymousSession> {
     const body: Record<string, unknown> = {
       client_id: this.#clientId,
       session_token: sessionToken,
@@ -197,84 +235,33 @@ export class AnonymousSessionClient {
   }
 
   /**
-   * Returns a valid anonymous session, creating or renewing it as needed.
-   *
-   * Implements the full token renewal lifecycle:
-   * 1. If `session` is `null` — creates a new anonymous session.
-   * 2. If the access token is still valid — returns the session unchanged.
-   * 3. If the access token is expired — re-mints it using the session token.
-   * 4. If the session token has also expired (`session_expired` or
-   *    `invalid_session_token`) — silently creates a fresh anonymous session.
-   *    **Any metadata previously attached to the session is permanently lost.**
-   * 5. For all other errors — throws an {@link AnonymousSessionError}.
-   *
-   * @param session - The current anonymous session, or `null` if none exists
-   * @param options - Options for the token request
-   * @param options.audience - The API audience to scope the access token to
-   * @param options.scope - Space-separated list of scopes to request
-   * @returns A valid anonymous session (may be the same object, renewed, or brand-new)
-   * @throws {AnonymousSessionError} For non-recoverable errors
-   *
-   * @example
-   * ```typescript
-   * // Stored session from a previous visit (may or may not be expired)
-   * let session = loadSessionFromStorage();
-   *
-   * session = await authClient.anonymous.getTokenSilently(session, {
-   *   audience: 'https://api.example.com',
-   * });
-   *
-   * // session.accessToken is guaranteed to be valid at this point
-   * ```
-   */
-  async getTokenSilently(
-    session: AnonymousSession | null,
-    options?: GetAnonymousTokenSilentlyOptions
-  ): Promise<AnonymousSession> {
-    // No session — create one from scratch
-    if (!session) {
-      return this.createSession(options);
-    }
-
-    // Access token is still valid — nothing to do
-    const now = Math.floor(Date.now() / 1000);
-    if (session.expiresAt > now) {
-      return session;
-    }
-
-    // Access token expired — try to re-mint using the session token
-    try {
-      return await this.getToken(session.sessionToken, options);
-    } catch (e) {
-      if (e instanceof AnonymousSessionError && SESSION_INVALIDATION_CODES.has(e.code)) {
-        // Session token also expired or invalid — silently start a fresh session.
-        // Any metadata attached to the old session is permanently lost.
-        return this.createSession(options);
-      }
-      throw e;
-    }
-  }
-
-  /**
    * Ends an anonymous session.
    *
    * Calls `POST /anonymous/logout` to invalidate the session on Auth0's side.
-   * After this call the session token can no longer be used to mint access tokens.
+   * The anonymous session is identified via the `auth0_anon` cookie, which is
+   * sent automatically through `credentials: 'include'`.
    *
    * Note: Any access tokens issued before logout remain valid until they naturally
    * expire. There is no server-side session store to revoke them from.
    *
-   * @param sessionToken - The session token of the anonymous session to end
    * @returns Promise that resolves when the session has been ended
    * @throws {AnonymousSessionError} When the request fails
    *
    * @example
    * ```typescript
-   * await authClient.anonymous.logout(session.sessionToken);
+   * await authClient.anonymous.logout();
    * ```
    */
-  async logout(sessionToken: string): Promise<void> {
+  async logout(): Promise<void> {
     const url = `${this.#baseUrl}/anonymous/logout`;
+
+    const body: Record<string, unknown> = {
+      client_id: this.#clientId,
+    };
+
+    if (this.#clientSecret) {
+      body.client_secret = this.#clientSecret;
+    }
 
     const response = await this.#customFetch(url, {
       method: 'POST',
@@ -282,10 +269,7 @@ export class AnonymousSessionClient {
         'Content-Type': 'application/json',
       },
       credentials: 'include',
-      body: JSON.stringify({
-        client_id: this.#clientId,
-        session_token: sessionToken,
-      }),
+      body: JSON.stringify(body),
     });
 
     if (!response.ok) {
@@ -303,6 +287,10 @@ export class AnonymousSessionClient {
    */
   async #postAnonymousToken(body: Record<string, unknown>): Promise<AnonymousTokens> {
     const url = `${this.#baseUrl}/anonymous/token`;
+
+    if (this.#clientSecret) {
+      body.client_secret = this.#clientSecret;
+    }
 
     const response = await this.#customFetch(url, {
       method: 'POST',

--- a/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
@@ -1,0 +1,324 @@
+import { AnonymousSessionError, type AnonymousSessionApiErrorResponse } from './errors.js';
+import type {
+  AnonymousSessionClientOptions,
+  AnonymousSession,
+  AnonymousTokens,
+  AnonymousTokenApiResponse,
+  CreateAnonymousSessionOptions,
+  GetAnonymousTokenSilentlyOptions,
+} from './types.js';
+
+/**
+ * Error codes that indicate the session token is no longer valid.
+ * When these are received during token renewal, the SDK silently creates
+ * a fresh anonymous session instead of surfacing an error.
+ */
+const SESSION_INVALIDATION_CODES = new Set(['session_expired', 'invalid_session_token']);
+
+/**
+ * Parses an Auth0 token API response into an {@link AnonymousTokens} object.
+ */
+function parseTokenResponse(apiResponse: AnonymousTokenApiResponse): AnonymousTokens {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    accessToken: apiResponse.access_token,
+    expiresIn: apiResponse.expires_in,
+    expiresAt: now + apiResponse.expires_in,
+    scope: apiResponse.scope,
+    sessionToken: apiResponse.session_token,
+  };
+}
+
+/**
+ * Reads and parses an error response body, falling back to a generic error shape
+ * if the body cannot be parsed as JSON.
+ */
+async function parseErrorResponse(response: Response): Promise<AnonymousSessionApiErrorResponse> {
+  try {
+    return (await response.json()) as AnonymousSessionApiErrorResponse;
+  } catch {
+    return {
+      error: 'server_error',
+      error_description: `Request failed with status ${response.status}`,
+    };
+  }
+}
+
+/**
+ * Client for anonymous session operations.
+ *
+ * Provides low-level HTTP calls to the Auth0 anonymous session endpoints as well
+ * as a higher-level {@link getTokenSilently} method that implements the renewal
+ * logic: if the access token is expired it re-mints it from the session token;
+ * if the session token itself has expired a fresh anonymous session is created
+ * silently (any metadata previously set on the session is lost at that point).
+ *
+ * This client is exposed on {@link AuthClient} as `authClient.anonymous`.
+ *
+ * **Prerequisites:**
+ * - The tenant must have the `anonymous_sessions_enabled` feature flag enabled.
+ * - The client ID must be configured for anonymous sessions via the Management API.
+ * - Any resource server you want to call with an anonymous token must have
+ *   `allow_anonymous_access: true` and a `subject_type_authorization` policy set.
+ *
+ * @example
+ * ```typescript
+ * // Create a session
+ * const session = await authClient.anonymous.createSession({
+ *   audience: 'https://api.example.com',
+ *   metadata: { referral: 'homepage' },
+ * });
+ *
+ * // Later, get a valid access token (renews automatically if expired)
+ * const updatedSession = await authClient.anonymous.getTokenSilently(session, {
+ *   audience: 'https://api.example.com',
+ * });
+ *
+ * // End the session
+ * await authClient.anonymous.logout(updatedSession.sessionToken);
+ * ```
+ */
+export class AnonymousSessionClient {
+  readonly #baseUrl: string;
+  readonly #clientId: string;
+  readonly #customFetch: typeof fetch;
+
+  /**
+   * @internal
+   */
+  constructor(options: AnonymousSessionClientOptions) {
+    this.#baseUrl = `https://${options.domain}`;
+    this.#clientId = options.clientId;
+    this.#customFetch = options.customFetch ?? ((...args) => fetch(...args));
+  }
+
+  /**
+   * Creates a new anonymous session.
+   *
+   * Calls `POST /anonymous/token` without a session token to establish a fresh
+   * anonymous identity. Returns a session containing both the session token (for
+   * future renewal) and an access token (for calling APIs).
+   *
+   * Optionally accepts up to 1 KB of metadata that is attached to the anonymous
+   * identity at creation time. Metadata is **set once** and cannot be changed
+   * after the session is created.
+   *
+   * @param options - Options for the new session
+   * @param options.audience - The API audience to scope the access token to
+   * @param options.scope - Space-separated list of scopes to request
+   * @param options.metadata - Up to 1 KB of key-value metadata (set-once)
+   * @returns The newly created anonymous session
+   * @throws {AnonymousSessionError} When the request fails
+   *
+   * @example
+   * ```typescript
+   * const session = await authClient.anonymous.createSession({
+   *   audience: 'https://api.example.com',
+   *   metadata: { source: 'landing-page' },
+   * });
+   * ```
+   */
+  async createSession(options?: CreateAnonymousSessionOptions): Promise<AnonymousSession> {
+    const body: Record<string, unknown> = {
+      client_id: this.#clientId,
+    };
+
+    if (options?.audience) {
+      body.audience = options.audience;
+    }
+    if (options?.scope) {
+      body.scope = options.scope;
+    }
+    if (options?.metadata) {
+      body.metadata = options.metadata;
+    }
+
+    const tokens = await this.#postAnonymousToken(body);
+
+    if (!tokens.sessionToken) {
+      throw new AnonymousSessionError('server_error', 'session_token missing from create session response');
+    }
+
+    return {
+      sessionToken: tokens.sessionToken,
+      accessToken: tokens.accessToken,
+      expiresAt: tokens.expiresAt,
+      scope: tokens.scope,
+    };
+  }
+
+  /**
+   * Obtains a new access token for an existing anonymous session.
+   *
+   * Calls `POST /anonymous/token` with the current session token to re-mint a
+   * short-lived access token. The anonymous identity and session token remain
+   * unchanged. Metadata cannot be passed on re-mint.
+   *
+   * @param sessionToken - The session token from a previously created anonymous session
+   * @param options - Options for the renewed token
+   * @param options.audience - The API audience to scope the access token to
+   * @param options.scope - Space-separated list of scopes to request
+   * @returns An updated session with a fresh access token and the same session token
+   * @throws {AnonymousSessionError} When the request fails, including `session_expired`
+   *   or `invalid_session_token` if the session token is no longer valid
+   *
+   * @example
+   * ```typescript
+   * const refreshed = await authClient.anonymous.getToken(session.sessionToken, {
+   *   audience: 'https://api.example.com',
+   * });
+   * ```
+   */
+  async getToken(sessionToken: string, options?: GetAnonymousTokenSilentlyOptions): Promise<AnonymousSession> {
+    const body: Record<string, unknown> = {
+      client_id: this.#clientId,
+      session_token: sessionToken,
+    };
+
+    if (options?.audience) {
+      body.audience = options.audience;
+    }
+    if (options?.scope) {
+      body.scope = options.scope;
+    }
+
+    const tokens = await this.#postAnonymousToken(body);
+
+    return {
+      sessionToken,
+      accessToken: tokens.accessToken,
+      expiresAt: tokens.expiresAt,
+      scope: tokens.scope,
+    };
+  }
+
+  /**
+   * Returns a valid anonymous session, creating or renewing it as needed.
+   *
+   * Implements the full token renewal lifecycle:
+   * 1. If `session` is `null` — creates a new anonymous session.
+   * 2. If the access token is still valid — returns the session unchanged.
+   * 3. If the access token is expired — re-mints it using the session token.
+   * 4. If the session token has also expired (`session_expired` or
+   *    `invalid_session_token`) — silently creates a fresh anonymous session.
+   *    **Any metadata previously attached to the session is permanently lost.**
+   * 5. For all other errors — throws an {@link AnonymousSessionError}.
+   *
+   * @param session - The current anonymous session, or `null` if none exists
+   * @param options - Options for the token request
+   * @param options.audience - The API audience to scope the access token to
+   * @param options.scope - Space-separated list of scopes to request
+   * @returns A valid anonymous session (may be the same object, renewed, or brand-new)
+   * @throws {AnonymousSessionError} For non-recoverable errors
+   *
+   * @example
+   * ```typescript
+   * // Stored session from a previous visit (may or may not be expired)
+   * let session = loadSessionFromStorage();
+   *
+   * session = await authClient.anonymous.getTokenSilently(session, {
+   *   audience: 'https://api.example.com',
+   * });
+   *
+   * // session.accessToken is guaranteed to be valid at this point
+   * ```
+   */
+  async getTokenSilently(
+    session: AnonymousSession | null,
+    options?: GetAnonymousTokenSilentlyOptions
+  ): Promise<AnonymousSession> {
+    // No session — create one from scratch
+    if (!session) {
+      return this.createSession(options);
+    }
+
+    // Access token is still valid — nothing to do
+    const now = Math.floor(Date.now() / 1000);
+    if (session.expiresAt > now) {
+      return session;
+    }
+
+    // Access token expired — try to re-mint using the session token
+    try {
+      return await this.getToken(session.sessionToken, options);
+    } catch (e) {
+      if (e instanceof AnonymousSessionError && SESSION_INVALIDATION_CODES.has(e.code)) {
+        // Session token also expired or invalid — silently start a fresh session.
+        // Any metadata attached to the old session is permanently lost.
+        return this.createSession(options);
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Ends an anonymous session.
+   *
+   * Calls `POST /anonymous/logout` to invalidate the session on Auth0's side.
+   * After this call the session token can no longer be used to mint access tokens.
+   *
+   * Note: Any access tokens issued before logout remain valid until they naturally
+   * expire. There is no server-side session store to revoke them from.
+   *
+   * @param sessionToken - The session token of the anonymous session to end
+   * @returns Promise that resolves when the session has been ended
+   * @throws {AnonymousSessionError} When the request fails
+   *
+   * @example
+   * ```typescript
+   * await authClient.anonymous.logout(session.sessionToken);
+   * ```
+   */
+  async logout(sessionToken: string): Promise<void> {
+    const url = `${this.#baseUrl}/anonymous/logout`;
+
+    const response = await this.#customFetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
+      body: JSON.stringify({
+        client_id: this.#clientId,
+        session_token: sessionToken,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorBody = await parseErrorResponse(response);
+      throw new AnonymousSessionError(
+        errorBody.error,
+        errorBody.error_description || 'Failed to end anonymous session',
+        errorBody
+      );
+    }
+  }
+
+  /**
+   * Shared helper that calls `POST /anonymous/token` and returns parsed tokens.
+   */
+  async #postAnonymousToken(body: Record<string, unknown>): Promise<AnonymousTokens> {
+    const url = `${this.#baseUrl}/anonymous/token`;
+
+    const response = await this.#customFetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorBody = await parseErrorResponse(response);
+      throw new AnonymousSessionError(
+        errorBody.error,
+        errorBody.error_description || 'Anonymous token request failed',
+        errorBody
+      );
+    }
+
+    const apiResponse = (await response.json()) as AnonymousTokenApiResponse;
+    return parseTokenResponse(apiResponse);
+  }
+}

--- a/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
@@ -20,10 +20,14 @@ const SESSION_INVALIDATION_CODES = new Set(['session_expired', 'invalid_session_
  */
 function parseTokenResponse(apiResponse: AnonymousTokenApiResponse): AnonymousTokens {
   const now = Math.floor(Date.now() / 1000);
+  const expiresIn = apiResponse.expires_in;
+  if (typeof expiresIn !== 'number' || !Number.isFinite(expiresIn)) {
+    throw new AnonymousSessionError('server_error', 'expires_in missing or invalid in anonymous token response');
+  }
   return {
     accessToken: apiResponse.access_token,
-    expiresIn: apiResponse.expires_in,
-    expiresAt: now + apiResponse.expires_in,
+    expiresIn,
+    expiresAt: now + expiresIn,
     scope: apiResponse.scope,
     sessionToken: apiResponse.session_token,
   };
@@ -318,7 +322,12 @@ export class AnonymousSessionClient {
       );
     }
 
-    const apiResponse = (await response.json()) as AnonymousTokenApiResponse;
+    let apiResponse: AnonymousTokenApiResponse;
+    try {
+      apiResponse = (await response.json()) as AnonymousTokenApiResponse;
+    } catch {
+      throw new AnonymousSessionError('server_error', 'Invalid response from anonymous token endpoint');
+    }
     return parseTokenResponse(apiResponse);
   }
 }

--- a/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
@@ -20,6 +20,9 @@ const SESSION_INVALIDATION_CODES = new Set(['session_expired', 'invalid_session_
  */
 function parseTokenResponse(apiResponse: AnonymousTokenApiResponse): AnonymousTokens {
   const now = Math.floor(Date.now() / 1000);
+  if (typeof apiResponse.access_token !== 'string' || !apiResponse.access_token) {
+    throw new AnonymousSessionError('server_error', 'access_token missing or invalid in anonymous token response');
+  }
   const expiresIn = apiResponse.expires_in;
   if (typeof expiresIn !== 'number' || !Number.isFinite(expiresIn)) {
     throw new AnonymousSessionError('server_error', 'expires_in missing or invalid in anonymous token response');
@@ -74,7 +77,8 @@ async function parseErrorResponse(response: Response): Promise<AnonymousSessionA
  * });
  *
  * // Later, get a valid access token (renews automatically if expired)
- * const updatedSession = await authClient.anonymous.getTokenSilently(session, {
+ * const updatedSession = await authClient.anonymous.getTokenSilently({
+ *   sessionToken: session.sessionToken,
  *   audience: 'https://api.example.com',
  * });
  *

--- a/packages/auth0-auth-js/src/anonymous-session/errors.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/errors.ts
@@ -1,0 +1,66 @@
+/**
+ * Shape of an error response from Auth0 anonymous session endpoints.
+ */
+export interface AnonymousSessionApiErrorResponse {
+  error: string;
+  error_description: string;
+  message?: string;
+}
+
+/**
+ * Error codes that can be set on an {@link AnonymousSessionError}.
+ *
+ * Codes that map directly to Auth0 API error responses:
+ * - `session_expired` — The session token has expired.
+ * - `invalid_session_token` — The session token is malformed.
+ * - `metadata_too_large` — The metadata payload at session creation exceeded 1 KB.
+ * - `unauthorized_client` — The client ID is not enabled for anonymous sessions.
+ * - `feature_not_enabled` — The tenant-level anonymous sessions flag is off.
+ * - `invalid_client` — Client authentication failed.
+ * - `invalid_target` — The resource server is not enabled for anonymous access.
+ * - `invalid_request` — The request was malformed or the resource server is not enabled.
+ * - `invalid_scope` — The requested scope is not granted to anonymous callers.
+ * - `server_error` — An Auth0 infrastructure error occurred.
+ */
+export type AnonymousSessionErrorCode =
+  | 'session_expired'
+  | 'invalid_session_token'
+  | 'metadata_too_large'
+  | 'unauthorized_client'
+  | 'feature_not_enabled'
+  | 'invalid_client'
+  | 'invalid_target'
+  | 'invalid_request'
+  | 'invalid_scope'
+  | 'server_error'
+  | string;
+
+/**
+ * Error thrown when an anonymous session operation fails.
+ *
+ * The `code` field identifies the specific failure reason. Codes `session_expired`
+ * and `invalid_session_token` are handled silently by {@link AnonymousSessionClient.getTokenSilently}
+ * and will never reach the caller from that method. All other codes are surfaced directly.
+ */
+export class AnonymousSessionError extends Error {
+  /**
+   * Machine-readable error code identifying the failure reason.
+   * Maps to the `error` field in the Auth0 API response.
+   */
+  public code: AnonymousSessionErrorCode;
+  /**
+   * The raw error response from Auth0, if available.
+   */
+  public cause?: AnonymousSessionApiErrorResponse;
+
+  constructor(code: AnonymousSessionErrorCode, message: string, cause?: AnonymousSessionApiErrorResponse) {
+    super(message);
+    this.name = 'AnonymousSessionError';
+    this.code = code;
+    this.cause = cause && {
+      error: cause.error,
+      error_description: cause.error_description,
+      message: cause.message,
+    };
+  }
+}

--- a/packages/auth0-auth-js/src/anonymous-session/index.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/index.ts
@@ -1,0 +1,10 @@
+export { AnonymousSessionClient } from './anonymous-session-client.js';
+export { AnonymousSessionError } from './errors.js';
+export type { AnonymousSessionErrorCode } from './errors.js';
+export type {
+  AnonymousSession,
+  AnonymousTokens,
+  AnonymousSessionClaims,
+  CreateAnonymousSessionOptions,
+  GetAnonymousTokenSilentlyOptions,
+} from './types.js';

--- a/packages/auth0-auth-js/src/anonymous-session/types.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/types.ts
@@ -12,6 +12,10 @@ export interface AnonymousSessionClientOptions {
    */
   clientId: string;
   /**
+   * The client secret. Required for confidential clients.
+   */
+  clientSecret?: string;
+  /**
    * Optional custom Fetch implementation to use.
    */
   customFetch?: typeof fetch;
@@ -77,8 +81,11 @@ export interface AnonymousTokens {
 /**
  * Decoded claims from an anonymous session token (JWT).
  *
- * Note: In EA, session tokens are issued as JWE (opaque). This type is reserved
- * as an extension point for JWT format support that may be added in the future.
+ * **Not returned by any method in EA.** In EA, session tokens are issued as
+ * opaque JWEs — they cannot be decoded client-side and no SDK method currently
+ * returns this type. It is exported for forward compatibility: if session tokens
+ * move to a readable JWT format in a future release, this interface will describe
+ * the claims shape without a breaking change.
  */
 export interface AnonymousSessionClaims {
   /** Issuer of the token. */
@@ -119,6 +126,12 @@ export interface CreateAnonymousSessionOptions {
  * Options for silently obtaining a valid anonymous access token.
  */
 export interface GetAnonymousTokenSilentlyOptions {
+  /**
+   * The session token from an existing anonymous session.
+   * When provided, the SDK will re-mint the access token using the session token.
+   * When omitted, a fresh anonymous session is created.
+   */
+  sessionToken?: string;
   /**
    * The API audience the access token should be scoped to.
    */

--- a/packages/auth0-auth-js/src/anonymous-session/types.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/types.ts
@@ -1,0 +1,146 @@
+/**
+ * Configuration options for the AnonymousSessionClient.
+ */
+export interface AnonymousSessionClientOptions {
+  /**
+   * The Auth0 domain (without https://).
+   * @example 'example.auth0.com'
+   */
+  domain: string;
+  /**
+   * The client ID of the application.
+   */
+  clientId: string;
+  /**
+   * Optional custom Fetch implementation to use.
+   */
+  customFetch?: typeof fetch;
+}
+
+/**
+ * Represents an active anonymous session.
+ *
+ * Stores both the long-lived session token (used to re-mint access tokens)
+ * and the current short-lived access token (used to call APIs).
+ */
+export interface AnonymousSession {
+  /**
+   * Long-lived handle for the anonymous identity.
+   * Never sent to APIs directly. Used by the SDK to re-mint access tokens.
+   */
+  sessionToken: string;
+  /**
+   * Short-lived Bearer token for calling APIs.
+   */
+  accessToken: string;
+  /**
+   * Unix timestamp (seconds) at which the access token expires.
+   */
+  expiresAt: number;
+  /**
+   * Scopes granted to this anonymous session.
+   */
+  scope?: string;
+}
+
+/**
+ * Tokens returned from the anonymous token endpoint.
+ *
+ * On session creation both `accessToken` and `sessionToken` are present.
+ * On token renewal (re-mint) only `accessToken` is returned; the `sessionToken`
+ * remains unchanged.
+ */
+export interface AnonymousTokens {
+  /**
+   * Short-lived Bearer token for calling APIs.
+   */
+  accessToken: string;
+  /**
+   * Number of seconds until the access token expires.
+   */
+  expiresIn: number;
+  /**
+   * Unix timestamp (seconds) at which the access token expires.
+   */
+  expiresAt: number;
+  /**
+   * Scopes granted to this token.
+   */
+  scope?: string;
+  /**
+   * Long-lived handle for the anonymous identity.
+   * Only present when a new session is created (not on re-mint).
+   */
+  sessionToken?: string;
+}
+
+/**
+ * Decoded claims from an anonymous session token (JWT).
+ *
+ * Note: In EA, session tokens are issued as JWE (opaque). This type is reserved
+ * as an extension point for JWT format support that may be added in the future.
+ */
+export interface AnonymousSessionClaims {
+  /** Issuer of the token. */
+  iss: string;
+  /** Subject — the anonymous identity, e.g. `anon@abc123`. */
+  sub: string;
+  /** Unique identifier for the anonymous session. */
+  session_id: string;
+  /** Unix timestamp when the anonymous session was created. */
+  created_at: number;
+  /** Up to 1KB of key-value metadata set at session creation time. */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Options for creating a new anonymous session.
+ *
+ * Metadata is set once at creation time and cannot be changed afterwards.
+ */
+export interface CreateAnonymousSessionOptions {
+  /**
+   * The API audience the access token should be scoped to.
+   * Must be a resource server that has `allow_anonymous_access` enabled.
+   */
+  audience?: string;
+  /**
+   * Space-separated list of scopes to request.
+   */
+  scope?: string;
+  /**
+   * Up to 1KB of arbitrary key-value metadata to attach to the anonymous session.
+   * Set once at creation time — cannot be changed after the session is created.
+   */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Options for silently obtaining a valid anonymous access token.
+ */
+export interface GetAnonymousTokenSilentlyOptions {
+  /**
+   * The API audience the access token should be scoped to.
+   */
+  audience?: string;
+  /**
+   * Space-separated list of scopes to request.
+   */
+  scope?: string;
+}
+
+// ─── Internal wire types (snake_case matching Auth0 API) ─────────────────────
+
+/**
+ * @internal
+ * Raw response body from `POST /anonymous/token`.
+ */
+export interface AnonymousTokenApiResponse {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+  scope?: string;
+  /** Only present on session creation, not on re-mint. */
+  session_token?: string;
+}
+

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -27,6 +27,7 @@ import { PasswordlessClient } from './passwordless/passwordless-client.js';
 import { PasswordlessVerifyError } from './passwordless/errors.js';
 import { isE164PhoneNumber } from './passwordless/utils.js';
 import { DatabaseClient } from './database/database-client.js';
+import { AnonymousSessionClient } from './anonymous-session/anonymous-session-client.js';
 import { createTelemetryFetch, getTelemetryConfig } from './telemetry.js';
 import {
   AuthClientOptions,
@@ -285,6 +286,16 @@ export class AuthClient {
    */
   public passwordless: PasswordlessClient;
   public database: DatabaseClient;
+  /**
+   * Sub-client for Auth0 Anonymous Sessions.
+   *
+   * Use `authClient.anonymous.createSession()` to establish an anonymous identity,
+   * `authClient.anonymous.getTokenSilently()` to obtain (and renew) access tokens,
+   * and `authClient.anonymous.logout()` to end the session.
+   *
+   * Requires the tenant and client to be configured for anonymous sessions.
+   */
+  public anonymous: AnonymousSessionClient;
 
   constructor(options: AuthClientOptions) {
     this.#options = options;
@@ -361,6 +372,12 @@ export class AuthClient {
     });
 
     this.database = new DatabaseClient({
+      domain: this.#options.domain,
+      clientId: this.#options.clientId,
+      customFetch: this.#customFetch,
+    });
+
+    this.anonymous = new AnonymousSessionClient({
       domain: this.#options.domain,
       clientId: this.#options.clientId,
       customFetch: this.#customFetch,

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -380,6 +380,7 @@ export class AuthClient {
     this.anonymous = new AnonymousSessionClient({
       domain: this.#options.domain,
       clientId: this.#options.clientId,
+      clientSecret: this.#options.clientSecret,
       customFetch: this.#customFetch,
     });
   }

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -290,8 +290,8 @@ export class AuthClient {
    * Sub-client for Auth0 Anonymous Sessions.
    *
    * Use `authClient.anonymous.createSession()` to establish an anonymous identity,
-   * `authClient.anonymous.getTokenSilently()` to obtain (and renew) access tokens,
-   * and `authClient.anonymous.logout()` to end the session.
+   * `authClient.anonymous.getTokenSilently(session)` to obtain (and renew) access tokens,
+   * and `authClient.anonymous.logout(session.sessionToken)` to end the session.
    *
    * Requires the tenant and client to be configured for anonymous sessions.
    */

--- a/packages/auth0-auth-js/src/index.ts
+++ b/packages/auth0-auth-js/src/index.ts
@@ -19,3 +19,4 @@ export type {
 } from './passwordless/types.js';
 export type { TokenByMagicLinkCodeOptions } from './types.js';
 export * from './database/index.js';
+export * from './anonymous-session/index.js';


### PR DESCRIPTION
## Summary

- Adds `AnonymousSessionClient` sub-client exposed as `authClient.anonymous`
- Implements `POST /anonymous/token` (create + re-mint) and `POST /anonymous/logout`
- Includes full token renewal logic in `getTokenSilently()` — silently re-creates session on `session_expired`/`invalid_session_token`, surfaces all other errors
- Exports shared types (`AnonymousSession`, `AnonymousTokens`, `AnonymousSessionClaims`, `CreateAnonymousSessionOptions`, `GetAnonymousTokenSilentlyOptions`) and `AnonymousSessionError` for downstream SDKs (auth0-spa-js, auth0-server-js)

## Test plan

- [ ] 25 unit tests covering all methods and renewal paths pass (`npx vitest run src/anonymous-session/anonymous-session-client.spec.ts`)
- [ ] Full package test suite passes (`npx vitest run`)
- [ ] No TypeScript errors in new files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added anonymous session support for creating, renewing, silently recovering, and logging out sessions.
  * Exposed anonymous session APIs, types, and structured error handling through the authentication client.
  * Added support for configuring audience, scope, metadata, and session credentials.
* **Tests**
  * Added comprehensive coverage for successful flows, expiration handling, fallback behavior, request details, and API errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->