### PR TITLE
fix(auth0-server-js): require auth0-auth-js ^1.12.1 for passkey client auth

### DIFF
--- a/packages/auth0-server-js/EXAMPLES.md
+++ b/packages/auth0-server-js/EXAMPLES.md
@@ -355,7 +355,7 @@ const authorizationUrl = await serverClient.startInteractiveLogin();
 
 - **Client Certificate**: Your application must have a valid client certificate issued by a Certificate Authority (CA) that Auth0 trusts.
 - **Domain Configuration**: Your Auth0 tenant must be configured to support mTLS endpoints.
-- **No Additional Auth**: When `useMtls: true`, you don't need `clientSecret` or `clientAssertionSigningKey`.
+- **No Additional Auth**: When `useMtls: true`, you don't need `clientSecret` or `clientAssertionSigningKey`. The one exception is `passkey.register()` / `passkey.challenge()`, which are not served on the mTLS endpoint aliases and accept only a `clientSecret`. See [Login and Signup using Passkeys](#login-and-signup-using-passkeys).
 - **Custom Fetch Required**: You must provide a `customFetch` implementation that includes the client certificate in the TLS handshake.
 - **Store Configuration**: mTLS works with both stateless and stateful store configurations.
 
@@ -997,6 +997,15 @@ Because the WebAuthn ceremony (`navigator.credentials.create()` / `navigator.cre
 >
 > Read [the Auth0 docs](https://auth0.com/docs/authenticate/database-connections/passkeys) to learn more about passkeys.
 
+> [!IMPORTANT]
+> **Client authentication differs across the passkey methods.**
+>
+> `passkey.register()` and `passkey.challenge()` accept `client_secret` as their only client credential. If your application is a confidential client, configure a `clientSecret` on the `ServerClient` and the SDK sends it on these two requests. Public clients authenticate with `clientId` alone and need no change.
+>
+> These two endpoints do not accept a private key JWT, and they are not served on the mTLS endpoint aliases. An application configured with only a `clientAssertionSigningKey` or only `useMtls` therefore has no credential the SDK can send to them, and Auth0 rejects the request. To use them, set the application's authentication method to **Client Secret** in the Auth0 Dashboard and pass that secret as `clientSecret`.
+>
+> `passkey.getToken()` is not affected. It goes through the token endpoint, so it works with a `clientSecret`, a `clientAssertionSigningKey`, or mTLS.
+
 ### Requesting a Signup Challenge
 
 To register a new user, call `passkey.register()` with the user's profile and return the result to the browser:
@@ -1011,7 +1020,7 @@ const { authSession, authnParamsPublicKey } = await serverClient.passkey.registe
 - `authnParamsPublicKey`: WebAuthn credential creation options. The browser passes these to `navigator.credentials.create()`.
 - `authSession`: A flow-state token. The browser must send this back when completing the flow. It is **not** stored server-side.
 
-This method does not create a session.
+This method does not create a session. On a confidential client it needs a `clientSecret`; see the client authentication note [above](#login-and-signup-using-passkeys).
 
 ### Requesting a Login Challenge
 
@@ -1024,7 +1033,7 @@ const { authSession, authnParamsPublicKey } = await serverClient.passkey.challen
 - `authnParamsPublicKey`: WebAuthn credential request options. The browser passes these to `navigator.credentials.get()`.
 - `authSession`: A flow-state token, sent back when completing the flow.
 
-This method does not create a session.
+This method does not create a session. On a confidential client it needs a `clientSecret`; see the client authentication note [above](#login-and-signup-using-passkeys).
 
 ### Completing the Passkey Flow
 

--- a/packages/auth0-server-js/package.json
+++ b/packages/auth0-server-js/package.json
@@ -25,7 +25,7 @@
     }
   },
   "dependencies": {
-    "@auth0/auth0-auth-js": "^1.12.0",
+    "@auth0/auth0-auth-js": "^1.12.1",
     "jose": "^6.0.8"
   },
   "devDependencies": {

--- a/packages/auth0-server-js/src/passkey/server-passkey-client.ts
+++ b/packages/auth0-server-js/src/passkey/server-passkey-client.ts
@@ -30,6 +30,12 @@ export class ServerPasskeyClient<TStoreOptions = unknown> {
    *
    * This method does not create a session; no state is persisted.
    *
+   * On a confidential client this endpoint accepts `client_secret` as its only
+   * credential, so configure `clientSecret` on the `ServerClient`. It does not
+   * accept a private key JWT and is not served on the mTLS endpoint aliases, so a
+   * client configured with only `clientAssertionSigningKey` or only `useMtls` is
+   * rejected by Auth0. Public clients authenticate with `clientId` alone.
+   *
    * @param options User profile data and optional realm/organization.
    * @param storeOptions Optional options used to resolve the domain (resolver mode).
    *
@@ -53,6 +59,9 @@ export class ServerPasskeyClient<TStoreOptions = unknown> {
    * call `getToken()` with the resulting credential to complete login.
    *
    * This method does not create a session; no state is persisted.
+   *
+   * Client authentication works the same way as {@link ServerPasskeyClient.register}:
+   * on a confidential client, only a `clientSecret` is accepted here.
    *
    * @param options Optional realm/organization configuration.
    * @param storeOptions Optional options used to resolve the domain (resolver mode).

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -5714,6 +5714,128 @@ test('passkey.register - should call the domain resolver with storeOptions (reso
   expect(domainResolver).toHaveBeenCalledWith(storeOptions);
 });
 
+// `/passkey/register` and `/passkey/challenge` accept `client_secret` as their only
+// client credential, so `ServerClient` has to forward the configured secret for a
+// confidential client to authenticate at all. These tests assert the request body on
+// the wire, which is the layer the original bug lived in: the options were forwarded
+// correctly but the credential never reached the body.
+describe('passkey (client authentication)', () => {
+  const newServerClient = (extra?: Record<string, unknown>) =>
+    new ServerClient({
+      domain,
+      clientId: '<client_id>',
+      transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+      stateStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() },
+      ...extra,
+    });
+
+  // Captures the request body and URL for both passkey challenge endpoints.
+  const capture = (endpoint: 'register' | 'challenge') => {
+    const captured: { body?: Record<string, unknown>; url?: string } = {};
+    server.use(
+      http.post(`https://${domain}/passkey/${endpoint}`, async ({ request }) => {
+        captured.url = request.url;
+        captured.body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          auth_session: 'auth_session_123',
+          authn_params_public_key: { challenge: 'challenge', rpId: domain },
+        });
+      })
+    );
+    return captured;
+  };
+
+  test.each(['challenge', 'register'] as const)(
+    '%s - sends client_secret for a confidential client',
+    async (endpoint) => {
+      const captured = capture(endpoint);
+
+      const client = newServerClient({ clientSecret: '<client_secret>' });
+      await (endpoint === 'register'
+        ? client.passkey.register({ email: 'jane@example.com' })
+        : client.passkey.challenge());
+
+      expect(captured.body!.client_id).toBe('<client_id>');
+      expect(captured.body!.client_secret).toBe('<client_secret>');
+    }
+  );
+
+  test.each(['challenge', 'register'] as const)(
+    '%s - sends client_id only for a public client',
+    async (endpoint) => {
+      const captured = capture(endpoint);
+
+      const client = newServerClient();
+      await (endpoint === 'register'
+        ? client.passkey.register({ email: 'jane@example.com' })
+        : client.passkey.challenge());
+
+      expect(captured.body!.client_id).toBe('<client_id>');
+      expect('client_secret' in captured.body!).toBe(false);
+    }
+  );
+
+  // Auth0 rejects a request carrying both a certificate and a body credential, so
+  // `useMtls` wins over a co-configured `clientSecret`.
+  test.each(['challenge', 'register'] as const)(
+    '%s - omits client_secret when mTLS is enabled',
+    async (endpoint) => {
+      const captured = capture(endpoint);
+
+      const client = newServerClient({
+        clientSecret: '<client_secret>',
+        useMtls: true,
+        customFetch: fetch,
+      });
+      await (endpoint === 'register'
+        ? client.passkey.register({ email: 'jane@example.com' })
+        : client.passkey.challenge());
+
+      expect(captured.body!.client_id).toBe('<client_id>');
+      expect('client_secret' in captured.body!).toBe(false);
+    }
+  );
+
+  // These two endpoints are not served on the mTLS endpoint aliases, so the request
+  // must go to the regular host even when mTLS is configured.
+  test('challenge - uses the regular host, not the mTLS alias, under mTLS', async () => {
+    const captured = capture('challenge');
+
+    await newServerClient({ useMtls: true, customFetch: fetch }).passkey.challenge();
+
+    expect(captured.url).toBe(`https://${domain}/passkey/challenge`);
+    expect(captured.url).not.toContain('mtls.');
+  });
+
+  // A private key JWT is not accepted here, so no credential is sent and Auth0's
+  // rejection is surfaced unchanged rather than pre-empted by the SDK.
+  test('challenge - sends no credential for a private_key_jwt-only client', async () => {
+    const captured = capture('challenge');
+
+    await newServerClient({
+      clientAssertionSigningKey: '<client_assertion_signing_key>',
+    }).passkey.challenge();
+
+    expect(captured.body!.client_id).toBe('<client_id>');
+    expect('client_secret' in captured.body!).toBe(false);
+    expect('client_assertion' in captured.body!).toBe(false);
+  });
+
+  // Resolver (multi-tenant) mode builds a per-call AuthClient, so the credential has
+  // to survive that path too.
+  test('challenge - forwards client_secret in resolver mode', async () => {
+    const captured = capture('challenge');
+
+    const client = newServerClient({
+      domain: async () => domain,
+      clientSecret: '<client_secret>',
+    });
+    await client.passkey.challenge(undefined, { request: { headers: { host: 'example.test' } } });
+
+    expect(captured.body!.client_secret).toBe('<client_secret>');
+  });
+});
+
 describe('passwordless (session layer)', () => {
   const PASSWORDLESS_GRANT = 'http://auth0.com/oauth/grant-type/passwordless/otp';
   const startUrl = `https://${domain}/passwordless/start`;


### PR DESCRIPTION
## Description
`/passkey/register` and `/passkey/challenge` accept `client_secret` as their only body-level client credential. `@auth0/auth0-auth-js` only started sending it in **1.12.1** ([#239](https://github.com/auth0/auth0-auth-js/pull/239)), so on 1.12.0 confidential clients could not authenticate against either endpoint.

No source changes are needed in this package. `ServerClient` already forwards `clientSecret` and `useMtls` into its `AuthClient` options, so the fix propagates through both the static and resolver (multi-tenant) paths untouched. This PR raises the dependency floor and documents the constraint.

- **`package.json`**: `@auth0/auth0-auth-js` `^1.12.0` → `^1.12.1`. A fresh install already resolves 1.12.1 under the old caret, but a consumer with a lockfile pinned to 1.12.0 keeps getting the broken version. Only the floor moves them.
- **JSDoc** on `register()` / `challenge()`: these endpoints do not accept a private key JWT and are not served on the mTLS endpoint aliases, so a client configured with only `clientAssertionSigningKey` or only `useMtls` has no credential the SDK can send. `getToken()` is unaffected, since it goes through the token endpoint.
- **`EXAMPLES.md`**: same explanation, cross-linked from both challenge sections.
- **9 regression tests** asserting the request body on the wire for public, client-secret, mTLS, and private-key-JWT-only clients, plus resolver mode. They fail against `auth0-auth-js@1.12.0` and pass against 1.12.1, so they cover the defect rather than the plumbing.

## Testing
Verified against the **published** `@auth0/auth0-auth-js@1.12.1` tarball, not just workspace source: all 9 passkey assertions pass. Confirmed `buildClientAuthBody` is in the shipped `dist` and is spread into both request bodies.