### PR TITLE
fix(auth0-auth-js): support private_key_jwt client authentication

### DIFF
--- a/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.spec.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.spec.ts
@@ -1,8 +1,23 @@
 import { expect, test, describe, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
+import { decodeJwt, decodeProtectedHeader } from 'jose';
 import { AnonymousSessionClient } from './anonymous-session-client.js';
 import { AnonymousSessionError } from './errors.js';
+
+const exportPrivateKeyToPem = async (privateKey: CryptoKey): Promise<string> => {
+  const pkcs8 = await crypto.subtle.exportKey('pkcs8', privateKey);
+  const keyBase64 = Buffer.from(pkcs8).toString('base64');
+  const keyLines = keyBase64.match(/.{1,64}/g) ?? [keyBase64];
+  return `-----BEGIN PRIVATE KEY-----\n${keyLines.join('\n')}\n-----END PRIVATE KEY-----`;
+};
+
+const generateRsaKeyPair = () =>
+  crypto.subtle.generateKey(
+    { name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: { name: 'SHA-256' } },
+    true,
+    ['sign', 'verify']
+  ) as Promise<CryptoKeyPair>;
 
 const domain = 'auth0.local';
 const clientId = 'test-client-id';
@@ -434,5 +449,112 @@ describe('expiresAt', () => {
     // expires_in is 3600 in the mock
     expect(session.expiresAt).toBeGreaterThanOrEqual(before + 3600);
     expect(session.expiresAt).toBeLessThanOrEqual(after + 3600);
+  });
+});
+
+// ─── client authentication ────────────────────────────────────────────────────
+
+describe('client authentication', () => {
+  test('sends client_secret when clientSecret is configured', async () => {
+    let capturedBody: Record<string, unknown> = {};
+
+    server.use(
+      http.post(`https://${domain}/anonymous/token`, async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          access_token: accessToken,
+          token_type: 'Bearer',
+          expires_in: 3600,
+          session_token: sessionToken,
+        });
+      })
+    );
+
+    const client = makeClient({ clientSecret: 'test-secret' });
+    await client.createSession();
+
+    expect(capturedBody.client_secret).toBe('test-secret');
+    expect(capturedBody).not.toHaveProperty('client_assertion');
+  });
+
+  test('sends no auth fields for a public client', async () => {
+    let capturedBody: Record<string, unknown> = {};
+
+    server.use(
+      http.post(`https://${domain}/anonymous/token`, async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          access_token: accessToken,
+          token_type: 'Bearer',
+          expires_in: 3600,
+          session_token: sessionToken,
+        });
+      })
+    );
+
+    const client = makeClient();
+    await client.createSession();
+
+    expect(capturedBody).not.toHaveProperty('client_secret');
+    expect(capturedBody).not.toHaveProperty('client_assertion');
+  });
+
+  test('sends client_assertion for private_key_jwt with a PEM key', async () => {
+    let capturedBody: Record<string, unknown> = {};
+
+    server.use(
+      http.post(`https://${domain}/anonymous/token`, async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          access_token: accessToken,
+          token_type: 'Bearer',
+          expires_in: 3600,
+          session_token: sessionToken,
+        });
+      })
+    );
+
+    const { privateKey } = await generateRsaKeyPair();
+    const pem = await exportPrivateKeyToPem(privateKey);
+    const client = makeClient({ clientAssertionSigningKey: pem, clientAssertionSigningAlg: 'RS256' });
+    await client.createSession();
+
+    expect(capturedBody.client_assertion_type).toBe('urn:ietf:params:oauth:client-assertion-type:jwt-bearer');
+    const jwt = capturedBody.client_assertion as string;
+    expect(typeof jwt).toBe('string');
+    expect(decodeProtectedHeader(jwt).alg).toBe('RS256');
+    const claims = decodeJwt(jwt);
+    expect(claims.iss).toBe(clientId);
+    expect(claims.sub).toBe(clientId);
+    expect(claims.aud).toBe(`https://${domain}/`);
+    expect(typeof claims.jti).toBe('string');
+    const ttl = (claims.exp as number) - (claims.iat as number);
+    expect(ttl).toBe(120);
+    expect(capturedBody).not.toHaveProperty('client_secret');
+  });
+
+  test('sends client_assertion for private_key_jwt with a CryptoKey', async () => {
+    let capturedBody: Record<string, unknown> = {};
+
+    server.use(
+      http.post(`https://${domain}/anonymous/token`, async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          access_token: accessToken,
+          token_type: 'Bearer',
+          expires_in: 3600,
+          session_token: sessionToken,
+        });
+      })
+    );
+
+    const { privateKey } = await generateRsaKeyPair();
+    const client = makeClient({ clientAssertionSigningKey: privateKey });
+    await client.createSession();
+
+    const jwt = capturedBody.client_assertion as string;
+    expect(typeof jwt).toBe('string');
+    expect(decodeJwt(jwt).aud).toBe(`https://${domain}/`);
+    expect(capturedBody).not.toHaveProperty('client_secret');
   });
 });

