### PR TITLE
fix(auth0-auth-js): remove metadata_too_large from error code union

### DIFF
--- a/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.spec.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.spec.ts
@@ -42,10 +42,10 @@ const restHandlers = [
       );
     }
 
-    // Simulate metadata_too_large
+    // Simulate metadata size error — platform returns invalid_request, not metadata_too_large
     if (body.metadata && JSON.stringify(body.metadata).length > 1024) {
       return HttpResponse.json(
-        { error: 'metadata_too_large', error_description: 'Metadata exceeds 1 KB limit' },
+        { error: 'invalid_request', error_description: 'metadata exceeds the maximum allowed size' },
         { status: 400 }
       );
     }
@@ -254,13 +254,13 @@ describe('createSession', () => {
     });
   });
 
-  test('throws AnonymousSessionError with code metadata_too_large when metadata exceeds 1 KB', async () => {
+  test('throws AnonymousSessionError with code invalid_request when metadata exceeds 1 KB', async () => {
     const client = makeClient();
     const largeMetadata = { data: 'x'.repeat(1025) };
 
     await expect(client.createSession({ metadata: largeMetadata })).rejects.toMatchObject({
       name: 'AnonymousSessionError',
-      code: 'metadata_too_large',
+      code: 'invalid_request',
     });
   });
 });

--- a/packages/auth0-auth-js/src/anonymous-session/errors.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/errors.ts
@@ -13,19 +13,18 @@ export interface AnonymousSessionApiErrorResponse {
  * Codes that map directly to Auth0 API error responses:
  * - `session_expired` — The session token has expired.
  * - `invalid_session_token` — The session token is malformed.
- * - `metadata_too_large` — The metadata payload at session creation exceeded 1 KB.
  * - `unauthorized_client` — The client ID is not enabled for anonymous sessions.
  * - `feature_not_enabled` — The tenant-level anonymous sessions flag is off.
  * - `invalid_client` — Client authentication failed.
  * - `invalid_target` — The resource server is not enabled for anonymous access.
  * - `invalid_request` — The request was malformed or the resource server is not enabled.
+ *   Also returned when the metadata payload exceeds the size limit (~1 KB, JSON-serialized).
  * - `invalid_scope` — The requested scope is not granted to anonymous callers.
  * - `server_error` — An Auth0 infrastructure error occurred.
  */
 export type AnonymousSessionErrorCode =
   | 'session_expired'
   | 'invalid_session_token'
-  | 'metadata_too_large'
   | 'unauthorized_client'
   | 'feature_not_enabled'
   | 'invalid_client'


### PR DESCRIPTION
## What

`AnonymousSessionErrorCode` listed `metadata_too_large` under a doc block saying it maps directly to Auth0 API error responses. The platform never sends it — it is an internal validation reason that is dropped before the response is written.

What actually comes back when metadata is too large:
```json
{ "error": "invalid_request", "error_description": "metadata exceeds the maximum allowed size" }
```

Any code checking `error.code === 'metadata_too_large'` is a branch that never runs. The `| string` tail in the union means the compiler does not warn about it.

## Changes

- `errors.ts` — removed `metadata_too_large` from `AnonymousSessionErrorCode`; updated the `invalid_request` doc entry to mention the metadata size case
- `anonymous-session-client.spec.ts` — updated the MSW mock and test assertion from `metadata_too_large` to `invalid_request` to match what the platform actually sends