### PR TITLE
fix(auth0-auth-js): surface session_expires_in as sessionExpiresAt

### DIFF
--- a/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.spec.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.spec.ts
@@ -8,6 +8,7 @@ const domain = 'auth0.local';
 const clientId = 'test-client-id';
 const sessionToken = 'test-session-token';
 const accessToken = 'test-access-token';
+const sessionExpiresIn = 2592000; // 30 days in seconds
 
 const makeClient = (overrides?: Partial<ConstructorParameters<typeof AnonymousSessionClient>[0]>) =>
   new AnonymousSessionClient({ domain, clientId, ...overrides });
@@ -57,6 +58,7 @@ const restHandlers = [
         token_type: 'Bearer',
         expires_in: 3600,
         scope: body.scope ?? 'openid',
+        session_expires_in: sessionExpiresIn - 3600, // counts down, not reset
       });
     }
 
@@ -67,6 +69,7 @@ const restHandlers = [
       expires_in: 3600,
       scope: body.scope ?? 'openid',
       session_token: sessionToken,
+      session_expires_in: sessionExpiresIn,
     });
   }),
 
@@ -104,6 +107,7 @@ describe('createSession', () => {
           token_type: 'Bearer',
           expires_in: 3600,
           session_token: sessionToken,
+          session_expires_in: sessionExpiresIn,
         });
       })
     );
@@ -127,6 +131,7 @@ describe('createSession', () => {
           token_type: 'Bearer',
           expires_in: 3600,
           session_token: sessionToken,
+          session_expires_in: sessionExpiresIn,
         });
       })
     );
@@ -148,6 +153,7 @@ describe('createSession', () => {
           token_type: 'Bearer',
           expires_in: 3600,
           session_token: sessionToken,
+          session_expires_in: sessionExpiresIn,
         });
       })
     );
@@ -295,6 +301,7 @@ describe('getTokenSilently', () => {
           access_token: 'renewed-access-token',
           token_type: 'Bearer',
           expires_in: 3600,
+          session_expires_in: sessionExpiresIn,
         });
       })
     );
@@ -319,6 +326,7 @@ describe('getTokenSilently', () => {
           token_type: 'Bearer',
           expires_in: 3600,
           session_token: sessionToken,
+          session_expires_in: sessionExpiresIn,
         });
       })
     );
@@ -434,5 +442,39 @@ describe('expiresAt', () => {
     // expires_in is 3600 in the mock
     expect(session.expiresAt).toBeGreaterThanOrEqual(before + 3600);
     expect(session.expiresAt).toBeLessThanOrEqual(after + 3600);
+  });
+});
+
+// ─── sessionExpiresAt ─────────────────────────────────────────────────────────
+
+describe('sessionExpiresAt', () => {
+  test('set on createSession from session_expires_in', async () => {
+    const client = makeClient();
+    const before = Math.floor(Date.now() / 1000);
+    const session = await client.createSession();
+    const after = Math.floor(Date.now() / 1000);
+
+    expect(session.sessionExpiresAt).toBeGreaterThanOrEqual(before + sessionExpiresIn);
+    expect(session.sessionExpiresAt).toBeLessThanOrEqual(after + sessionExpiresIn);
+  });
+
+  test('set on getTokenSilently re-mint and counts down from original expiry', async () => {
+    const client = makeClient();
+    const before = Math.floor(Date.now() / 1000);
+    const session = await client.getTokenSilently({ sessionToken });
+    const after = Math.floor(Date.now() / 1000);
+
+    // default handler returns sessionExpiresIn - 3600 for re-mint
+    const expected = sessionExpiresIn - 3600;
+    expect(session.sessionExpiresAt).toBeGreaterThanOrEqual(before + expected);
+    expect(session.sessionExpiresAt).toBeLessThanOrEqual(after + expected);
+  });
+
+  test('renewal sessionExpiresAt is less than create sessionExpiresAt', async () => {
+    const client = makeClient();
+    const created = await client.createSession();
+    const renewed = await client.getTokenSilently({ sessionToken });
+
+    expect(renewed.sessionExpiresAt).toBeLessThan(created.sessionExpiresAt);
   });
 });