--- a/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
@@ -1,4 +1,5 @@
 import { AnonymousSessionError, type AnonymousSessionApiErrorResponse } from './errors.js';
+import { buildClientAuthBody } from './utils.js';
 import type {
   AnonymousSessionClientOptions,
   AnonymousSession,
@@ -87,18 +88,24 @@ async function parseErrorResponse(response: Response): Promise<AnonymousSessionA
  * ```
  */
 export class AnonymousSessionClient {
+  readonly #domain: string;
   readonly #baseUrl: string;
   readonly #clientId: string;
   readonly #clientSecret?: string;
+  readonly #clientAssertionSigningKey?: string | CryptoKey;
+  readonly #clientAssertionSigningAlg?: string;
   readonly #customFetch: typeof fetch;
 
   /**
    * @internal
    */
   constructor(options: AnonymousSessionClientOptions) {
+    this.#domain = options.domain;
     this.#baseUrl = `https://${options.domain}`;
     this.#clientId = options.clientId;
     this.#clientSecret = options.clientSecret;
+    this.#clientAssertionSigningKey = options.clientAssertionSigningKey;
+    this.#clientAssertionSigningAlg = options.clientAssertionSigningAlg;
     this.#customFetch = options.customFetch ?? ((...args) => fetch(...args));
   }
 
