### PR TITLE
fix(auth0-auth-js): correct AnonymousSessionClaims shape and unexport AnonymousTokens

### DIFF
--- a/packages/auth0-auth-js/src/anonymous-session/index.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/index.ts
@@ -3,7 +3,6 @@ export { AnonymousSessionError } from './errors.js';
 export type { AnonymousSessionErrorCode } from './errors.js';
 export type {
   AnonymousSession,
-  AnonymousTokens,
   AnonymousSessionClaims,
   CreateAnonymousSessionOptions,
   GetAnonymousTokenSilentlyOptions,

--- a/packages/auth0-auth-js/src/anonymous-session/types.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/types.ts
@@ -90,14 +90,18 @@ export interface AnonymousTokens {
 export interface AnonymousSessionClaims {
   /** Issuer of the token. */
   iss: string;
-  /** Subject — the anonymous identity, e.g. `anon@abc123`. */
+  /** Subject — the anonymous identity, e.g. `anon|<id>`. */
   sub: string;
-  /** Unique identifier for the anonymous session. */
-  session_id: string;
-  /** Unix timestamp when the anonymous session was created. */
-  created_at: number;
+  /** Audience — the tenant issuer URL. */
+  aud: string | string[];
+  /** Issued-at timestamp (seconds since epoch). */
+  iat: number;
+  /** Expiry timestamp (seconds since epoch). */
+  exp: number;
+  /** Session ID. */
+  sid: string;
   /** Up to 1KB of key-value metadata set at session creation time. */
-  metadata?: Record<string, unknown>;
+  metadata?: Record<string, string>;
 }
 
 /**


### PR DESCRIPTION
## What

Two issues with exported types that no public method returns.

### `AnonymousSessionClaims` — wrong field names

The interface was kept for forward compatibility (session tokens are currently opaque JWEs). The shape was wrong against the actual platform payload:

| Before | After |
|---|---|
| `session_id: string` | removed — does not exist |
| `created_at: number` | removed — does not exist |
| — | `aud: string \| string[]` added |
| — | `iat: number` added |
| — | `exp: number` added |
| — | `sid: string` added |
| `metadata?: Record<string, unknown>` | `metadata?: Record<string, string>` |

Correct shape taken from `SessionTokenService.encryptSessionToken`: `{ iss, sub, aud, iat, exp, sid, metadata }`.

### `AnonymousTokens` — removed from public export

`AnonymousTokens` was exported from `index.ts` but no public method returns it. It is an internal type used between `#postAnonymousToken` and `createSession`/`#mintToken`. Removed from the barrel export; the type itself stays in `types.ts` for internal use.