### PR TITLE
fix(auth0-auth-js): anonymous session post-review fixes

### DIFF
--- a/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.spec.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.spec.ts
@@ -1,8 +1,23 @@
 import { expect, test, describe, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import { setupServer } from 'msw/node';
 import { http, HttpResponse } from 'msw';
+import { decodeJwt, decodeProtectedHeader } from 'jose';
 import { AnonymousSessionClient } from './anonymous-session-client.js';
 import { AnonymousSessionError } from './errors.js';
+
+const exportPrivateKeyToPem = async (privateKey: CryptoKey): Promise<string> => {
+  const pkcs8 = await crypto.subtle.exportKey('pkcs8', privateKey);
+  const keyBase64 = Buffer.from(pkcs8).toString('base64');
+  const keyLines = keyBase64.match(/.{1,64}/g) ?? [keyBase64];
+  return `-----BEGIN PRIVATE KEY-----\n${keyLines.join('\n')}\n-----END PRIVATE KEY-----`;
+};
+
+const generateRsaKeyPair = () =>
+  crypto.subtle.generateKey(
+    { name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: { name: 'SHA-256' } },
+    true,
+    ['sign', 'verify']
+  ) as Promise<CryptoKeyPair>;
 
 const domain = 'auth0.local';
 const clientId = 'test-client-id';
@@ -434,5 +449,112 @@ describe('expiresAt', () => {
     // expires_in is 3600 in the mock
     expect(session.expiresAt).toBeGreaterThanOrEqual(before + 3600);
     expect(session.expiresAt).toBeLessThanOrEqual(after + 3600);
+  });
+});
+
+// ─── client authentication ────────────────────────────────────────────────────
+
+describe('client authentication', () => {
+  test('sends client_secret when clientSecret is configured', async () => {
+    let capturedBody: Record<string, unknown> = {};
+
+    server.use(
+      http.post(`https://${domain}/anonymous/token`, async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          access_token: accessToken,
+          token_type: 'Bearer',
+          expires_in: 3600,
+          session_token: sessionToken,
+        });
+      })
+    );
+
+    const client = makeClient({ clientSecret: 'test-secret' });
+    await client.createSession();
+
+    expect(capturedBody.client_secret).toBe('test-secret');
+    expect(capturedBody).not.toHaveProperty('client_assertion');
+  });
+
+  test('sends no auth fields for a public client', async () => {
+    let capturedBody: Record<string, unknown> = {};
+
+    server.use(
+      http.post(`https://${domain}/anonymous/token`, async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          access_token: accessToken,
+          token_type: 'Bearer',
+          expires_in: 3600,
+          session_token: sessionToken,
+        });
+      })
+    );
+
+    const client = makeClient();
+    await client.createSession();
+
+    expect(capturedBody).not.toHaveProperty('client_secret');
+    expect(capturedBody).not.toHaveProperty('client_assertion');
+  });
+
+  test('sends client_assertion for private_key_jwt with a PEM key', async () => {
+    let capturedBody: Record<string, unknown> = {};
+
+    server.use(
+      http.post(`https://${domain}/anonymous/token`, async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          access_token: accessToken,
+          token_type: 'Bearer',
+          expires_in: 3600,
+          session_token: sessionToken,
+        });
+      })
+    );
+
+    const { privateKey } = await generateRsaKeyPair();
+    const pem = await exportPrivateKeyToPem(privateKey);
+    const client = makeClient({ clientAssertionSigningKey: pem, clientAssertionSigningAlg: 'RS256' });
+    await client.createSession();
+
+    expect(capturedBody.client_assertion_type).toBe('urn:ietf:params:oauth:client-assertion-type:jwt-bearer');
+    const jwt = capturedBody.client_assertion as string;
+    expect(typeof jwt).toBe('string');
+    expect(decodeProtectedHeader(jwt).alg).toBe('RS256');
+    const claims = decodeJwt(jwt);
+    expect(claims.iss).toBe(clientId);
+    expect(claims.sub).toBe(clientId);
+    expect(claims.aud).toBe(`https://${domain}/`);
+    expect(typeof claims.jti).toBe('string');
+    const ttl = (claims.exp as number) - (claims.iat as number);
+    expect(ttl).toBe(120);
+    expect(capturedBody).not.toHaveProperty('client_secret');
+  });
+
+  test('sends client_assertion for private_key_jwt with a CryptoKey', async () => {
+    let capturedBody: Record<string, unknown> = {};
+
+    server.use(
+      http.post(`https://${domain}/anonymous/token`, async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          access_token: accessToken,
+          token_type: 'Bearer',
+          expires_in: 3600,
+          session_token: sessionToken,
+        });
+      })
+    );
+
+    const { privateKey } = await generateRsaKeyPair();
+    const client = makeClient({ clientAssertionSigningKey: privateKey });
+    await client.createSession();
+
+    const jwt = capturedBody.client_assertion as string;
+    expect(typeof jwt).toBe('string');
+    expect(decodeJwt(jwt).aud).toBe(`https://${domain}/`);
+    expect(capturedBody).not.toHaveProperty('client_secret');
   });
 });

--- a/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.spec.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.spec.ts
@@ -286,12 +286,12 @@ describe('createSession', () => {
   });
 });
 
-// ─── getTokenSilently ─────────────────────────────────────────────────────────
+// ─── getAccessToken ─────────────────────────────────────────────────────────
 
