### PR TITLE
docs(mfa): document verifying an authenticator

### DIFF
--- a/packages/auth0-auth-js/EXAMPLES.md
+++ b/packages/auth0-auth-js/EXAMPLES.md
@@ -45,6 +45,7 @@
     - [Enrolling an Authenticator](#enrolling-an-authenticator)
     - [Listing Authenticators](#listing-authenticators)
     - [Challenging an Authenticator](#challenging-an-authenticator)
+    - [Verifying an Authenticator](#verifying-an-authenticator)
     - [Deleting an Authenticator](#deleting-an-authenticator)
 - [Using Passkeys](#using-passkeys)
     - [Requesting a Signup Challenge](#requesting-a-signup-challenge)
@@ -1080,6 +1081,42 @@ const smsChallenge = await authClient.mfa.challengeAuthenticator({
 // For OOB challenges, the response includes an oobCode
 // smsChallenge.oobCode - Out-of-band code for verification
 ```
+
+### Verifying an Authenticator
+
+To complete the MFA flow, use the `verify` method to exchange the user's submitted factor for tokens:
+
+```ts
+const mfaToken = '<mfa_token>';
+
+// Verify with OTP (code from the user's authenticator app)
+const tokens = await authClient.mfa.verify({
+  mfaToken,
+  factorType: 'otp',
+  otp: '<otp_code>',
+});
+
+// Verify with OOB (code delivered by SMS, voice or email)
+const oobTokens = await authClient.mfa.verify({
+  mfaToken,
+  factorType: 'oob',
+  oobCode: '<oob_code_from_challenge>',
+  bindingCode: '<binding_code>', // Only for prompt-based OOB challenges
+});
+
+// Verify with a recovery code
+const recoveryTokens = await authClient.mfa.verify({
+  mfaToken,
+  factorType: 'recovery-code',
+  recoveryCode: '<recovery_code>',
+});
+
+// tokens.accessToken, tokens.idToken, tokens.refreshToken
+// tokens.recoveryCode - A new recovery code, when one is issued. Display it to the
+// user once; it cannot be retrieved again.
+```
+
+An `MfaVerifyError` is thrown when verification fails (e.g., invalid code, expired token).
 
 ### Deleting an Authenticator
 

--- a/packages/auth0-auth-js/EXAMPLES.md
+++ b/packages/auth0-auth-js/EXAMPLES.md
@@ -1101,7 +1101,15 @@ const oobTokens = await authClient.mfa.verify({
   mfaToken,
   factorType: 'oob',
   oobCode: '<oob_code_from_challenge>',
-  bindingCode: '<binding_code>', // Only for prompt-based OOB challenges
+});
+
+// Only when the challenge response came back with bindingMethod 'prompt': the user
+// must also enter the code delivered over the channel, passed as bindingCode.
+const promptBoundTokens = await authClient.mfa.verify({
+  mfaToken,
+  factorType: 'oob',
+  oobCode: '<oob_code_from_challenge>',
+  bindingCode: '<binding_code>',
 });
 
 // Verify with a recovery code


### PR DESCRIPTION
`authClient.mfa.verify()` is what actually completes an MFA flow and returns tokens, but it was the only method on the MFA client with no example in `EXAMPLES.md` — enroll, list, challenge and delete are all documented. Anyone following the guide could get as far as issuing a challenge and then had to read the source to finish.

Documents the three `factorType` variants (`otp`, `oob`, `recovery-code`), the options each one takes, and the `recoveryCode` that can come back on the response.

```ts
const tokens = await authClient.mfa.verify({
  mfaToken,
  factorType: 'otp',
  otp: '<otp_code>',
});
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added examples for verifying MFA factors using OTP, OOB, and recovery codes.
  * Documented returned tokens and handling verification errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->