@@ -292,9 +299,16 @@ export class AnonymousSessionClient {
   async #postAnonymousToken(body: Record<string, unknown>): Promise<AnonymousTokens> {
     const url = `${this.#baseUrl}/anonymous/token`;
 
-    if (this.#clientSecret) {
-      body.client_secret = this.#clientSecret;
-    }
+    const authFields = await buildClientAuthBody(
+      {
+        clientSecret: this.#clientSecret,
+        clientAssertionSigningKey: this.#clientAssertionSigningKey,
+        clientAssertionSigningAlg: this.#clientAssertionSigningAlg,
+      },
+      this.#clientId,
+      this.#domain
+    );
+    Object.assign(body, authFields);
 
     const response = await this.#customFetch(url, {
       method: 'POST',

--- a/packages/auth0-auth-js/src/anonymous-session/types.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/types.ts
@@ -12,9 +12,19 @@ export interface AnonymousSessionClientOptions {
    */
   clientId: string;
   /**
-   * The client secret. Required for confidential clients.
+   * The client secret. Used for `client_secret_post` authentication.
    */
   clientSecret?: string;
+  /**
+   * A private key (PEM string or `CryptoKey`) used to sign a client assertion
+   * JWT for `private_key_jwt` authentication.
+   */
+  clientAssertionSigningKey?: string | CryptoKey;
+  /**
+   * The algorithm used to sign the client assertion JWT.
+   * Defaults to `'RS256'` when `clientAssertionSigningKey` is provided.
+   */
+  clientAssertionSigningAlg?: string;
   /**
    * Optional custom Fetch implementation to use.
    */

--- a/packages/auth0-auth-js/src/anonymous-session/utils.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/utils.ts
@@ -1,0 +1,66 @@
+import { SignJWT, importPKCS8 } from 'jose';
+import type { AnonymousSessionClientOptions } from './types.js';
+
+const DEFAULT_CLIENT_ASSERTION_ALG = 'RS256';
+const CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
+const CLIENT_ASSERTION_EXPIRY_SECONDS = 120;
+
+/**
+ * Subset of {@link AnonymousSessionClientOptions} carrying the client-authentication fields.
+ * @internal
+ */
+export type ClientAuthOptions = Pick<
+  AnonymousSessionClientOptions,
+  'clientSecret' | 'clientAssertionSigningKey' | 'clientAssertionSigningAlg'
+>;
+
+/**
+ * Builds the client-authentication fields injected into the `/anonymous/token`
+ * request body, matching node-auth0's `addClientAuthentication` (FR-1c).
+ *
+ * Resolution order: `private_key_jwt` → `client_secret_post` → public client
+ * (no body auth).
+ *
+ * Unlike the passwordless variant, an empty object is returned for a public
+ * client (no auth options configured): the anonymous token endpoint does not
+ * require client authentication for public clients.
+ *
+ * @internal
+ */
+export async function buildClientAuthBody(
+  options: ClientAuthOptions,
+  clientId: string,
+  domain: string
+): Promise<Record<string, string>> {
+  if (options.clientAssertionSigningKey) {
+    const alg = options.clientAssertionSigningAlg ?? DEFAULT_CLIENT_ASSERTION_ALG;
+    const privateKey =
+      options.clientAssertionSigningKey instanceof CryptoKey
+        ? options.clientAssertionSigningKey
+        : await importPKCS8(options.clientAssertionSigningKey as string, alg);
+
+    // Claims mirror node-auth0 client-authentication: iss/sub = clientId,
+    // aud = `https://{domain}/` (trailing slash), short-lived, unique jti.
+    const clientAssertion = await new SignJWT({})
+      .setProtectedHeader({ alg })
+      .setIssuer(clientId)
+      .setSubject(clientId)
+      .setAudience(`https://${domain}/`)
+      .setJti(crypto.randomUUID())
+      .setIssuedAt()
+      .setExpirationTime(`${CLIENT_ASSERTION_EXPIRY_SECONDS}s`)
+      .sign(privateKey);
+
+    return {
+      client_assertion: clientAssertion,
+      client_assertion_type: CLIENT_ASSERTION_TYPE,
+    };
+  }
+
+  if (options.clientSecret) {
+    return { client_secret: options.clientSecret };
+  }
+
+  // Public client — no body-level authentication required.
+  return {};
+}

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -390,6 +390,8 @@ export class AuthClient {
       domain: this.#options.domain,
       clientId: this.#options.clientId,
       clientSecret: this.#options.clientSecret,
+      clientAssertionSigningKey: this.#options.clientAssertionSigningKey,
+      clientAssertionSigningAlg: this.#options.clientAssertionSigningAlg,
       customFetch: this.#customFetch,
     });
   }


### PR DESCRIPTION
## What

Anonymous session token requests only supported `client_secret_post`. Confidential clients configured for `private_key_jwt` had no way to authenticate — they were locked out entirely.

## Changes

- `AnonymousSessionClientOptions` gains `clientAssertionSigningKey` and `clientAssertionSigningAlg`
- New `anonymous-session/utils.ts` with `buildClientAuthBody` — resolution order: `private_key_jwt` → `client_secret_post` → public client (no body auth)
- `AnonymousSessionClient#postAnonymousToken` calls it instead of the bespoke secret-only block
- `AuthClient` passes the new fields through when constructing the anonymous client

## Notes

- Public clients (no auth configured) return an empty auth body — valid for this endpoint, unlike the passwordless variant which throws `MissingClientAuthError`
- mTLS is transport-level and remains handled via `customFetch`; not included here per the gaps analysis

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple authentication methods when starting anonymous sessions, including client secrets and private key JWTs.
  * Added configuration for signing keys and algorithms, with RS256 used by default.
  * Public clients can now authenticate without client credentials.
* **Bug Fixes**
  * Logout requests no longer send client secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->