### PR TITLE
fix(auth0-auth-js): narrow metadata type to Record<string, string>

### DIFF
--- a/packages/auth0-auth-js/src/anonymous-session/types.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/types.ts
@@ -97,7 +97,7 @@ export interface AnonymousSessionClaims {
   /** Unix timestamp when the anonymous session was created. */
   created_at: number;
   /** Up to 1KB of key-value metadata set at session creation time. */
-  metadata?: Record<string, unknown>;
+  metadata?: Record<string, string>;
 }
 
 /**
@@ -119,7 +119,7 @@ export interface CreateAnonymousSessionOptions {
    * Up to 1KB of arbitrary key-value metadata to attach to the anonymous session.
    * Set once at creation time — cannot be changed after the session is created.
    */
-  metadata?: Record<string, unknown>;
+  metadata?: Record<string, string>;
 }
 
 /**


### PR DESCRIPTION
## What

`CreateAnonymousSessionOptions.metadata` and `AnonymousSessionClaims.metadata` were typed as `Record<string, unknown>`. The platform only accepts string values (`additionalProperties: { type: 'string' }`), so passing non-string values typechecked cleanly but always failed at runtime with a `400 invalid_request`.

## Changes

- Both `metadata` fields narrowed from `Record<string, unknown>` to `Record<string, string>`

## Notes

This is technically a breaking change for callers passing non-string metadata values, but those callers are already broken at runtime. The type change moves the failure from runtime to compile time.

`auth0-server-js` already enforces `Record<string, string>` on its own surface as a workaround — this fixes it in the right place.