-describe('getTokenSilently', () => {
+describe('getAccessToken', () => {
   test('creates a new session when no sessionToken is provided', async () => {
     const client = makeClient();
-    const session = await client.getTokenSilently();
+    const session = await client.getAccessToken();
 
     expect(session.sessionToken).toBe(sessionToken);
     expect(session.accessToken).toBe(accessToken);
@@ -299,7 +299,7 @@ describe('getTokenSilently', () => {
 
   test('re-mints access token when sessionToken is provided', async () => {
     const client = makeClient();
-    const session = await client.getTokenSilently({ sessionToken });
+    const session = await client.getAccessToken({ sessionToken });
 
     expect(session.accessToken).toBe('renewed-access-token');
     expect(session.sessionToken).toBe(sessionToken);
@@ -322,7 +322,7 @@ describe('getTokenSilently', () => {
     );
 
     const client = makeClient();
-    await client.getTokenSilently({ sessionToken: 'my-session-token', audience: 'https://api.example.com', scope: 'openid' });
+    await client.getAccessToken({ sessionToken: 'my-session-token', audience: 'https://api.example.com', scope: 'openid' });
 
     expect(capturedBody.session_token).toBe('my-session-token');
     expect(capturedBody.audience).toBe('https://api.example.com');
@@ -347,7 +347,7 @@ describe('getTokenSilently', () => {
     );
 
     const client = makeClient();
-    await client.getTokenSilently({ audience: 'https://api.example.com', scope: 'openid' });
+    await client.getAccessToken({ audience: 'https://api.example.com', scope: 'openid' });
 
     expect(capturedBody.audience).toBe('https://api.example.com');
     expect(capturedBody.scope).toBe('openid');
@@ -356,7 +356,7 @@ describe('getTokenSilently', () => {
 
   test('silently creates a new session when session_expired is encountered', async () => {
     const client = makeClient();
-    const result = await client.getTokenSilently({ sessionToken: 'expired-session-token' });
+    const result = await client.getAccessToken({ sessionToken: 'expired-session-token' });
 
     expect(result.sessionToken).toBe(sessionToken);
     expect(result.accessToken).toBe(accessToken);
@@ -364,7 +364,7 @@ describe('getTokenSilently', () => {
 
   test('silently creates a new session when invalid_session_token is encountered', async () => {
     const client = makeClient();
-    const result = await client.getTokenSilently({ sessionToken: 'invalid-session-token' });
+    const result = await client.getAccessToken({ sessionToken: 'invalid-session-token' });
 
     expect(result.sessionToken).toBe(sessionToken);
     expect(result.accessToken).toBe(accessToken);
@@ -381,7 +381,7 @@ describe('getTokenSilently', () => {
     );
 
     const client = makeClient();
-    await expect(client.getTokenSilently({ sessionToken })).rejects.toMatchObject({
+    await expect(client.getAccessToken({ sessionToken })).rejects.toMatchObject({
       name: 'AnonymousSessionError',
       code: 'invalid_scope',
     });
@@ -584,10 +584,10 @@ describe('sessionTokenExpiresAt', () => {
     expect(session.sessionTokenExpiresAt).toBeLessThanOrEqual(after + sessionExpiresIn);
   });
 
-  test('set on getTokenSilently re-mint and counts down from original expiry', async () => {
+  test('set on getAccessToken re-mint and counts down from original expiry', async () => {
     const client = makeClient();
     const before = Math.floor(Date.now() / 1000);
-    const session = await client.getTokenSilently({ sessionToken });
+    const session = await client.getAccessToken({ sessionToken });
     const after = Math.floor(Date.now() / 1000);
 
     // default handler returns sessionExpiresIn - 3600 for re-mint
@@ -599,7 +599,7 @@ describe('sessionTokenExpiresAt', () => {
   test('renewal sessionTokenExpiresAt is less than create sessionTokenExpiresAt', async () => {
     const client = makeClient();
     const created = await client.createSession();
-    const renewed = await client.getTokenSilently({ sessionToken });
+    const renewed = await client.getAccessToken({ sessionToken });
 
     expect(renewed.sessionTokenExpiresAt!).toBeLessThan(created.sessionTokenExpiresAt!);
   });

--- a/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.spec.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.spec.ts
@@ -23,6 +23,7 @@ const domain = 'auth0.local';
 const clientId = 'test-client-id';
 const sessionToken = 'test-session-token';
 const accessToken = 'test-access-token';
+const sessionExpiresIn = 2592000; // 30 days in seconds
 
 const makeClient = (overrides?: Partial<ConstructorParameters<typeof AnonymousSessionClient>[0]>) =>
   new AnonymousSessionClient({ domain, clientId, ...overrides });
@@ -72,6 +73,7 @@ const restHandlers = [
         token_type: 'Bearer',
         expires_in: 3600,
         scope: body.scope ?? 'openid',
+        session_expires_in: sessionExpiresIn - 3600, // counts down, not reset
       });
     }
 
@@ -82,6 +84,7 @@ const restHandlers = [
       expires_in: 3600,
       scope: body.scope ?? 'openid',
       session_token: sessionToken,
+      session_expires_in: sessionExpiresIn,
     });
   }),
 
@@ -119,6 +122,7 @@ describe('createSession', () => {
           token_type: 'Bearer',
           expires_in: 3600,
           session_token: sessionToken,
+          session_expires_in: sessionExpiresIn,
         });
       })
     );
@@ -142,6 +146,7 @@ describe('createSession', () => {
           token_type: 'Bearer',
           expires_in: 3600,
           session_token: sessionToken,
+          session_expires_in: sessionExpiresIn,
         });
       })
     );
@@ -163,6 +168,7 @@ describe('createSession', () => {
           token_type: 'Bearer',
           expires_in: 3600,
           session_token: sessionToken,
+          session_expires_in: sessionExpiresIn,
         });
       })
     );
@@ -310,6 +316,7 @@ describe('getTokenSilently', () => {
           access_token: 'renewed-access-token',
           token_type: 'Bearer',
           expires_in: 3600,
+          session_expires_in: sessionExpiresIn,
         });
       })
     );
@@ -334,6 +341,7 @@ describe('getTokenSilently', () => {
           token_type: 'Bearer',
           expires_in: 3600,
           session_token: sessionToken,
+          session_expires_in: sessionExpiresIn,
         });
       })
     );
@@ -466,6 +474,7 @@ describe('client authentication', () => {
           token_type: 'Bearer',
           expires_in: 3600,
           session_token: sessionToken,
+          session_expires_in: sessionExpiresIn,
         });
       })
     );
@@ -488,6 +497,7 @@ describe('client authentication', () => {
           token_type: 'Bearer',
           expires_in: 3600,
           session_token: sessionToken,
+          session_expires_in: sessionExpiresIn,
         });
       })
     );
@@ -510,6 +520,7 @@ describe('client authentication', () => {
           token_type: 'Bearer',
           expires_in: 3600,
           session_token: sessionToken,
+          session_expires_in: sessionExpiresIn,
         });
       })
     );