--- a/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
@@ -33,6 +33,7 @@ function parseTokenResponse(apiResponse: AnonymousTokenApiResponse): AnonymousTo
     expiresAt: now + expiresIn,
     scope: apiResponse.scope,
     sessionToken: apiResponse.session_token,
+    sessionExpiresAt: now + apiResponse.session_expires_in,
   };
 }
 
@@ -153,6 +154,7 @@ export class AnonymousSessionClient {
       sessionToken: tokens.sessionToken,
       accessToken: tokens.accessToken,
       expiresAt: tokens.expiresAt,
+      sessionExpiresAt: tokens.sessionExpiresAt,
       scope: tokens.scope,
     };
   }
@@ -234,6 +236,7 @@ export class AnonymousSessionClient {
       sessionToken,
       accessToken: tokens.accessToken,
       expiresAt: tokens.expiresAt,
+      sessionExpiresAt: tokens.sessionExpiresAt,
       scope: tokens.scope,
     };
   }

--- a/packages/auth0-auth-js/src/anonymous-session/types.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/types.ts
@@ -42,6 +42,16 @@ export interface AnonymousSession {
    */
   expiresAt: number;
   /**
+   * Unix timestamp (seconds) at which the session token itself expires.
+   *
+   * The session token is minted once and never reissued, so this value counts
+   * down on every response rather than resetting. Present on both create and
+   * re-mint responses when the tenant has anonymous sessions enabled.
+   *
+   * Use this — not `expiresAt` — to drive cookie `Max-Age` or session expiry UI.
+   */
+  sessionExpiresAt: number;
+  /**
    * Scopes granted to this anonymous session.
    */
   scope?: string;
@@ -76,6 +86,11 @@ export interface AnonymousTokens {
    * Only present when a new session is created (not on re-mint).
    */
   sessionToken?: string;
+  /**
+   * Unix timestamp (seconds) at which the session token itself expires.
+   * Computed from `session_expires_in` in the API response.
+   */
+  sessionExpiresAt: number;
 }
 
 /**
@@ -155,5 +170,11 @@ export interface AnonymousTokenApiResponse {
   scope?: string;
   /** Only present on session creation, not on re-mint. */
   session_token?: string;
+  /**
+   * Remaining lifetime of the session token in seconds. Present on both create
+   * and re-mint responses. Counts down toward the original expiry — does not
+   * reset on each renewal.
+   */
+  session_expires_in: number;
 }
 


### PR DESCRIPTION
## What

The platform returns `session_expires_in` on every `/anonymous/token` response (create and re-mint). The SDK was dropping it — `AnonymousTokenApiResponse` did not declare it, so `parseTokenResponse` never read it. Nothing on `AnonymousSession` described when the session token itself expired.

## Why it matters

- The session token is minted once and never reissued. `session_expires_in` counts down on each response, it does not reset.
- `auth0-server-js` picks a cookie `Max-Age` from this value. Without it, it falls back to 30 days from creation time — which is wrong on any tenant that shortens the anonymous session lifetime.
- `auth0-spa-js` has no way to know or act on session expiry.

## Changes

- `AnonymousTokenApiResponse.session_expires_in` — added as required `number` (platform always sends it)
- `AnonymousTokens.sessionExpiresAt` — added as required `number` (always computed)
- `AnonymousSession.sessionExpiresAt` — added as optional `number` (optional on public surface for forward-compat)
- `parseTokenResponse` — computes `sessionExpiresAt = now + session_expires_in`
- `createSession` and `#mintToken` — pass `sessionExpiresAt` through to the returned session
- Tests — 3 new cases: set on create, set on re-mint, re-mint value is less than create value (counts down)