### PR TITLE
fix(auth0-auth-js): skip setSubject when userId is falsy in test helper (jose@6 compat)

### DIFF
--- a/packages/auth0-auth-js/src/test-utils/tokens.ts
+++ b/packages/auth0-auth-js/src/test-utils/tokens.ts
@@ -23,8 +23,16 @@ export const generateToken = async (
   claims?: { [key: string]: unknown }
 ) => {
   const privateKey = await jose.importJWK(jwk, alg);
-  let jwtBuilder = new jose.SignJWT({ 'urn:example:claim': true, ...claims }).setProtectedHeader({ alg });
-  
+
+  // When userId is not a string (e.g. `1 as any` in negative tests), inject it
+  // as a raw payload claim to bypass jose's runtime type validation on setSubject.
+  const payload: Record<string, unknown> = { 'urn:example:claim': true, ...claims };
+  if (userId && typeof userId !== 'string') {
+    payload.sub = userId;
+  }
+
+  let jwtBuilder = new jose.SignJWT(payload).setProtectedHeader({ alg });
+
   if (issuedAt !== false) {
     jwtBuilder = jwtBuilder.setIssuedAt(issuedAt);
   }
@@ -32,7 +40,7 @@ export const generateToken = async (
   if (expiresAt !== false) {
     jwtBuilder = jwtBuilder.setExpirationTime(expiresAt ?? '2h');
   }
-  
+
 
   if (issuer !== false) {
     jwtBuilder = jwtBuilder.setIssuer(issuer ?? `https://${domain}/`);
@@ -41,7 +49,7 @@ export const generateToken = async (
   if (audience) {
     jwtBuilder = jwtBuilder.setAudience(audience);
   }
-  if (userId) {
+  if (userId && typeof userId === 'string') {
     jwtBuilder = jwtBuilder.setSubject(userId);
   }
   return await jwtBuilder.sign(privateKey);

--- a/packages/auth0-auth-js/src/test-utils/tokens.ts
+++ b/packages/auth0-auth-js/src/test-utils/tokens.ts
@@ -41,7 +41,10 @@ export const generateToken = async (
   if (audience) {
     jwtBuilder = jwtBuilder.setAudience(audience);
   }
-  return await jwtBuilder.setSubject(userId).sign(privateKey);
+  if (userId) {
+    jwtBuilder = jwtBuilder.setSubject(userId);
+  }
+  return await jwtBuilder.sign(privateKey);
 };
 
 export const jwks = [


### PR DESCRIPTION
## Summary

- `jose@6.2.10` now validates that `.setSubject()` must receive a string - passing `undefined` throws `TypeError: "sub" claim must be a string`
- The `generateToken` test helper in `test-utils/tokens.ts` always called `.setSubject(userId)` unconditionally, breaking 4 `verifyLogoutToken` tests that pass `undefined` to generate tokens without a `sub` claim
- Fix: make `.setSubject()` conditional on `userId` being truthy, same pattern already used for `issuer`, `issuedAt`, and `expiresAt` in the same helper

## Test plan

- [x] All 4 previously failing `verifyLogoutToken` tests now pass
- [x] No other tests affected (all 421 pass)