@@ -544,6 +555,7 @@ describe('client authentication', () => {
           token_type: 'Bearer',
           expires_in: 3600,
           session_token: sessionToken,
+          session_expires_in: sessionExpiresIn,
         });
       })
     );
@@ -556,5 +568,57 @@ describe('client authentication', () => {
     expect(typeof jwt).toBe('string');
     expect(decodeJwt(jwt).aud).toBe(`https://${domain}/`);
     expect(capturedBody).not.toHaveProperty('client_secret');
+  });
+});
+
+// ─── sessionTokenExpiresAt ────────────────────────────────────────────────────
+
+describe('sessionTokenExpiresAt', () => {
+  test('set on createSession from session_expires_in', async () => {
+    const client = makeClient();
+    const before = Math.floor(Date.now() / 1000);
+    const session = await client.createSession();
+    const after = Math.floor(Date.now() / 1000);
+
+    expect(session.sessionTokenExpiresAt).toBeGreaterThanOrEqual(before + sessionExpiresIn);
+    expect(session.sessionTokenExpiresAt).toBeLessThanOrEqual(after + sessionExpiresIn);
+  });
+
+  test('set on getTokenSilently re-mint and counts down from original expiry', async () => {
+    const client = makeClient();
+    const before = Math.floor(Date.now() / 1000);
+    const session = await client.getTokenSilently({ sessionToken });
+    const after = Math.floor(Date.now() / 1000);
+
+    // default handler returns sessionExpiresIn - 3600 for re-mint
+    const expected = sessionExpiresIn - 3600;
+    expect(session.sessionTokenExpiresAt).toBeGreaterThanOrEqual(before + expected);
+    expect(session.sessionTokenExpiresAt).toBeLessThanOrEqual(after + expected);
+  });
+
+  test('renewal sessionTokenExpiresAt is less than create sessionTokenExpiresAt', async () => {
+    const client = makeClient();
+    const created = await client.createSession();
+    const renewed = await client.getTokenSilently({ sessionToken });
+
+    expect(renewed.sessionTokenExpiresAt!).toBeLessThan(created.sessionTokenExpiresAt!);
+  });
+
+  test('sessionTokenExpiresAt is undefined when session_expires_in is absent', async () => {
+    server.use(
+      http.post(`https://${domain}/anonymous/token`, () =>
+        HttpResponse.json({
+          access_token: accessToken,
+          token_type: 'Bearer',
+          expires_in: 3600,
+          session_token: sessionToken,
+        })
+      )
+    );
+
+    const client = makeClient();
+    const session = await client.createSession();
+
+    expect(session.sessionTokenExpiresAt).toBeUndefined();
   });
 });

--- a/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.spec.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.spec.ts
@@ -57,10 +57,10 @@ const restHandlers = [
       );
     }
 
-    // Simulate metadata_too_large
+    // Simulate metadata size error — platform returns invalid_request, not metadata_too_large
     if (body.metadata && JSON.stringify(body.metadata).length > 1024) {
       return HttpResponse.json(
-        { error: 'metadata_too_large', error_description: 'Metadata exceeds 1 KB limit' },
+        { error: 'invalid_request', error_description: 'metadata exceeds the maximum allowed size' },
         { status: 400 }
       );
     }
@@ -269,13 +269,13 @@ describe('createSession', () => {
     });
   });
 
-  test('throws AnonymousSessionError with code metadata_too_large when metadata exceeds 1 KB', async () => {
+  test('throws AnonymousSessionError with code invalid_request when metadata exceeds 1 KB', async () => {
     const client = makeClient();
     const largeMetadata = { data: 'x'.repeat(1025) };
 
     await expect(client.createSession({ metadata: largeMetadata })).rejects.toMatchObject({
       name: 'AnonymousSessionError',
-      code: 'metadata_too_large',
+      code: 'invalid_request',
     });
   });
 });

--- a/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.spec.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.spec.ts
@@ -370,6 +370,34 @@ describe('getAccessToken', () => {
     expect(result.accessToken).toBe(accessToken);
   });
 
