### PR TITLE
feat(auth0-server-js): expose Experiment Center override params on AuthorizationParameters

### DIFF
--- a/packages/auth0-server-js/EXAMPLES.md
+++ b/packages/auth0-server-js/EXAMPLES.md
@@ -22,6 +22,7 @@
   - [Passing `authorizationParams`](#passing-authorization-params)
   - [Passing `appState` to track state during login](#passing-appstate-to-track-state-during-login)
   - [Logging in to an Organization](#logging-in-to-an-organization)
+  - [Using Experiment Center](#using-experiment-center)
   - [Using Pushed Authorization Requests](#using-pushed-authorization-requests)
   - [Using Pushed Authorization Requests and Rich Authorization Requests](#using-pushed-authorization-requests-and-rich-authorization-requests)
   - [Passing `StoreOptions`](#passing-storeoptions)
@@ -711,6 +712,33 @@ try {
 ```
 
 See the [Auth0 Organizations documentation](https://auth0.com/docs/manage-users/organizations) for setup and concepts.
+
+### Using Experiment Center
+
+Pass `experiment_id` and `variation_id` via `authorizationParams` to force a user into a specific [Experiment Center](https://auth0.com/docs/customize/experiment-center/overview) variation for the login request, bypassing the server-side deterministic assignment. Both IDs are obtained from your Auth0 Dashboard or the Management API.
+
+```ts
+await serverClient.startInteractiveLogin({
+  authorizationParams: {
+    experiment_id: '<EXPERIMENT_ID>',
+    variation_id: '<VARIATION_ID>',
+  },
+});
+```
+
+When the experiment uses segment targeting, also pass `segment_id`:
+
+```ts
+await serverClient.startInteractiveLogin({
+  authorizationParams: {
+    experiment_id: '<EXPERIMENT_ID>',
+    variation_id: '<VARIATION_ID>',
+    segment_id: '<SEGMENT_ID>',
+  },
+});
+```
+
+> Experiment Center is an Enterprise feature. Refer to the [Experiment Center documentation](https://auth0.com/docs/customize/experiment-center/overview) for more information and setup.
 
 ### Using Pushed Authorization Requests
 

--- a/packages/auth0-server-js/src/server-client.spec.ts
+++ b/packages/auth0-server-js/src/server-client.spec.ts
@@ -721,6 +721,57 @@ test('startInteractiveLogin - should build the authorization url with custom par
   expect(url.searchParams.size).toBe(7);
 });
 
+test('startInteractiveLogin - should include experiment override params on the authorization url', async () => {
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    stateStore: new DefaultStateStore({ secret: '<secret>' }),
+    transactionStore: new DefaultTransactionStore({ secret: '<secret>' }),
+    authorizationParams: {
+      redirect_uri: '/test_redirect_uri',
+      scope: '<scope>',
+    },
+  });
+
+  const url = await serverClient.startInteractiveLogin({
+    authorizationParams: {
+      experiment_id: '<experiment_id>',
+      variation_id: '<variation_id>',
+      segment_id: '<segment_id>',
+    },
+  });
+
+  expect(url.searchParams.get('experiment_id')).toBe('<experiment_id>');
+  expect(url.searchParams.get('variation_id')).toBe('<variation_id>');
+  expect(url.searchParams.get('segment_id')).toBe('<segment_id>');
+});
+
+test('startInteractiveLogin - should include experiment override params without segment_id on the authorization url', async () => {
+  const serverClient = new ServerClient({
+    domain,
+    clientId: '<client_id>',
+    clientSecret: '<client_secret>',
+    stateStore: new DefaultStateStore({ secret: '<secret>' }),
+    transactionStore: new DefaultTransactionStore({ secret: '<secret>' }),
+    authorizationParams: {
+      redirect_uri: '/test_redirect_uri',
+      scope: '<scope>',
+    },
+  });
+
+  const url = await serverClient.startInteractiveLogin({
+    authorizationParams: {
+      experiment_id: '<experiment_id>',
+      variation_id: '<variation_id>',
+    },
+  });
+
+  expect(url.searchParams.get('experiment_id')).toBe('<experiment_id>');
+  expect(url.searchParams.get('variation_id')).toBe('<variation_id>');
+  expect(url.searchParams.has('segment_id')).toBe(false);
+});
+
 test('startInteractiveLogin - should build the authorization url and override global authorizationParams', async () => {
   const serverClient = new ServerClient({
     domain,

--- a/packages/auth0-server-js/src/types.ts
+++ b/packages/auth0-server-js/src/types.ts
@@ -104,6 +104,22 @@ export interface AuthorizationParameters {
    * this is supported for backwards compatibility.
    */
   organization?: string;
+  /**
+   * Forces the user into a specific Experiment Center experiment variation for this
+   * authorization request, bypassing the server-side deterministic assignment.
+   * Requires `variation_id`.
+   */
+  experiment_id?: string;
+  /**
+   * The variation (arm) to assign the user to within the experiment for this
+   * authorization request. Required when `experiment_id` is set.
+   */
+  variation_id?: string;
+  /**
+   * Scopes the experiment override to a specific segment for this authorization
+   * request. Optional — only needed when the experiment uses segment targeting.
+   */
+  segment_id?: string;
 
   [key: string]: unknown;
 }


### PR DESCRIPTION
## Summary

- Adds `experiment_id`, `variation_id`, and `segment_id` as named, typed `string` fields on `AuthorizationParameters`
- Params are forwarded to `/authorize` via the existing `authorizationParams` spread — no runtime logic changes needed
- Adds unit tests verifying the params appear on the `/authorize` URL (with and without `segment_id`)
- Adds a `### Using Experiment Center` section to `EXAMPLES.md` with usage examples

## What are these params?

[Experiment Center](https://auth0.com/docs/customize/experiment-center/overview) is Auth0's A/B testing platform. These three params let developers force a specific experiment variation on a `/authorize` request, bypassing the server-side deterministic assignment.

## Test plan

- [ ] `npx vitest run packages/auth0-server-js/src/server-client.spec.ts` — all tests pass
- [ ] Verify `experiment_id`, `variation_id`, `segment_id` appear in `AuthorizationParameters` typings with correct JSDoc
- [ ] Review `EXAMPLES.md` — new section renders correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Experiment Center parameters to interactive login authorization requests, allowing applications to select a specific experiment variation and optionally target a segment.
  * Parameters can be provided per login to avoid applying overrides to every login.

* **Documentation**
  * Added usage guidance and a table-of-contents entry for configuring Experiment Center overrides during interactive login.
  * Documented that Experiment Center is an Enterprise feature and that overrides should be supplied per login.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->