### PR TITLE
feat(auth0-server-js): expose getUserInfo delegating to auth-js

### DIFF
--- a/packages/auth0-server-js/EXAMPLES.md
+++ b/packages/auth0-server-js/EXAMPLES.md
@@ -48,20 +48,22 @@
   - [Performing a delegation exchange without a session](#performing-a-delegation-exchange-without-a-session)
   - [Using actor tokens for delegation](#using-actor-tokens-for-delegation)
   - [Passing `StoreOptions`](#passing-storeoptions-6)
+- [Retrieving User Information](#retrieving-user-information)
+  - [Passing `StoreOptions`](#passing-storeoptions-7)
 - [Impersonation via Session Transfer](#impersonation-via-session-transfer)
   - [Initiator: requesting a Session Transfer Token and redirecting](#initiator-requesting-a-session-transfer-token-and-redirecting)
   - [Target: redeeming the Session Transfer Token](#target-redeeming-the-session-transfer-token)
   - [Reading the `act` claim on the impersonation session](#reading-the-act-claim-on-the-impersonation-session)
 - [Retrieving the logged-in User](#retrieving-the-logged-in-user)
-  - [Passing `StoreOptions`](#passing-storeoptions-7)
-- [Retrieving the Session Data](#retrieving-the-session-data)
   - [Passing `StoreOptions`](#passing-storeoptions-8)
+- [Retrieving the Session Data](#retrieving-the-session-data)
+  - [Passing `StoreOptions`](#passing-storeoptions-9)
 - [Retrieving an Access Token](#retrieving-an-access-token)
   - [Using Multi-Resource Refresh Tokens (MRRT)](#using-multi-resource-refresh-tokens-mrrt)
   - [Modifying Token Scopes](#modifying-token-scopes)
-  - [Passing `StoreOptions`](#passing-storeoptions-9)
-- [Retrieving an Access Token for a Connection](#retrieving-an-access-token-for-a-connection)
   - [Passing `StoreOptions`](#passing-storeoptions-10)
+- [Retrieving an Access Token for a Connection](#retrieving-an-access-token-for-a-connection)
+  - [Passing `StoreOptions`](#passing-storeoptions-11)
 - [Accessing the full HTTP response](#accessing-the-full-http-response)
 - [Revoking a Refresh Token](#revoking-a-refresh-token)
   - [Revoking the session token](#revoking-the-session-token)
@@ -69,9 +71,9 @@
   - [Revoking on logout](#revoking-on-logout)
 - [Logout](#logout)
   - [Passing the `returnTo` parameter](#passing-the-returnto-parameter)
-  - [Passing `StoreOptions`](#passing-storeoptions-11)
-- [Handle Backchannel Logout](#handle-backchannel-logout)
   - [Passing `StoreOptions`](#passing-storeoptions-12)
+- [Handle Backchannel Logout](#handle-backchannel-logout)
+  - [Passing `StoreOptions`](#passing-storeoptions-13)
 - [Per-Request Options](#per-request-options)
   - [Argument shape](#argument-shape)
   - [Cancelling a request](#cancelling-a-request)
@@ -1178,6 +1180,55 @@ const storeOptions = {
 await serverClient.loginWithCustomTokenExchange({ subjectToken, subjectTokenType }, storeOptions);
 
 const tokenResponse = await serverClient.customTokenExchange({ subjectToken, subjectTokenType }, storeOptions);
+```
+
+Read more above in [Configuring the Store](#configuring-the-store)
+
+## Retrieving User Information
+
+`getUserInfo()` fetches user profile claims from the OIDC `/userinfo` endpoint for an access token you supply. Use it when you need fresh user claims for a token your application already holds.
+
+> [!IMPORTANT]
+> You must pass the access token explicitly. `getUserInfo()` does **not** read the token from the session and does **not** trigger a refresh.
+>
+> The access token must be accepted by the `/userinfo` endpoint, which depends on how it was obtained:
+>
+> - **Without Multi-Resource Refresh Tokens (MRRT):** use a default OIDC access token — one issued without an explicit `audience` parameter.
+> - **With MRRT:** access tokens are audience-bound, so you must explicitly request the userinfo endpoint as the audience (e.g. `audience: 'https://<AUTH0_DOMAIN>/userinfo'`) when obtaining the token. A token bound to a different resource-server audience is rejected by `/userinfo`, typically resulting in a `UserInfoError` (HTTP 401 or 403).
+>
+> If you have a known `sub` from the session or an ID token, pass it as `expectedSubject` to guard against token substitution (recommended, though optional).
+
+```ts
+import { UserInfoError } from '@auth0/auth0-server-js';
+
+try {
+  const userInfo = await serverClient.getUserInfo({
+    accessToken: '<access_token>',
+    expectedSubject: '<known_sub>', // optional; throws UserInfoError on mismatch
+  });
+
+  console.log(userInfo.sub);
+  console.log(userInfo.email);
+  console.log(userInfo.name);
+} catch (error) {
+  if (error instanceof UserInfoError) {
+    console.error('Failed to retrieve user info:', error.message);
+    console.error('OAuth error:', error.cause?.error); // e.g., 'unauthorized'
+  }
+}
+```
+
+The returned `UserInfoResponse` contains OIDC standard claims like `sub`, `email`, and `name`. The exact claims depend on the scopes granted to the access token.
+
+### Passing `StoreOptions`
+
+`getUserInfo()` accepts an optional second argument passed to the configured domain resolver, so the request resolves against the correct tenant in [resolver mode](#dynamic-domain-resolver):
+
+```ts
+const storeOptions = {
+  /* ... */
+};
+const userInfo = await serverClient.getUserInfo({ accessToken: '<access_token>' }, storeOptions);
 ```
 
 Read more above in [Configuring the Store](#configuring-the-store)

--- a/packages/auth0-server-js/src/index.ts
+++ b/packages/auth0-server-js/src/index.ts
@@ -1,7 +1,7 @@
 export { ServerClient } from './server-client.js';
 export { AbstractStateStore } from './store/abstract-state-store.js';
 export { AbstractTransactionStore } from './store/abstract-transaction-store.js';
-export type { TokenResponse, ActClaim, RequestOptions } from '@auth0/auth0-auth-js';
+export type { TokenResponse, ActClaim, RequestOptions, GetUserInfoOptions, UserInfoResponse } from '@auth0/auth0-auth-js';
 export {
   TokenExchangeError,
   TokenRevocationError,
@@ -10,6 +10,7 @@ export {
   PasswordlessStartError,
   PasswordlessVerifyError,
   isMfaRequiredError,
+  UserInfoError,
 } from '@auth0/auth0-auth-js';
 
 export type { CookieHandler, CookieSerializeOptions } from './store/cookie-handler.js';

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -188,6 +188,33 @@ const restHandlers = [
       { status: 201 }
     );
   }),
+
+  http.get(`https://${domain}/userinfo`, ({ request }) => {
+    const authHeader = request.headers.get('authorization');
+
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return HttpResponse.json(
+        { error: 'unauthorized', error_description: 'Missing or invalid authorization header' },
+        { status: 401 }
+      );
+    }
+
+    const token = authHeader.replace('Bearer ', '');
+
+    if (token === '<userinfo_401>') {
+      return HttpResponse.json(
+        { error: 'unauthorized', error_description: 'The access token expired' },
+        { status: 401 }
+      );
+    }
+
+    return HttpResponse.json({
+      sub: 'user_123',
+      name: 'Jane Doe',
+      email: 'jane@example.com',
+      email_verified: true,
+    });
+  }),
 ];
 
 const server = setupServer(...restHandlers);
@@ -2568,6 +2595,119 @@ test('customTokenExchange - should throw when exchange fails', async () => {
       code: 'token_exchange_error',
     })
   );
+});
+
+test('getUserInfo - delegates to authClient.getUserInfo with the supplied options and returns the response unchanged', async () => {
+  const fixture = { sub: 'user_123', email: 'jane@example.com', name: 'Jane' };
+  const getUserInfoSpy = vi.spyOn(AuthClient.prototype, 'getUserInfo').mockResolvedValue(fixture);
+
+  try {
+    const serverClient = new ServerClient({
+      domain,
+      clientId: '<client_id>',
+      clientSecret: '<client_secret>',
+      transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+      stateStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() },
+    });
+
+    const result = await serverClient.getUserInfo({
+      accessToken: '<access_token>',
+      expectedSubject: 'user_123',
+    });
+
+    expect(getUserInfoSpy).toHaveBeenCalledWith({
+      accessToken: '<access_token>',
+      expectedSubject: 'user_123',
+    });
+    expect(result).toEqual(fixture);
+  } finally {
+    getUserInfoSpy.mockRestore();
+  }
+});
+
+test('getUserInfo - propagates UserInfoError from authClient', async () => {
+  const getUserInfoSpy = vi
+    .spyOn(AuthClient.prototype, 'getUserInfo')
+    .mockRejectedValue(new Auth0AuthJs.UserInfoError('userinfo failed'));
+
+  try {
+    const serverClient = new ServerClient({
+      domain,
+      clientId: '<client_id>',
+      clientSecret: '<client_secret>',
+      transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+      stateStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() },
+    });
+
+    await expect(
+      serverClient.getUserInfo({ accessToken: '<access_token>' })
+    ).rejects.toBeInstanceOf(Auth0AuthJs.UserInfoError);
+  } finally {
+    getUserInfoSpy.mockRestore();
+  }
+});
+
+test('getUserInfo - resolves the domain in resolver mode then delegates (does not throw the authClient getter error)', async () => {
+  const fixture = { sub: 'user_123' };
+  const getUserInfoSpy = vi.spyOn(AuthClient.prototype, 'getUserInfo').mockResolvedValue(fixture);
+  const domainResolver = vi.fn().mockResolvedValue(domain);
+
+  try {
+    const serverClient = new ServerClient({
+      domain: domainResolver,
+      clientId: '<client_id>',
+      clientSecret: '<client_secret>',
+      transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+      stateStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() },
+    });
+
+    const storeOptions = { request: { headers: { host: 'example.test' } } };
+    const result = await serverClient.getUserInfo({ accessToken: '<access_token>' }, storeOptions);
+
+    expect(domainResolver).toHaveBeenCalledWith(storeOptions);
+    expect(getUserInfoSpy).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(fixture);
+  } finally {
+    getUserInfoSpy.mockRestore();
+  }
+});
+
+test('getUserInfo - end-to-end through the HTTP layer returns claims and sends the supplied token as a Bearer header', async () => {
+  let capturedAuthHeader: string | null = null;
+  server.use(
+    http.get(`https://${domain}/userinfo`, ({ request }) => {
+      capturedAuthHeader = request.headers.get('authorization');
+      return HttpResponse.json({ sub: 'user_123', email: 'jane@example.com', name: 'Jane Doe' });
+    })
+  );
+
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() },
+  });
+
+  const result = await serverClient.getUserInfo({ accessToken: '<a_user_access_token>' });
+
+  expect(result.sub).toBe('user_123');
+  expect(result.email).toBe('jane@example.com');
+  expect(capturedAuthHeader).toBe('Bearer <a_user_access_token>');
+});
+
+test('getUserInfo - end-to-end wraps a /userinfo 401 in UserInfoError', async () => {
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    transactionStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn() },
+    stateStore: { get: vi.fn(), set: vi.fn(), delete: vi.fn(), deleteByLogoutToken: vi.fn() },
+  });
+
+  await expect(
+    serverClient.getUserInfo({ accessToken: '<userinfo_401>' })
+  ).rejects.toBeInstanceOf(Auth0AuthJs.UserInfoError);
 });
 
 test('loginWithCustomTokenExchange - should return authorizationDetails when RAR was used', async () => {

--- a/packages/auth0-server-js/src/server-client.ts
+++ b/packages/auth0-server-js/src/server-client.ts
@@ -61,7 +61,7 @@ import {
 import type { RequestOptions } from '@auth0/auth0-auth-js';
 import { compareScopes, ensureOpenIdScope } from './utils.js';
 import { decodeJwt } from 'jose';
-import type { AuthClientOptions } from '@auth0/auth0-auth-js';
+import type { AuthClientOptions, GetUserInfoOptions, UserInfoResponse } from '@auth0/auth0-auth-js';
 import { getTelemetryConfig } from './telemetry.js';
 import { ServerMfaClient } from './mfa/server-mfa-client.js';
 import { ServerPasskeyClient } from './passkey/server-passkey-client.js';
@@ -1036,6 +1036,33 @@ export class ServerClient<TStoreOptions = unknown> {
       const { internal, ...sessionData } = stateData;
       return sessionData;
     }
+  }
+
+  /**
+   * Retrieves the OIDC UserInfo claims for a given access token.
+   *
+   * The access token must be supplied explicitly by the caller. This method does NOT read
+   * the token from the session and does NOT trigger a refresh. The token must be accepted by
+   * the `/userinfo` endpoint:
+   * - Without Multi-Resource Refresh Tokens (MRRT): pass a default OIDC access token, one
+   *   obtained without an explicit `audience` parameter.
+   * - With MRRT: tokens are audience-bound, so request the userinfo endpoint as the audience
+   *   (e.g. `https://<domain>/userinfo`) when obtaining the token. A token bound to a
+   *   different resource-server audience is rejected by `/userinfo`.
+   *
+   * @param options Options containing the access token and an optional expected subject
+   *                for OIDC subject-consistency validation.
+   * @param storeOptions Optional store options, used to resolve the domain in resolver mode.
+   * @throws {UserInfoError} When the `/userinfo` request fails or the subject check fails.
+   * @returns A Promise resolving to the UserInfo claims.
+   */
+  public async getUserInfo(
+    options: GetUserInfoOptions,
+    storeOptions?: TStoreOptions
+  ): Promise<UserInfoResponse> {
+    const domain = await this.#resolveDomain(storeOptions);
+    const authClient = this.#getAuthClient(domain);
+    return authClient.getUserInfo(options);
   }
 
   // TEMPORARY: Overloads for backwards compatibility in minor version.


### PR DESCRIPTION
### Description

Adds `getUserInfo()` to `ServerClient`, retrieving a user's OIDC profile claims from the `/userinfo` endpoint for an access token you supply.

```ts
const userInfo = await serverClient.getUserInfo({
  accessToken: '<access_token>',
});

console.log(userInfo.sub, userInfo.email, userInfo.name);
```

The access token is passed explicitly. `getUserInfo()` does not read the token from the session and does not trigger a refresh. Pass an optional `expectedSubject` to assert the returned `sub` matches a known value; a mismatch throws `UserInfoError`.

### What's included

- `ServerClient.getUserInfo(options, storeOptions?)`. In resolver (multi-tenant) mode, `storeOptions` is used to resolve the correct domain before the request.
- Re-exports of `GetUserInfoOptions`, `UserInfoResponse`, and `UserInfoError` from `@auth0/auth0-server-js`, so you do not need to import them from `@auth0/auth0-auth-js`.

### Access token requirements

The access token must be one that `/userinfo` accepts:

- **Without Multi-Resource Refresh Tokens (MRRT):** use a default OIDC access token, obtained without an explicit `audience`.
- **With MRRT:** access tokens are audience-bound, so request the userinfo endpoint as the audience (for example, `https://<your-domain>/userinfo`) when obtaining the token. A token bound to a different audience is rejected by `/userinfo`.

See `EXAMPLES.md` for full usage, including resolver mode and error handling.