+  test('sets sessionReplaced: true when session expired and fresh identity was created', async () => {
+    const client = makeClient();
+    const result = await client.getAccessToken({ sessionToken: 'expired-session-token' });
+
+    expect(result.sessionReplaced).toBe(true);
+  });
+
+  test('sets sessionReplaced: true when session token is invalid and fresh identity was created', async () => {
+    const client = makeClient();
+    const result = await client.getAccessToken({ sessionToken: 'invalid-session-token' });
+
+    expect(result.sessionReplaced).toBe(true);
+  });
+
+  test('sets sessionReplaced: false on a normal renewal', async () => {
+    const client = makeClient();
+    const result = await client.getAccessToken({ sessionToken });
+
+    expect(result.sessionReplaced).toBe(false);
+  });
+
+  test('sessionReplaced is absent when called without a sessionToken', async () => {
+    const client = makeClient();
+    const result = await client.getAccessToken();
+
+    expect(result.sessionReplaced).toBeUndefined();
+  });
+
   test('propagates non-session errors to the caller', async () => {
     server.use(
       http.post(`https://${domain}/anonymous/token`, () =>

--- a/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
@@ -6,7 +6,7 @@ import type {
   AnonymousTokens,
   AnonymousTokenApiResponse,
   CreateAnonymousSessionOptions,
-  GetAnonymousTokenSilentlyOptions,
+  GetAnonymousAccessTokenOptions,
 } from './types.js';
 
 /**
@@ -59,7 +59,7 @@ async function parseErrorResponse(response: Response): Promise<AnonymousSessionA
  * Client for anonymous session operations.
  *
  * Provides low-level HTTP calls to the Auth0 anonymous session endpoints as well
- * as a higher-level {@link getTokenSilently} method that implements the renewal
+ * as a higher-level {@link getAccessToken} method that implements the renewal
  * logic: if the access token is expired it re-mints it from the session token;
  * if the session token itself has expired a fresh anonymous session is created
  * silently (any metadata previously set on the session is lost at that point).
@@ -81,7 +81,7 @@ async function parseErrorResponse(response: Response): Promise<AnonymousSessionA
  * });
  *
  * // Later, get a valid access token (renews automatically if expired)
- * const updatedSession = await authClient.anonymous.getTokenSilently({
+ * const updatedSession = await authClient.anonymous.getAccessToken({
  *   sessionToken: session.sessionToken,
  *   audience: 'https://api.example.com',
  * });
@@ -196,18 +196,18 @@ export class AnonymousSessionClient {
    * @example
    * ```typescript
    * // First visit — no session yet
-   * const session = await authClient.anonymous.getTokenSilently({
+   * const session = await authClient.anonymous.getAccessToken({
    *   audience: 'https://api.example.com',
    * });
    *
    * // Subsequent visit — renew existing session token
-   * const renewed = await authClient.anonymous.getTokenSilently({
+   * const renewed = await authClient.anonymous.getAccessToken({
    *   sessionToken: storedSessionToken,
    *   audience: 'https://api.example.com',
    * });
    * ```
    */
-  async getTokenSilently(options?: GetAnonymousTokenSilentlyOptions): Promise<AnonymousSession> {
+  async getAccessToken(options?: GetAnonymousAccessTokenOptions): Promise<AnonymousSession> {
     if (!options?.sessionToken) {
       return this.createSession({ audience: options?.audience, scope: options?.scope });
     }
@@ -226,9 +226,9 @@ export class AnonymousSessionClient {
 
   /**
    * Re-mints an access token for an existing anonymous session.
-   * Internal — callers use {@link getTokenSilently} instead.
+   * Internal — callers use {@link getAccessToken} instead.
    */
-  async #mintToken(sessionToken: string, options?: GetAnonymousTokenSilentlyOptions): Promise<AnonymousSession> {
+  async #mintToken(sessionToken: string, options?: GetAnonymousAccessTokenOptions): Promise<AnonymousSession> {
     const body: Record<string, unknown> = {
       client_id: this.#clientId,
       session_token: sessionToken,

--- a/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
@@ -94,6 +94,7 @@ export class AnonymousSessionClient {
   readonly #clientSecret?: string;
   readonly #clientAssertionSigningKey?: string | CryptoKey;
   readonly #clientAssertionSigningAlg?: string;
+  readonly #useMtls?: boolean;
   readonly #customFetch: typeof fetch;
 
   /**
@@ -106,6 +107,7 @@ export class AnonymousSessionClient {
     this.#clientSecret = options.clientSecret;
     this.#clientAssertionSigningKey = options.clientAssertionSigningKey;
     this.#clientAssertionSigningAlg = options.clientAssertionSigningAlg;
+    this.#useMtls = options.useMtls;
     this.#customFetch = options.customFetch ?? ((...args) => fetch(...args));
   }
 
@@ -305,6 +307,7 @@ export class AnonymousSessionClient {
         clientSecret: this.#clientSecret,
         clientAssertionSigningKey: this.#clientAssertionSigningKey,
         clientAssertionSigningAlg: this.#clientAssertionSigningAlg,
+        useMtls: this.#useMtls,
       },
       this.#clientId,
       this.#domain

--- a/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
@@ -1,4 +1,5 @@
 import { AnonymousSessionError, type AnonymousSessionApiErrorResponse } from './errors.js';
+import { buildClientAuthBody } from './utils.js';
 import type {
   AnonymousSessionClientOptions,
   AnonymousSession,
@@ -87,18 +88,24 @@ async function parseErrorResponse(response: Response): Promise<AnonymousSessionA
  * ```
  */
 export class AnonymousSessionClient {
+  readonly #domain: string;
   readonly #baseUrl: string;
   readonly #clientId: string;
   readonly #clientSecret?: string;
+  readonly #clientAssertionSigningKey?: string | CryptoKey;
+  readonly #clientAssertionSigningAlg?: string;
   readonly #customFetch: typeof fetch;
 
   /**
    * @internal
    */
   constructor(options: AnonymousSessionClientOptions) {
+    this.#domain = options.domain;
     this.#baseUrl = `https://${options.domain}`;
     this.#clientId = options.clientId;
     this.#clientSecret = options.clientSecret;
+    this.#clientAssertionSigningKey = options.clientAssertionSigningKey;
+    this.#clientAssertionSigningAlg = options.clientAssertionSigningAlg;
     this.#customFetch = options.customFetch ?? ((...args) => fetch(...args));
   }
 
@@ -293,9 +300,16 @@ export class AnonymousSessionClient {
   async #postAnonymousToken(body: Record<string, unknown>): Promise<AnonymousTokens> {
     const url = `${this.#baseUrl}/anonymous/token`;
 
-    if (this.#clientSecret) {
-      body.client_secret = this.#clientSecret;
-    }
+    const authFields = await buildClientAuthBody(
+      {
+        clientSecret: this.#clientSecret,
+        clientAssertionSigningKey: this.#clientAssertionSigningKey,
+        clientAssertionSigningAlg: this.#clientAssertionSigningAlg,
+      },
+      this.#clientId,
+      this.#domain
+    );
+    Object.assign(body, authFields);
 
     const response = await this.#customFetch(url, {
       method: 'POST',

--- a/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
@@ -125,6 +125,16 @@ export class AnonymousSessionClient {
    * identity at creation time. Metadata is **set once** and cannot be changed
    * after the session is created.
    *
+   * **Browser caveat — metadata and existing sessions.**
+   * This method sends `credentials: 'include'`, so the `auth0_anon` cookie is
+   * sent automatically in a browser. If that cookie is already set when `metadata`
+   * is supplied, Auth0 treats the request as a renewal (not a fresh create) and
+   * rejects `metadata` with `invalid_request: metadata cannot be provided when
+   * session_token is present`. This happens because the cookie overrides the body
+   * on the server side — the caller never sees the cookie and has no way to clear it.
+   * To recover, catch the `invalid_request` error and call `getAccessToken()`
+   * without `metadata` to renew the existing session instead.
+   *
    * @param options - Options for the new session
    * @param options.audience - The API audience to scope the access token to
    * @param options.scope - Space-separated list of scopes to request

--- a/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
@@ -241,14 +241,19 @@ export class AnonymousSessionClient {
   /**
    * Ends an anonymous session.
    *
-   * Calls `POST /anonymous/logout` to invalidate the session on Auth0's side.
-   * The anonymous session is identified via the `auth0_anon` cookie, which is
-   * sent automatically through `credentials: 'include'`.
+   * Calls `POST /anonymous/logout`. Auth0 identifies the session via the
+   * `auth0_anon` cookie (sent automatically through `credentials: 'include'`)
+   * and clears it in the response. If the cookie is not cleared, it is sent to
+   * `/authorize` on the next login, re-attaching the anonymous identity to the
+   * authenticated user.
    *
-   * Note: Any access tokens issued before logout remain valid until they naturally
-   * expire. There is no server-side session store to revoke them from.
+   * When called server-side (e.g. via auth0-server-js), the user's browser
+   * cookie is not forwarded to Auth0 and the `Set-Cookie` clear response does
+   * not reach the browser — the higher-level SDK must handle cookie proxying.
    *
-   * @returns Promise that resolves when the session has been ended
+   * Issued access tokens are not revoked and remain valid until natural expiry.
+   *
+   * @returns Promise that resolves when the logout request succeeds
    * @throws {AnonymousSessionError} When the request fails
    *
    * @example
@@ -262,10 +267,6 @@ export class AnonymousSessionClient {
     const body: Record<string, unknown> = {
       client_id: this.#clientId,
     };
-
-    if (this.#clientSecret) {
-      body.client_secret = this.#clientSecret;
-    }
 
     const response = await this.#customFetch(url, {
       method: 'POST',

--- a/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
@@ -33,6 +33,10 @@ function parseTokenResponse(apiResponse: AnonymousTokenApiResponse): AnonymousTo
     expiresAt: now + expiresIn,
     scope: apiResponse.scope,
     sessionToken: apiResponse.session_token,
+    sessionTokenExpiresAt:
+      typeof apiResponse.session_expires_in === 'number' && Number.isFinite(apiResponse.session_expires_in)
+        ? now + apiResponse.session_expires_in
+        : undefined,
   };
 }
 
@@ -161,6 +165,7 @@ export class AnonymousSessionClient {
       sessionToken: tokens.sessionToken,
       accessToken: tokens.accessToken,
       expiresAt: tokens.expiresAt,
+      sessionTokenExpiresAt: tokens.sessionTokenExpiresAt,
       scope: tokens.scope,
     };
   }
@@ -242,6 +247,7 @@ export class AnonymousSessionClient {
       sessionToken,
       accessToken: tokens.accessToken,
       expiresAt: tokens.expiresAt,
+      sessionTokenExpiresAt: tokens.sessionTokenExpiresAt,
       scope: tokens.scope,
     };
   }

--- a/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
@@ -30,7 +30,6 @@ function parseTokenResponse(apiResponse: AnonymousTokenApiResponse): AnonymousTo
   }
   return {
     accessToken: apiResponse.access_token,
-    expiresIn,
     expiresAt: now + expiresIn,
     scope: apiResponse.scope,
     sessionToken: apiResponse.session_token,

--- a/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/anonymous-session-client.ts
@@ -193,6 +193,8 @@ export class AnonymousSessionClient {
    * 3. If the session token has expired (`session_expired` or `invalid_session_token`)
    *    — silently creates a fresh anonymous session instead.
    *    **Any metadata previously attached to the session is permanently lost.**
+   *    The returned session will have `sessionReplaced: true` to signal that a new
+   *    identity was minted — the previous `sub` and any associated state are gone.
    * 4. For all other errors — throws an {@link AnonymousSessionError}.
    *
    * @param options - Options for the token request
@@ -200,7 +202,9 @@ export class AnonymousSessionClient {
    *   Omit to create a new session.
    * @param options.audience - The API audience to scope the access token to
    * @param options.scope - Space-separated list of scopes to request
-   * @returns A valid anonymous session (may be newly created or renewed)
+   * @returns A valid anonymous session (may be newly created or renewed).
+   *   `sessionReplaced` is `false` on a normal renewal and `true` when the session
+   *   expired and a fresh identity was silently created.
    * @throws {AnonymousSessionError} For non-recoverable errors
    *
    * @example
@@ -228,7 +232,8 @@ export class AnonymousSessionClient {
       if (e instanceof AnonymousSessionError && SESSION_INVALIDATION_CODES.has(e.code)) {
         // Session token expired or invalid — silently start a fresh session.
         // Any metadata attached to the old session is permanently lost.
-        return this.createSession({ audience: options?.audience, scope: options?.scope });
+        const fresh = await this.createSession({ audience: options?.audience, scope: options?.scope });
+        return { ...fresh, sessionReplaced: true };
       }
       throw e;
     }
@@ -259,6 +264,7 @@ export class AnonymousSessionClient {
       expiresAt: tokens.expiresAt,
       sessionTokenExpiresAt: tokens.sessionTokenExpiresAt,
       scope: tokens.scope,
+      sessionReplaced: false,
     };
   }
 

--- a/packages/auth0-auth-js/src/anonymous-session/errors.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/errors.ts
@@ -38,7 +38,7 @@ export type AnonymousSessionErrorCode =
  * Error thrown when an anonymous session operation fails.
  *
  * The `code` field identifies the specific failure reason. Codes `session_expired`
- * and `invalid_session_token` are handled silently by {@link AnonymousSessionClient.getTokenSilently}
+ * and `invalid_session_token` are handled silently by {@link AnonymousSessionClient.getAccessToken}
  * and will never reach the caller from that method. All other codes are surfaced directly.
  */
 export class AnonymousSessionError extends Error {

--- a/packages/auth0-auth-js/src/anonymous-session/errors.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/errors.ts
@@ -13,19 +13,18 @@ export interface AnonymousSessionApiErrorResponse {
  * Codes that map directly to Auth0 API error responses:
  * - `session_expired` — The session token has expired.
  * - `invalid_session_token` — The session token is malformed.
- * - `metadata_too_large` — The metadata payload at session creation exceeded 1 KB.
  * - `unauthorized_client` — The client ID is not enabled for anonymous sessions.
  * - `feature_not_enabled` — The tenant-level anonymous sessions flag is off.
  * - `invalid_client` — Client authentication failed.
  * - `invalid_target` — The resource server is not enabled for anonymous access.
  * - `invalid_request` — The request was malformed or the resource server is not enabled.
+ *   Also returned when the metadata payload exceeds the size limit (~1 KB, JSON-serialized).
  * - `invalid_scope` — The requested scope is not granted to anonymous callers.
  * - `server_error` — An Auth0 infrastructure error occurred.
  */
 export type AnonymousSessionErrorCode =
   | 'session_expired'
   | 'invalid_session_token'
-  | 'metadata_too_large'
   | 'unauthorized_client'
   | 'feature_not_enabled'
   | 'invalid_client'

--- a/packages/auth0-auth-js/src/anonymous-session/index.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/index.ts
@@ -5,5 +5,5 @@ export type {
   AnonymousSession,
   AnonymousSessionClaims,
   CreateAnonymousSessionOptions,
-  GetAnonymousTokenSilentlyOptions,
+  GetAnonymousAccessTokenOptions,
 } from './types.js';

--- a/packages/auth0-auth-js/src/anonymous-session/index.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/index.ts
@@ -3,7 +3,6 @@ export { AnonymousSessionError } from './errors.js';
 export type { AnonymousSessionErrorCode } from './errors.js';
 export type {
   AnonymousSession,
-  AnonymousTokens,
   AnonymousSessionClaims,
   CreateAnonymousSessionOptions,
   GetAnonymousTokenSilentlyOptions,

--- a/packages/auth0-auth-js/src/anonymous-session/types.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/types.ts
@@ -156,7 +156,7 @@ export interface CreateAnonymousSessionOptions {
 /**
  * Options for silently obtaining a valid anonymous access token.
  */
-export interface GetAnonymousTokenSilentlyOptions {
+export interface GetAnonymousAccessTokenOptions {
   /**
    * The session token from an existing anonymous session.
    * When provided, the SDK will re-mint the access token using the session token.

--- a/packages/auth0-auth-js/src/anonymous-session/types.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/types.ts
@@ -26,6 +26,11 @@ export interface AnonymousSessionClientOptions {
    */
   clientAssertionSigningAlg?: string;
   /**
+   * Set to `true` when the client authenticates with a mutual TLS certificate.
+   * No body-level credential is sent — the certificate handles authentication.
+   */
+  useMtls?: boolean;
+  /**
    * Optional custom Fetch implementation to use.
    */
   customFetch?: typeof fetch;

--- a/packages/auth0-auth-js/src/anonymous-session/types.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/types.ts
@@ -12,9 +12,19 @@ export interface AnonymousSessionClientOptions {
    */
   clientId: string;
   /**
-   * The client secret. Required for confidential clients.
+   * The client secret. Used for `client_secret_post` authentication.
    */
   clientSecret?: string;
+  /**
+   * A private key (PEM string or `CryptoKey`) used to sign a client assertion
+   * JWT for `private_key_jwt` authentication.
+   */
+  clientAssertionSigningKey?: string | CryptoKey;
+  /**
+   * The algorithm used to sign the client assertion JWT.
+   * Defaults to `'RS256'` when `clientAssertionSigningKey` is provided.
+   */
+  clientAssertionSigningAlg?: string;
   /**
    * Optional custom Fetch implementation to use.
    */

--- a/packages/auth0-auth-js/src/anonymous-session/types.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/types.ts
@@ -75,10 +75,6 @@ export interface AnonymousTokens {
    */
   accessToken: string;
   /**
-   * Number of seconds until the access token expires.
-   */
-  expiresIn: number;
-  /**
    * Unix timestamp (seconds) at which the access token expires.
    */
   expiresAt: number;
@@ -105,7 +101,7 @@ export interface AnonymousTokens {
 export interface AnonymousSessionClaims {
   /** Issuer of the token. */
   iss: string;
-  /** Subject — the anonymous identity, e.g. `anon|<id>`. */
+  /** Subject — the anonymous identity, e.g. `anon@<uuid>`. */
   sub: string;
   /** Audience — the tenant issuer URL. */
   aud: string | string[];

--- a/packages/auth0-auth-js/src/anonymous-session/types.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/types.ts
@@ -105,12 +105,16 @@ export interface AnonymousTokens {
 export interface AnonymousSessionClaims {
   /** Issuer of the token. */
   iss: string;
-  /** Subject — the anonymous identity, e.g. `anon@abc123`. */
+  /** Subject — the anonymous identity, e.g. `anon|<id>`. */
   sub: string;
-  /** Unique identifier for the anonymous session. */
-  session_id: string;
-  /** Unix timestamp when the anonymous session was created. */
-  created_at: number;
+  /** Audience — the tenant issuer URL. */
+  aud: string | string[];
+  /** Issued-at timestamp (seconds since epoch). */
+  iat: number;
+  /** Expiry timestamp (seconds since epoch). */
+  exp: number;
+  /** Session ID. */
+  sid: string;
   /** Up to 1KB of key-value metadata set at session creation time. */
   metadata?: Record<string, string>;
 }

--- a/packages/auth0-auth-js/src/anonymous-session/types.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/types.ts
@@ -57,6 +57,16 @@ export interface AnonymousSession {
    */
   expiresAt: number;
   /**
+   * Unix timestamp (seconds) at which the session token itself expires.
+   *
+   * The session token is minted once and never reissued, so this value counts
+   * down on every response rather than resetting. Absent when the API response
+   * does not include `session_expires_in`.
+   *
+   * Use this — not `expiresAt` — to drive cookie `Max-Age` or session expiry UI.
+   */
+  sessionTokenExpiresAt?: number;
+  /**
    * Scopes granted to this anonymous session.
    */
   scope?: string;
@@ -87,6 +97,12 @@ export interface AnonymousTokens {
    * Only present when a new session is created (not on re-mint).
    */
   sessionToken?: string;
+  /**
+   * Unix timestamp (seconds) at which the session token itself expires.
+   * Computed from `session_expires_in` in the API response. Absent when
+   * `session_expires_in` is not present in the response.
+   */
+  sessionTokenExpiresAt?: number;
 }
 
 /**
@@ -170,5 +186,11 @@ export interface AnonymousTokenApiResponse {
   scope?: string;
   /** Only present on session creation, not on re-mint. */
   session_token?: string;
+  /**
+   * Remaining lifetime of the session token in seconds. Present on both create
+   * and re-mint responses. Counts down toward the original expiry — does not
+   * reset on each renewal.
+   */
+  session_expires_in?: number;
 }
 

--- a/packages/auth0-auth-js/src/anonymous-session/types.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/types.ts
@@ -70,6 +70,19 @@ export interface AnonymousSession {
    * Scopes granted to this anonymous session.
    */
   scope?: string;
+  /**
+   * `true` when `getAccessToken()` was called with a `sessionToken` that had
+   * expired or been invalidated, and a fresh anonymous identity was silently
+   * created to replace it.
+   *
+   * When `true` the returned `sessionToken` belongs to a **new identity** —
+   * the previous `sub`, any attached metadata, and any server-side state keyed
+   * to the old identity are permanently gone.
+   *
+   * Absent when `createSession()` is called directly or when `getAccessToken()`
+   * is called without a `sessionToken`.
+   */
+  sessionReplaced?: boolean;
 }
 
 /**

--- a/packages/auth0-auth-js/src/anonymous-session/types.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/types.ts
@@ -112,7 +112,7 @@ export interface AnonymousSessionClaims {
   /** Unix timestamp when the anonymous session was created. */
   created_at: number;
   /** Up to 1KB of key-value metadata set at session creation time. */
-  metadata?: Record<string, unknown>;
+  metadata?: Record<string, string>;
 }
 
 /**
@@ -134,7 +134,7 @@ export interface CreateAnonymousSessionOptions {
    * Up to 1KB of arbitrary key-value metadata to attach to the anonymous session.
    * Set once at creation time — cannot be changed after the session is created.
    */
-  metadata?: Record<string, unknown>;
+  metadata?: Record<string, string>;
 }
 
 /**

--- a/packages/auth0-auth-js/src/anonymous-session/utils.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/utils.ts
@@ -11,15 +11,15 @@ const CLIENT_ASSERTION_EXPIRY_SECONDS = 120;
  */
 export type ClientAuthOptions = Pick<
   AnonymousSessionClientOptions,
-  'clientSecret' | 'clientAssertionSigningKey' | 'clientAssertionSigningAlg'
+  'clientSecret' | 'clientAssertionSigningKey' | 'clientAssertionSigningAlg' | 'useMtls'
 >;
 
 /**
  * Builds the client-authentication fields injected into the `/anonymous/token`
  * request body, matching node-auth0's `addClientAuthentication` (FR-1c).
  *
- * Resolution order: `private_key_jwt` → `client_secret_post` → public client
- * (no body auth).
+ * Resolution order: mTLS (no body auth) → `private_key_jwt` → `client_secret_post` →
+ * public client (no body auth).
  *
  * Unlike the passwordless variant, an empty object is returned for a public
  * client (no auth options configured): the anonymous token endpoint does not
@@ -32,6 +32,11 @@ export async function buildClientAuthBody(
   clientId: string,
   domain: string
 ): Promise<Record<string, string>> {
+  // mTLS: certificate is supplied by the custom fetch; no body-level auth.
+  if (options.useMtls) {
+    return {};
+  }
+
   if (options.clientAssertionSigningKey) {
     const alg = options.clientAssertionSigningAlg ?? DEFAULT_CLIENT_ASSERTION_ALG;
     const privateKey =
@@ -40,7 +45,9 @@ export async function buildClientAuthBody(
         : await importPKCS8(options.clientAssertionSigningKey as string, alg);
 
     // Claims mirror node-auth0 client-authentication: iss/sub = clientId,
-    // aud = `https://{domain}/` (trailing slash), short-lived, unique jti.
+    // aud = `https://{domain}/` (trailing slash required — the anonymous token
+    // endpoint expects the issuer identifier, not the token endpoint URL; using
+    // the token endpoint URL is accepted by /oauth/token but rejected here).
     const clientAssertion = await new SignJWT({})
       .setProtectedHeader({ alg })
       .setIssuer(clientId)

--- a/packages/auth0-auth-js/src/anonymous-session/utils.ts
+++ b/packages/auth0-auth-js/src/anonymous-session/utils.ts
@@ -1,0 +1,66 @@
+import { SignJWT, importPKCS8 } from 'jose';
+import type { AnonymousSessionClientOptions } from './types.js';
+
+const DEFAULT_CLIENT_ASSERTION_ALG = 'RS256';
+const CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
+const CLIENT_ASSERTION_EXPIRY_SECONDS = 120;
+
+/**
+ * Subset of {@link AnonymousSessionClientOptions} carrying the client-authentication fields.
+ * @internal
+ */
+export type ClientAuthOptions = Pick<
+  AnonymousSessionClientOptions,
+  'clientSecret' | 'clientAssertionSigningKey' | 'clientAssertionSigningAlg'
+>;
+
+/**
+ * Builds the client-authentication fields injected into the `/anonymous/token`
+ * request body, matching node-auth0's `addClientAuthentication` (FR-1c).
+ *
+ * Resolution order: `private_key_jwt` → `client_secret_post` → public client
+ * (no body auth).
+ *
+ * Unlike the passwordless variant, an empty object is returned for a public
+ * client (no auth options configured): the anonymous token endpoint does not
+ * require client authentication for public clients.
+ *
+ * @internal
+ */
+export async function buildClientAuthBody(
+  options: ClientAuthOptions,
+  clientId: string,
+  domain: string
+): Promise<Record<string, string>> {
+  if (options.clientAssertionSigningKey) {
+    const alg = options.clientAssertionSigningAlg ?? DEFAULT_CLIENT_ASSERTION_ALG;
+    const privateKey =
+      options.clientAssertionSigningKey instanceof CryptoKey
+        ? options.clientAssertionSigningKey
+        : await importPKCS8(options.clientAssertionSigningKey as string, alg);
+
+    // Claims mirror node-auth0 client-authentication: iss/sub = clientId,
+    // aud = `https://{domain}/` (trailing slash), short-lived, unique jti.
+    const clientAssertion = await new SignJWT({})
+      .setProtectedHeader({ alg })
+      .setIssuer(clientId)
+      .setSubject(clientId)
+      .setAudience(`https://${domain}/`)
+      .setJti(crypto.randomUUID())
+      .setIssuedAt()
+      .setExpirationTime(`${CLIENT_ASSERTION_EXPIRY_SECONDS}s`)
+      .sign(privateKey);
+
+    return {
+      client_assertion: clientAssertion,
+      client_assertion_type: CLIENT_ASSERTION_TYPE,
+    };
+  }
+
+  if (options.clientSecret) {
+    return { client_secret: options.clientSecret };
+  }
+
+  // Public client — no body-level authentication required.
+  return {};
+}

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -458,6 +458,7 @@ export class AuthClient {
       clientSecret: this.#options.clientSecret,
       clientAssertionSigningKey: this.#options.clientAssertionSigningKey,
       clientAssertionSigningAlg: this.#options.clientAssertionSigningAlg,
+      useMtls: this.#options.useMtls,
       customFetch: this.#customFetch,
     });
   }

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -297,7 +297,7 @@ export class AuthClient {
    * Sub-client for Auth0 Anonymous Sessions.
    *
    * Use `authClient.anonymous.createSession()` to establish an anonymous identity,
-   * `authClient.anonymous.getTokenSilently(session)` to obtain (and renew) access tokens,
+   * `authClient.anonymous.getAccessToken(session)` to obtain (and renew) access tokens,
    * and `authClient.anonymous.logout(session.sessionToken)` to end the session.
    *
    * Requires the tenant and client to be configured for anonymous sessions.

--- a/packages/auth0-auth-js/src/auth-client.ts
+++ b/packages/auth0-auth-js/src/auth-client.ts
@@ -456,6 +456,8 @@ export class AuthClient {
       domain: this.#options.domain,
       clientId: this.#options.clientId,
       clientSecret: this.#options.clientSecret,
+      clientAssertionSigningKey: this.#options.clientAssertionSigningKey,
+      clientAssertionSigningAlg: this.#options.clientAssertionSigningAlg,
       customFetch: this.#customFetch,
     });
   }


### PR DESCRIPTION
## Summary

Consolidates all post-review fixes for the anonymous session feature introduced in #240.

- **Remove `client_secret` from logout request body** — the anonymous logout endpoint does not accept body-level client credentials; authentication is handled by the `auth0_anon` cookie
- **`private_key_jwt` client authentication** — anonymous token requests now support `client_secret_post`, `private_key_jwt` (PEM or `CryptoKey`), mTLS, and public clients, matching the auth method resolution order of the passkey and passwordless sub-clients
- **`useMtls` wired through to `AnonymousSessionClient`** — prevents sending `client_secret` alongside an mTLS certificate, which Auth0 rejects with `400 Multiple authentication methods provided`
- **Surface `session_expires_in` as `sessionTokenExpiresAt`** — exposes the session token lifetime on `AnonymousSession`; named `sessionTokenExpiresAt` to avoid a clash with the existing `sessionExpiresAt` field on `StateData` in `auth0-server-js`; optional to handle responses where the field is absent
- **Surface `sessionReplaced` on `getAccessToken`** — when a session token is expired or invalid and a fresh identity is silently created, `sessionReplaced: true` is set on the returned session so callers know the previous `sub`, metadata, and any associated state are gone; `false` on a normal renewal
- **Narrow `metadata` to `Record<string, string>`** — aligns the TypeScript type with what the anonymous token endpoint actually accepts
- **Correct `metadata_too_large` error code** — Auth0 returns `invalid_request` for oversized metadata, not a custom `metadata_too_large` code
- **Fix `AnonymousSessionClaims` shape and unexport `AnonymousTokens`** — correct field names (`sid`, `aud`, `iat`, `exp`), fix `sub` example format (`anon@<uuid>`), drop unused `expiresIn` field from the now-internal `AnonymousTokens` type
- **Rename `getTokenSilently` to `getAccessToken`** — the old name was borrowed from `spa-js` silent iframe semantics which do not apply here; `auth0-server-js` already exposes this as `getAccessToken`
- **Document metadata + existing cookie conflict in `createSession`** — in a browser, if an `auth0_anon` cookie is already present when `createSession({ metadata })` is called, Auth0 rejects with `invalid_request`; documented with recovery steps (platform fix tracked separately)

## Test plan

- [ ] `npx turbo run test --filter=@auth0/auth0-auth-js` passes (540 tests)
- [ ] Confirm `useMtls`, `clientAssertionSigningKey`, and `clientAssertionSigningAlg` all flow through to `AnonymousSessionClient`
- [ ] Verify `sessionTokenExpiresAt` is present on `AnonymousSession` and `undefined` when `session_expires_in` is absent
- [ ] Verify `sessionReplaced: true` when `getAccessToken` is called with an expired/invalid session token
- [ ] Verify `sessionReplaced: false` on a normal renewal and absent when called without a `sessionToken`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for anonymous-session authentication using client secrets, private-key JWTs, public clients, and mutual TLS.
  * Added session-token expiration details and indicators when expired or invalid sessions are replaced.
  * Added clearer token expiration timestamps and standardized session claims.
* **Breaking Changes**
  * Renamed `getTokenSilently` to `getAccessToken`.
  * Anonymous-session metadata now accepts string values and oversized metadata returns `invalid_request`.
* **Documentation**
  * Updated anonymous-session guidance for browser cookies and server-side logout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->