### PR TITLE
docs: add layered CLAUDE.md/AGENTS.md agent guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# AI Agent Guidelines for auth0-auth-js
+
+@./CLAUDE.md for all coding guidelines, commands, project structure, code style, testing conventions, and boundaries.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,38 @@
+# AI Agent Guidelines for auth0-auth-js
+
+## Your Role
+
+You are a TypeScript SDK engineer on the auth0-auth-js monorepo: cross-runtime (Node, Bun, Deno, Cloudflare Workers) Auth0 authentication SDKs. You write small, well-tested, tree-shakeable ESM code.
+
+---
+
+## Workspace Packages
+
+This is a Turborepo + npm-workspaces monorepo. **Run build/test/lint from the package directory (or with `-w @auth0/<pkg>`), not blindly at the repo root** — each package has its own manifest, test suite, and conventions.
+
+| Package | Path | Purpose |
+|---------|------|---------|
+| `@auth0/auth0-auth-js` | `packages/auth0-auth-js` | Low-level authentication client (OAuth/OIDC flows, MFA, passkeys, passwordless, DB connections) |
+| `@auth0/auth0-api-js` | `packages/auth0-api-js` | API-side SDK: access-token verification, DPoP, token exchange |
+| `@auth0/auth0-server-js` | `packages/auth0-server-js` | Server-side app SDK: sessions, encrypted stores, cookies |
+| `@auth0/typescript-config` | `packages/typescript-config` | Shared `tsconfig` base (private, not published) |
+
+`@auth0/auth0-auth-js` is the base package: both `auth0-api-js` and `auth0-server-js` depend on it, so a change there can break its dependents — build it first and run their suites when you touch it.
+
+Shared root config affects every package: `turbo.json` (task graph), `packages/typescript-config` (base `tsconfig`), `vitest.workspace.js`, and the root `.prettierrc` conventions each package mirrors.
+
+---
+
+## Git Workflow
+
+### Branch Naming
+
+Release branches use the `release/*` prefix (the release workflow triggers on a merged PR whose head branch starts with `release/`). Feature/fix branches have no enforced pattern.
+
+### Commit Messages
+
+No enforced commit convention (no commitlint). Follow the existing history: short imperative subject, `feat(<pkg>): …` / `fix(<pkg>): …` scoping is common.
+
+### Pull Requests
+
+No local PR template — the [Auth0 org-level template](https://github.com/auth0/.github/blob/master/.github/PULL_REQUEST_TEMPLATE.md) applies. Fill in **Description**, **References**, **Testing**, and the **Checklist** — including that the PR adds test coverage for new/changed functionality, adds documentation for new/changed functionality, and targets the correct base branch if not the default (`main`).

--- a/packages/auth0-api-js/AGENTS.md
+++ b/packages/auth0-api-js/AGENTS.md
@@ -1,0 +1,3 @@
+# AI Agent Guidelines for @auth0/auth0-api-js
+
+@./CLAUDE.md for all coding guidelines, commands, project structure, code style, testing conventions, and boundaries.

--- a/packages/auth0-api-js/CLAUDE.md
+++ b/packages/auth0-api-js/CLAUDE.md
@@ -1,0 +1,103 @@
+# AI Agent Guidelines for @auth0/auth0-api-js
+
+## Project Structure
+
+```
+packages/auth0-api-js/
+├── src/
+│   ├── index.ts                       # Public entry (barrel) — ApiClient, errors, types, helpers
+│   ├── api-client.ts                  # ApiClient: access-token verification + token exchange (core)
+│   ├── dpop-api.ts                    # DPoP (RFC 9449) proof verification, WWW-Authenticate challenges
+│   ├── token.ts                       # getToken(): extract bearer token from request (RFC 6750/9449)
+│   ├── act.ts                         # RFC 8693 delegation: getCurrentActor, getDelegationChain
+│   ├── protected-resource-metadata.ts # RFC 9728 metadata builder
+│   ├── errors.ts                      # Error classes (AuthError base + standalone validators)
+│   ├── types.ts                       # Public types (no runtime code)
+│   ├── lru-cache.ts                   # TTL+size LRU with in-flight dedup (discovery + JWKS)
+│   └── test-utils/tokens.ts           # Test-only token/JWK helpers (not exported)
+├── eslint.config.mjs · .prettierrc · tsup.config.ts
+└── vitest.config.ts · vitest.config.workers.ts · wrangler.toml
+```
+
+`ApiClient` public methods: `verifyAccessToken`, `getAccessTokenForConnection`, `getTokenByExchangeProfile`, `getTokenOnBehalfOf`. `index.ts` also re-exports `MissingClientAuthError` / `TokenExchangeError` from `@auth0/auth0-auth-js`.
+
+---
+
+## Boundaries
+
+### ✅ Always Do
+
+- Run the unit suite (`npm test`) before committing.
+- Make surgical changes — touch only what the request requires; don't refactor adjacent code that isn't broken.
+- Follow existing code style and naming (single quotes, `printWidth` 120, `.js` extensions on relative imports, `#private` members).
+- Add unit tests for new functionality (`src/*.spec.ts`, co-located).
+- Throw errors from the existing hierarchy: `AuthError` subclasses (carry `code`, `statusCode`, `headers`, typed `cause`), or the standalone `MissingRequiredArgumentError` / `InvalidConfigurationError` for validation.
+- Keep `.version` and the `package.json` `version` field in sync — the release workflow reads `.version`.
+- Update `README.md` and `EXAMPLES.md` in the same PR when changing the public API, configuration options, or supported integration patterns.
+
+### ⚠️ Ask First
+
+- **Any breaking change — always ask first.** Never break backward compatibility on your own initiative.
+- Modifying public API signatures on `ApiClient` or the exported helpers.
+- Adding new dependencies.
+- Modifying security-related code: JWT verification, JWKS fetching/caching, DPoP proof validation (`dpop-api.ts`), audience/issuer/algorithm rules.
+- Changes to CI (`.github/workflows/*`) or the release actions.
+
+### 🚫 Never Do
+
+- Commit secrets, API keys, or tokens.
+- Log access tokens or JWK private material.
+- Modify auto-generated / build output (`dist/`) or hand-edit lock files.
+- Remove or skip failing tests without fixing them.
+- Accept symmetric `HS*` algorithms, widen the DPoP algorithm set beyond `ES256`, or make `audience` optional.
+
+---
+
+## Security Considerations
+
+- **This is an API-side verifier** — it validates inbound access tokens; it holds no user session and (by design) sends no telemetry.
+- **JWT verification** (`api-client.ts`): decode header/payload unverified → reject `HS*` symmetric algs → resolve issuer/domain → discover metadata → fetch JWKS → `jose.jwtVerify` with required `audience` (constructor, mandatory), `issuer` (from discovery), `algorithms` (default `['RS256']`), and required `iat`/`exp` claims.
+- **JWKS caching:** `createRemoteJWKSet` per URI, cached in an `LruCache` (default TTL 600s, 100 entries; configurable via `discoveryCache`). The JWKS fetch wrapper deliberately masks upstream error detail (`'JWKS request failed'`).
+- **DPoP (RFC 9449):** modes `allowed` (default) / `required` / `disabled`. Proof restricted to `ES256`, `typ` `dpop+jwt`; validates `jti`/`iat`/`htm`/`htu`/`ath`, the `iat` window, `htu` URL normalization, the `ath` = base64url(sha256(token)) binding, and the JWK thumbprint against `cnf.jkt`; rejects private-key material.
+- **Multi-domain:** issuer allowlist matched against the unverified `iss` before discovery; `normalizeDomain` enforces HTTPS and rejects credentials/query/path.
+- **Token logging:** none — errors surface messages, not token contents.
+
+---
+
+> The sections below are **reference** — each keeps a one-line anchor here and offloads its body to `references/*.md`, read on demand.
+
+## Commands
+
+```bash
+npm run build        # tsup — dual ESM/CJS to dist/
+npm test             # vitest run — unit tier (no credentials)
+npm run lint         # eslint "./**/*.ts*"
+npm run test:workers # vitest run --config vitest.config.workers.ts
+```
+
+See [references/commands.md](references/commands.md) for the full list (coverage, watch, clean). Read when you need to run, build, or test something.
+
+## Testing
+
+- **Framework:** Vitest 3 (provider `v8`); mocking via MSW 2.
+- **Location:** co-located `src/*.spec.ts`.
+- The default `npm test` suite is unit-only — no credentials required (it excludes `*.workers.spec.ts`, which run under the Cloudflare Workers pool). No live-tenant tier in this package.
+
+See [references/testing.md](references/testing.md) for MSW setup, `test.each` conventions, and the workers config. Read when writing or debugging tests.
+
+## Code Style
+
+- **CI-enforced:** ESLint flat config = `@eslint/js` recommended + `typescript-eslint` recommended (lint fails CI). Prettier: single quotes, `printWidth` 120, `arrowParens: always`, `trailingComma: es5`.
+- **Dominant convention:** PascalCase types/classes, camelCase members, `#private` fields, `SCREAMING_SNAKE` consts, `.js` import extensions; classes for stateful config (`ApiClient`, `LruCache`), functions for pure helpers (`getToken`, `verifyDpopProof`); heavy JSDoc with `@example`.
+
+See [references/code-style.md](references/code-style.md) for good/bad examples and patterns. Read when writing non-trivial new code.
+
+## Common Pitfalls
+
+See [references/pitfalls.md](references/pitfalls.md) for runtime-compatibility, ESM, and DPoP/verification gotchas. Read when a change spans runtimes or touches verification.
+
+## Docs Update Rules
+
+> A PR that adds or changes public API, configuration, or integration patterns is **not complete** until the relevant docs are updated in the same PR.
+
+See [references/docs-update.md](references/docs-update.md) for the tracked-docs inventory and the code-to-docs mapping. The "update README.md / EXAMPLES.md in the same PR" rule is in Boundaries → Always Do.

--- a/packages/auth0-api-js/references/code-style.md
+++ b/packages/auth0-api-js/references/code-style.md
@@ -1,0 +1,45 @@
+# Code Style — @auth0/auth0-api-js
+
+## Naming & structure
+
+- PascalCase classes/types (`ApiClient`, `ProtectedResourceMetadataBuilder`); camelCase members.
+- `#private` fields/methods (`#options`, `#jwksByUri`, `#discoverDomain`); `SCREAMING_SNAKE` module consts (`ALLOWED_DPOP_ALGORITHMS`, `DPOP_ERROR_MESSAGES`).
+- Relative imports carry `.js` extensions (ESM).
+- Explicit return types on exported/public functions; some inference on private helpers.
+
+## Patterns
+
+- **Class-based state, function-based purity.** Config-holding/stateful logic is a class (`ApiClient`, `LruCache`, `ProtectedResourceMetadataBuilder`); pure/stateless logic is an exported function (`getToken`, `verifyDpopProof`, `getCurrentActor`, `normalizeUrl`).
+- **Defensive immutability** — array copies (`[...arr]`) in the metadata builder; `readonly` on private fields.
+- **Heavy JSDoc** with `@param`/`@returns`/`@throws`/`@example`/`@see`, including code fences for DPoP.
+- **Validate early, throw typed.** Argument/shape checks throw `MissingRequiredArgumentError` / `InvalidRequestError` up front.
+
+## ✅ Good (from `src/act.ts`)
+
+```typescript
+export function getCurrentActor(claims: ClaimsWithAct): string | undefined {
+  if (!claims || typeof claims !== 'object') {
+    throw new InvalidRequestError(INVALID_ACT_CLAIM_MESSAGE);
+  }
+
+  if (claims.act === undefined) {
+    return undefined;
+  }
+
+  const sub = (claims.act as unknown as { sub?: unknown }).sub;
+  if (typeof sub !== 'string' || sub.trim().length === 0) {
+    throw new InvalidRequestError(INVALID_ACT_CLAIM_MESSAGE);
+  }
+
+  return sub;
+}
+```
+
+## ❌ Bad
+
+```typescript
+// No return type, silent on bad input, double quotes, no typed error
+export function getCurrentActor(claims) {
+    return claims.act ? claims.act.sub : null
+}
+```

--- a/packages/auth0-api-js/references/commands.md
+++ b/packages/auth0-api-js/references/commands.md
@@ -1,0 +1,24 @@
+# Commands — @auth0/auth0-api-js
+
+Run from `packages/auth0-api-js` (or add `-w @auth0/auth0-api-js` from the repo root).
+
+```bash
+# Build (dual ESM/CJS via tsup → dist/)
+npm run build
+npm run build:watch          # rebuild on change
+
+# Clean build output
+npm run clean                # rm -rf ./dist
+
+# Unit tests (safe — no credentials; excludes workers specs)
+npm test                     # vitest run
+npm run test:ci              # vitest --watch false --coverage (CI command)
+
+# Cloudflare Workers runtime tier
+npm run test:workers         # vitest run --config vitest.config.workers.ts
+
+# Lint
+npm run lint                 # eslint "./**/*.ts*"
+```
+
+CI (`.github/workflows/test.yml`) builds this package after `auth0-auth-js`, then runs `test:ci` on Node 20 and 22 and `lint` on Node 24. The Bun, Deno, and Workers workflows build `auth0-auth-js` first, then this package.

--- a/packages/auth0-api-js/references/docs-update.md
+++ b/packages/auth0-api-js/references/docs-update.md
@@ -1,0 +1,20 @@
+# Docs Update Rules — @auth0/auth0-api-js
+
+## Tracked docs
+
+| Doc | Covers | Exists |
+|-----|--------|--------|
+| `README.md` | Install, client setup, access-token verification, DPoP verification, RFC 9728 metadata, token exchange | ✅ |
+| `EXAMPLES.md` | Token on behalf of a user, access token for a connection, multiple custom domains, discovery cache, DPoP authentication | ✅ |
+
+## When you change code, update these docs
+
+| When this changes | Update |
+|-------------------|--------|
+| `ApiClient` public method (added / removed / renamed) | `README.md` usage, `EXAMPLES.md` affected samples |
+| Configuration options (`audience`, `domains`/resolver, `discoveryCache`, `dpop` mode) | `README.md` configuration section |
+| DPoP behaviour, verification rules, or WWW-Authenticate challenges | `README.md` DPoP section, `EXAMPLES.md` DPoP examples |
+| Token-exchange / delegation surface (`act` helpers, exchange profiles) | `README.md` + `EXAMPLES.md` |
+| Install / package name / peer requirements | `README.md` install section |
+
+Update the doc **in the same PR** as the code — do not defer.

--- a/packages/auth0-api-js/references/pitfalls.md
+++ b/packages/auth0-api-js/references/pitfalls.md
@@ -1,0 +1,9 @@
+# Common Pitfalls — @auth0/auth0-api-js
+
+- **Four runtimes.** Code must work on Node, Bun, Deno, and Cloudflare Workers (each has its own CI workflow). Prefer Web-standard APIs (`fetch`, `crypto.subtle`, `crypto.createHash` guarded) over Node-only built-ins; a change that passes `npm test` can still fail the Workers/Bun/Deno tiers.
+- **ESM `.js` import extensions are mandatory** on relative imports even though sources are `.ts`.
+- **`audience` is required.** The `ApiClient` constructor throws `MissingRequiredArgumentError` without it — verification is not optional.
+- **DPoP is `ES256`-only.** Don't add algorithms to `ALLOWED_DPOP_ALGORITHMS`; the proof `typ` must be `dpop+jwt`, and the JWK thumbprint must match the token's `cnf.jkt`.
+- **JWKS errors are intentionally generic** (`'JWKS request failed'`) to avoid leaking upstream detail — don't "improve" them to surface the raw error.
+- **Depends on `auth0-auth-js`.** Token-exchange flows delegate to its `AuthClient`; a change there can shift behaviour here.
+- **`.version` vs `package.json` version.** The release workflow reads `.version`; keep both in sync.

--- a/packages/auth0-api-js/references/testing.md
+++ b/packages/auth0-api-js/references/testing.md
@@ -1,0 +1,22 @@
+# Testing — @auth0/auth0-api-js
+
+## Tiers
+
+| Tier | Command | Config | Files | Credentials |
+|------|---------|--------|-------|-------------|
+| Unit (default) | `npm test` | `vitest.config.ts` | `src/*.spec.ts` (excludes workers) | none |
+| Cloudflare Workers | `npm run test:workers` | `vitest.config.workers.ts` | `src/**/*.workers.spec.ts` | none (uses `wrangler.toml`) |
+
+No live-tenant tier in this package.
+
+## Conventions
+
+- **Framework:** Vitest 3. `import { describe, test, expect, beforeAll, afterEach, afterAll } from 'vitest'`.
+- **Naming:** `describe(...)` groups with `test(...)`; heavy `test.each([...])` parameterized cases; titles are behaviour sentences (e.g. `"verifyAccessToken - should verify an access token successfully"`).
+- **Assertions:** `expect(...)` — `.toBe`, `.toBeDefined`, `expect(() => ...).toThrow(InvalidRequestError)`, `resolves`/`rejects`.
+
+## Mocking (MSW)
+
+- `setupServer` from `msw/node` with `http` / `HttpResponse`, mocking the Auth0 `.well-known/openid-configuration` and `.well-known/jwks.json`.
+- Lifecycle: `beforeAll(() => server.listen({ onUnhandledRequest: 'error' }))`, `afterEach(() => server.resetHandlers())`, `afterAll(() => server.close())`; `server.use(...)` per test.
+- Token/JWK fixtures from `src/test-utils/tokens.ts`.

--- a/packages/auth0-auth-js/AGENTS.md
+++ b/packages/auth0-auth-js/AGENTS.md
@@ -1,0 +1,3 @@
+# AI Agent Guidelines for @auth0/auth0-auth-js
+
+@./CLAUDE.md for all coding guidelines, commands, project structure, code style, testing conventions, and boundaries.

--- a/packages/auth0-auth-js/CLAUDE.md
+++ b/packages/auth0-auth-js/CLAUDE.md
@@ -1,0 +1,116 @@
+# AI Agent Guidelines for @auth0/auth0-auth-js
+
+## Project Structure
+
+```
+packages/auth0-auth-js/
+├── src/
+│   ├── index.ts                 # Public entry (barrel) — exports AuthClient + sub-clients, errors, types
+│   ├── auth-client.ts           # AuthClient: OAuth/OIDC flows, token grants, client auth (main class)
+│   ├── errors.ts                # Error hierarchy: ApiError base + OAuth2Error helpers
+│   ├── types.ts                 # Public option/response types
+│   ├── telemetry.ts             # Auth0-Client header fetch wrapper + opt-out
+│   ├── request-fetch.ts         # Per-request fetch composition + response capture
+│   ├── cache-provider.ts        # OIDC discovery + JWKS caching
+│   ├── lru-cache.ts             # LRU cache backing the discovery/JWKS cache
+│   ├── utils.ts                 # Header filtering, org-claim validation
+│   ├── mfa/                     # MfaClient sub-client (list/enroll/challenge/verify)
+│   ├── passkey/                 # PasskeyClient sub-client (WebAuthn)
+│   ├── passwordless/            # PasswordlessClient sub-client (OTP / magic-link)
+│   ├── database/                # DatabaseClient sub-client (sign-up, change-password)
+│   ├── anonymous-session/       # AnonymousSessionClient sub-client
+│   └── test-utils/              # Test-only token/JWK helpers (not exported)
+├── examples/                    # Markdown usage docs (linked from EXAMPLES.md) — no .ts fixtures
+├── test/                        # load-env.ts (integration), examples-typecheck.ts fixture
+├── eslint.config.mjs · .prettierrc · tsup.config.ts
+└── vitest.config.ts · vitest.config.workers.ts · vitest.config.integration.ts
+```
+
+`AuthClient` exposes sub-clients as instance fields: `mfa`, `passkey`, `passwordless`, `database`, `anonymous`.
+
+---
+
+## Boundaries
+
+### ✅ Always Do
+
+- Run the unit suite (`npm test`) before committing.
+- Make surgical changes — touch only what the request requires; don't refactor or reformat adjacent code that isn't broken.
+- Follow existing code style and naming (single quotes, `printWidth` 120, `.js` extensions on relative imports, `#private` class members).
+- Add unit tests for new functionality (`src/*.spec.ts`, co-located).
+- Throw errors from the existing hierarchy — `ApiError` subclasses with a snake_case `.code`; use `toOAuth2Error`/`extractHttpMetadata` to carry OAuth context.
+- Keep `.version` and the `package.json` `version` field in sync — the release workflow reads `.version`, the telemetry payload reads `package.json`.
+- Update `README.md` and `EXAMPLES.md` in the same PR when changing the public API, configuration options, or supported integration patterns.
+- When adding a **new outbound request path to Auth0**, route its fetch through the existing telemetry wrapper in `src/telemetry.ts` so it carries the `Auth0-Client` header, and preserve the `{ enabled: false }` opt-out — don't hand-roll a separate HTTP client.
+
+### ⚠️ Ask First
+
+- **Any breaking change — always ask first.** Never break backward compatibility on your own initiative.
+- Modifying public API signatures on `AuthClient` or any exported sub-client.
+- Adding new dependencies.
+- Modifying security-related code: PKCE, client auth (`#getClientAuth`), JWKS/JWT verification, the `PARAM_DENYLIST`, header filtering.
+- Changes to CI (`.github/workflows/*`) or the release actions.
+- Running the live integration tests (`npm run test:integration`) — they hit a real Auth0 tenant using `.env.validation` creds, are slow, and can mutate real resources.
+
+### 🚫 Never Do
+
+- Commit secrets, API keys, or tokens.
+- Log tokens, client secrets, or `Set-Cookie` values — `filterSensitiveHeaders` exists precisely to strip these.
+- Remove the telemetry opt-out or send `Auth0-Client` unconditionally.
+- Modify auto-generated / build output (`dist/`) or hand-edit lock files.
+- Remove or skip failing tests without fixing them.
+- Weaken PKCE (always `S256`) or the `HS*` symmetric-algorithm rejection.
+
+---
+
+## Security Considerations
+
+- **PKCE:** authorization URLs always use `S256` (`randomPKCECodeVerifier` + `calculatePKCECodeChallenge`); the code verifier is returned to the caller for the later token exchange. Do not add a non-PKCE path.
+- **State / nonce:** magic-link exchange validates `state` against `expectedState`; logout-token verification **rejects** any `nonce` claim.
+- **JWT/JWKS:** verified via `jose` (`createRemoteJWKSet`, `jwtVerify`); discovery + JWKS cached via `cache-provider.ts`. OIDC discovery/grants go through `openid-client`.
+- **Client auth:** three methods in priority order — mTLS (needs a custom fetch), `private_key_jwt` (`importPKCS8`, default `RS256`), `client_secret_post`; missing all throws `MissingClientAuthError`.
+- **Injection / DoS guards:** `PARAM_DENYLIST` (frozen Set) blocks security-critical OAuth params from `extras`; `MAX_ARRAY_VALUES_PER_KEY = 20`.
+- **Secret leakage:** `Set-Cookie` stripped from error/response headers; auth-bearing discovery config is never shared with the optional-auth path.
+- **Secrets:** provided at runtime by the caller; nothing is persisted or logged by this package.
+
+---
+
+> The sections below are **reference** — each keeps a one-line anchor here and offloads its body to `references/*.md`, read on demand.
+
+## Commands
+
+Core commands (run from this package dir):
+
+```bash
+npm run build        # tsup — dual ESM/CJS to dist/
+npm test             # vitest run — unit tier (no credentials)
+npm run lint         # eslint "./**/*.ts*"
+npm run typecheck    # tsc --noEmit --project tsconfig.test.json
+```
+
+See [references/commands.md](references/commands.md) for the full command list (workers/integration tiers, coverage, watch, clean, examples type-check). Read when you need to run, build, or test something specific.
+
+## Testing
+
+- **Framework:** Vitest 3 (`@vitest/coverage-v8`, provider `v8`); mocking via MSW 2.
+- **Location:** co-located `src/**/*.spec.ts`.
+- The default `npm test` suite is unit-only — no credentials required (it excludes `*.workers.spec.ts` and `*.live.integration.spec.ts`). A separate **live integration tier** (`npm run test:integration`) hits a real tenant — see Boundaries.
+
+See [references/testing.md](references/testing.md) for the three test tiers, MSW setup, conventions, and config files. Read when writing or debugging tests.
+
+## Code Style
+
+- **CI-enforced:** ESLint flat config = `@eslint/js` recommended + `typescript-eslint` recommended (lint fails CI). Prettier: single quotes, `printWidth` 120, `arrowParens: always`, `trailingComma: es5`.
+- **Dominant convention:** PascalCase types/classes, camelCase members, `#private` fields, `SCREAMING_SNAKE` module consts, `.js` extensions on relative imports; thin public async methods delegating to `#private` implementations; heavy JSDoc.
+
+See [references/code-style.md](references/code-style.md) for good/bad examples and patterns. Read when writing non-trivial new code.
+
+## Common Pitfalls
+
+See [references/pitfalls.md](references/pitfalls.md) for runtime-compatibility and ESM gotchas (4 packaged runtimes, `.js` import extensions, build-time telemetry constants). Read when a change spans runtimes or touches the build.
+
+## Docs Update Rules
+
+> A PR that adds or changes public API, configuration, or integration patterns is **not complete** until the relevant docs are updated in the same PR.
+
+See [references/docs-update.md](references/docs-update.md) for the tracked-docs inventory and the code-to-docs mapping. The "update README.md / EXAMPLES.md in the same PR" rule is in Boundaries → Always Do.

--- a/packages/auth0-auth-js/references/code-style.md
+++ b/packages/auth0-auth-js/references/code-style.md
@@ -1,0 +1,41 @@
+# Code Style — @auth0/auth0-auth-js
+
+## Naming & structure
+
+- PascalCase for classes and types (`AuthClient`, `OAuth2Error`); camelCase for methods and variables.
+- ECMAScript `#private` fields and methods (`#configuration`, `#customFetch`, `#buildAuthorizationUrl`).
+- `SCREAMING_SNAKE` for module-level constants (`DEFAULT_SCOPES`, `PARAM_DENYLIST`, `MAX_ARRAY_VALUES_PER_KEY`).
+- Relative imports carry `.js` extensions (ESM / NodeNext): `from './errors.js'`.
+- `import type { ... }` for type-only imports.
+- Explicit return types on public/async methods; some inference on private helpers.
+
+## Patterns
+
+- **Class-based core, function-based helpers.** Stateful/config-holding logic is a class (`AuthClient`, sub-clients); pure helpers are exported functions (`filterSensitiveHeaders`, `toOAuth2Error`).
+- **Thin public methods delegate to `#private` implementations**; discovery is resolved first via `await this.#discover()`.
+- **Heavy JSDoc** on every export: `@param`, `@returns`, `@throws`, `@deprecated`, `@internal`, `@example` fences, `{@link ...}` cross-refs.
+- **Defensive header handling** — copy and strip sensitive headers rather than mutating shared objects.
+
+## ✅ Good (from `src/utils.ts`)
+
+```typescript
+export function filterSensitiveHeaders(source: Headers): Headers {
+  try {
+    const filtered = new Headers(source);
+    filtered.delete('set-cookie');
+    return filtered;
+  } catch {
+    return new Headers();
+  }
+}
+```
+
+## ❌ Bad
+
+```typescript
+// Mutates the caller's Headers, leaks set-cookie, no return type, double quotes
+export function filterSensitiveHeaders(source) {
+    source.delete("set-cookie")
+    return source
+}
+```

--- a/packages/auth0-auth-js/references/commands.md
+++ b/packages/auth0-auth-js/references/commands.md
@@ -1,0 +1,31 @@
+# Commands — @auth0/auth0-auth-js
+
+Run from `packages/auth0-auth-js` (or add `-w @auth0/auth0-auth-js` from the repo root).
+
+```bash
+# Build (dual ESM/CJS via tsup → dist/)
+npm run build
+npm run build:watch          # rebuild on change
+
+# Clean build output
+npm run clean                # rm -rf ./dist
+
+# Unit tests (safe — no credentials; excludes workers + live-integration specs)
+npm test                     # vitest run
+npm run test:ci              # vitest --watch false --coverage (CI command)
+
+# Cloudflare Workers runtime tier
+npm run test:workers         # vitest run --config vitest.config.workers.ts
+
+# Live integration tier (Ask First — hits a real tenant)
+npm run test:integration     # vitest run --config vitest.config.integration.ts
+
+# Lint
+npm run lint                 # eslint "./**/*.ts*"
+
+# Type-check
+npm run typecheck            # tsc --noEmit --project tsconfig.test.json
+npm run type-check:examples  # tsc -p tsconfig.examples.json (the examples fixture)
+```
+
+CI (`.github/workflows/test.yml`) runs `build`, `typecheck`, `type-check:examples`, then `test:ci` on Node 20 and 22; `lint` on Node 24. Separate workflows run the Bun, Deno, and Workers runtime tiers.

--- a/packages/auth0-auth-js/references/docs-update.md
+++ b/packages/auth0-auth-js/references/docs-update.md
@@ -1,0 +1,20 @@
+# Docs Update Rules — @auth0/auth0-auth-js
+
+## Tracked docs
+
+| Doc | Covers | Exists |
+|-----|--------|--------|
+| `README.md` | Install, client setup, authorization/logout URLs, token exchange, ROPG, MFA, passkeys, DB connections, passwordless | ✅ |
+| `EXAMPLES.md` | Configuration, auth URLs, tokens, logout, userinfo, passwordless, MFA, passkeys, custom token exchange, DB connections, HTTP req/resp | ✅ |
+| `examples/` | Markdown usage docs linked from `EXAMPLES.md` (not runnable `.ts` apps) | ✅ |
+
+## When you change code, update these docs
+
+| When this changes | Update |
+|-------------------|--------|
+| `AuthClient` or a sub-client public method (added / removed / renamed) | `README.md` usage, `EXAMPLES.md` affected samples, the linked `examples/*.md` |
+| Configuration options (`AuthClientOptions`, telemetry, client-auth options) | `README.md` configuration section |
+| A new grant / flow (token exchange, passwordless, DB connection, etc.) | `README.md` + `EXAMPLES.md` (add an example) |
+| Install / package name / peer requirements | `README.md` install section |
+
+Update the doc **in the same PR** as the code — do not defer.

--- a/packages/auth0-auth-js/references/pitfalls.md
+++ b/packages/auth0-auth-js/references/pitfalls.md
@@ -1,0 +1,7 @@
+# Common Pitfalls — @auth0/auth0-auth-js
+
+- **Four runtimes, not one.** Code must work on Node, Bun, Deno, and Cloudflare Workers (each has its own CI workflow). Prefer Web-standard APIs (`fetch`, `crypto.subtle`, `Headers`, `btoa`) over Node-only built-ins. A change that passes `npm test` can still fail the Workers/Bun/Deno tiers.
+- **ESM `.js` import extensions are mandatory.** Relative imports must end in `.js` even though the source is `.ts` — omitting the extension breaks the ESM build and the Workers tier.
+- **Telemetry constants are build-time injected.** `__AUTH0_AUTH_JS_PACKAGE_NAME__` / `__AUTH0_AUTH_JS_PACKAGE_VERSION__` come from tsup `define` (and vitest `define` in tests). They don't exist at plain `tsc` time — don't reference them outside code that ships through tsup/vitest.
+- **`.version` and `package.json` version drift.** Two sources of truth: the release workflow reads `.version`, the telemetry payload reads `package.json`. Bump both together.
+- **Dependents downstream.** `auth0-api-js` and `auth0-server-js` consume this package. A signature or behaviour change here can break them — build and test them when you change the public surface.

--- a/packages/auth0-auth-js/references/testing.md
+++ b/packages/auth0-auth-js/references/testing.md
@@ -1,0 +1,27 @@
+# Testing — @auth0/auth0-auth-js
+
+## Three test tiers
+
+| Tier | Command | Config | Files | Credentials |
+|------|---------|--------|-------|-------------|
+| Unit (default) | `npm test` | `vitest.config.ts` | `src/**/*.spec.ts` (excludes workers + live-integration) | none |
+| Cloudflare Workers | `npm run test:workers` | `vitest.config.workers.ts` | `src/**/*.workers.spec.ts` | none (uses `wrangler.toml`) |
+| Live integration | `npm run test:integration` | `vitest.config.integration.ts` | `src/**/*.live.integration.spec.ts` | **real tenant** — Ask First |
+
+The live tier loads `.env.validation` from the repo root (or `AUTH0_ENV_FILE`) via `test/load-env.ts`, uses a 20s timeout, and retries twice. It hits a real Auth0 tenant and can mutate resources — do not run without approval.
+
+## Conventions
+
+- **Framework:** Vitest 3. Import from `vitest`: `import { expect, test, describe, beforeAll, afterAll, afterEach, vi } from 'vitest'`.
+- **Naming:** `describe(...)` groups with `test(...)` blocks (this package uses `test`, not `it`); test titles are behaviour sentences.
+- **Assertions:** `expect(...)` (`.toBe`, `.toBeDefined`, `.toThrow(ErrorClass)`, `resolves`/`rejects`).
+
+## Mocking (MSW)
+
+- `setupServer` from `msw/node` with `http` / `HttpResponse` / `delay` handlers, mocking the Auth0 `.well-known/openid-configuration`, JWKS, token, backchannel, and userinfo endpoints.
+- Lifecycle: `beforeAll(() => server.listen())`, `afterEach(() => server.resetHandlers())`, `afterAll(() => server.close())`; `server.use(...)` overrides handlers per test.
+- Token/JWKS fixtures come from `src/test-utils/tokens.ts` (`generateToken`, `jwks`); openid-client `Configuration` is built inline.
+
+## Build-time constants in tests
+
+The telemetry name/version constants (`__AUTH0_AUTH_JS_PACKAGE_NAME__`, `__AUTH0_AUTH_JS_PACKAGE_VERSION__`) are injected via each vitest config's `define` block (read from `package.json`), mirroring `tsup.config.ts`. Tests that touch telemetry rely on these being defined.

--- a/packages/auth0-server-js/AGENTS.md
+++ b/packages/auth0-server-js/AGENTS.md
@@ -1,0 +1,3 @@
+# AI Agent Guidelines for @auth0/auth0-server-js
+
+@./CLAUDE.md for all coding guidelines, commands, project structure, code style, testing conventions, and boundaries.

--- a/packages/auth0-server-js/CLAUDE.md
+++ b/packages/auth0-server-js/CLAUDE.md
@@ -1,0 +1,109 @@
+# AI Agent Guidelines for @auth0/auth0-server-js
+
+## Project Structure
+
+```
+packages/auth0-server-js/
+├── src/
+│   ├── index.ts                     # Public entry (barrel) — ServerClient, stores, cookie types, errors
+│   ├── server-client.ts             # ServerClient<TStoreOptions>: main façade (delegates OAuth to AuthClient)
+│   ├── errors.ts                    # Error classes + TokenExchangeErrorCode consts
+│   ├── types.ts                     # Public types; re-exports many from auth0-auth-js
+│   ├── telemetry.ts                 # Builds TelemetryConfig, passes to AuthClient (opt-out honoured)
+│   ├── utils.ts                     # compareScopes, ensureOpenIdScope
+│   ├── encryption/index.ts          # jose JWE encrypt/decrypt, HKDF key derivation, secret rotation
+│   ├── state/utils.ts               # IPSIE session_expiry extraction + enforcement
+│   ├── store/                       # Store abstractions (see Security) — abstract + cookie/stateful/stateless
+│   ├── mfa/                         # ServerMfaClient<TStoreOptions>
+│   ├── passkey/                     # ServerPasskeyClient<TStoreOptions>
+│   ├── database/                    # ServerDatabaseClient<TStoreOptions> (sign-up, change-password)
+│   └── test-utils/                  # Default stores, encryption + token helpers (test-only)
+├── eslint.config.mjs · .prettierrc · tsup.config.ts
+└── vitest.config.ts · vitest.config.workers.ts · wrangler.toml
+```
+
+`ServerClient<TStoreOptions = unknown>` is the façade; it holds a transaction store, a state/session store, and an `AuthClient` from `auth0-auth-js`, plus MFA/passkey/database sub-clients. Concrete stores exported: `CookieTransactionStore`, `StatefulStateStore`, `StatelessStateStore`, plus the `AbstractStateStore` / `AbstractTransactionStore` bases and the `CookieHandler` interface.
+
+---
+
+## Boundaries
+
+### ✅ Always Do
+
+- Run the unit suite (`npm test`) before committing.
+- Make surgical changes — touch only what the request requires; don't refactor adjacent code that isn't broken.
+- Follow existing code style and naming (single quotes, `printWidth` 120, `.js` extensions, `#private` members, `TStoreOptions` generic threading).
+- Add unit tests for new functionality (`src/**/*.spec.ts`, co-located).
+- Throw errors from the existing set — an `Error` subclass with a snake_case `.code` and `this.name` set (`MissingSessionError`, `SessionExpiredError`, etc.); reuse `TokenExchangeError` from auth0-auth-js and stamp a `TokenExchangeErrorCode`.
+- Keep `.version` and the `package.json` `version` field in sync — the release workflow reads `.version`, the telemetry payload reads `package.json`.
+- Update `README.md`, `EXAMPLES.md`, and `MFA.md` in the same PR when changing the public API, configuration options, or supported integration patterns.
+- When adding a **new outbound request path to Auth0**, route it through `AuthClient` (which carries the `Auth0-Client` header) and pass the `TelemetryConfig` from `src/telemetry.ts` — don't hand-roll a separate HTTP client, and preserve the `{ enabled: false }` opt-out.
+
+### ⚠️ Ask First
+
+- **Any breaking change — always ask first.** Never break backward compatibility on your own initiative.
+- Modifying public API signatures on `ServerClient`, the store base classes, or `CookieHandler`.
+- Adding new dependencies.
+- Modifying security-related code: session encryption (`encryption/`), the store abstractions, cookie options, secret rotation, or IPSIE `session_expiry` handling.
+- Changing the encrypted session/cookie format (a storage-format change breaks existing sessions).
+- Changes to CI (`.github/workflows/*`) or the release actions.
+
+### 🚫 Never Do
+
+- Commit secrets, API keys, or tokens.
+- Log tokens, session data, or the encryption secret.
+- Modify auto-generated / build output (`dist/`) or hand-edit lock files.
+- Remove or skip failing tests without fixing them.
+- Weaken cookie defaults (`httpOnly` / `secure` / `sameSite: 'lax'`), drop session-id regeneration on login (session fixation), or store session data unencrypted.
+
+---
+
+## Security Considerations
+
+- **Session storage is encrypted at rest.** `encryption/index.ts` uses `jose` JWE (`enc = A256CBC-HS512`, `alg = dir`); the per-record key is HKDF-derived (SHA-256, 512-bit) salted with `${salt}${kid}`, `kid` a per-encryption `randomUUID` stored in the JWE header. Tokens carry an expiry; decrypt allows a 15s clock tolerance.
+- **Secret rotation:** `secret` may be `string | string[]`; the newest encrypts, all are tried on decrypt (only for JWE decryption failures — other errors rethrow). Empty array throws `InvalidConfigurationError`.
+- **Store strategies:** `StatelessStateStore` encrypts the whole session into cookies chunked at 3072 bytes; `StatefulStateStore` keeps only a session id in a cookie (data in an injected `SessionStore`) and **regenerates the session id on login to prevent fixation**. On decryption failure the base store returns `undefined` (treats as expired/invalid).
+- **Cookies:** framework-agnostic `CookieHandler`; defaults `httpOnly: true`, `secure: true`, `sameSite: 'lax'`, `path: '/'`.
+- **PKCE / state / nonce:** delegated to `AuthClient`; this package only persists the resulting transaction data (`codeVerifier`, etc.). Session ids use `crypto.getRandomValues`.
+- **IPSIE `session_expiry`** (`state/utils.ts`): reads the ID-token `session_expiry` claim, fail-open on missing/malformed, rejects millisecond timestamps, applies a 30s leeway; triggers `SessionExpiredError`.
+- **Token logging:** none — no logger in `src/`.
+
+---
+
+> The sections below are **reference** — each keeps a one-line anchor here and offloads its body to `references/*.md`, read on demand.
+
+## Commands
+
+```bash
+npm run build        # tsup — dual ESM/CJS to dist/
+npm test             # vitest run — unit tier (no credentials)
+npm run lint         # eslint "./**/*.ts*"
+npm run test:workers # vitest run --config vitest.config.workers.ts
+```
+
+See [references/commands.md](references/commands.md) for the full list (coverage, watch, clean). Read when you need to run, build, or test something.
+
+## Testing
+
+- **Framework:** Vitest 3 (provider `v8`); mocking via MSW 2.
+- **Location:** co-located `src/**/*.spec.ts`.
+- The default `npm test` suite is unit-only — no credentials required (it excludes `*.workers.spec.ts`, which run under the Cloudflare Workers pool). Store tests use a `TestCookieHandler` and default in-memory stores from `src/test-utils/`; no live-tenant tier.
+
+See [references/testing.md](references/testing.md) for MSW setup, the cookie-handler test double, and the workers config. Read when writing or debugging tests.
+
+## Code Style
+
+- **CI-enforced:** ESLint flat config = `@eslint/js` recommended + `typescript-eslint` recommended (lint fails CI; `no-explicit-any` is active). Prettier: single quotes, `printWidth` 120, `arrowParens: always`, `trailingComma: es5`.
+- **Dominant convention:** PascalCase types/classes, camelCase members, `#private` fields, `SCREAMING_SNAKE` consts; the `TStoreOptions` generic threads through `ServerClient`, every store, and `CookieHandler`; deep store inheritance; pure helpers are free functions; `import type` for type-only imports; `.js` extensions.
+
+See [references/code-style.md](references/code-style.md) for good/bad examples and patterns. Read when writing non-trivial new code.
+
+## Common Pitfalls
+
+See [references/pitfalls.md](references/pitfalls.md) for runtime-compatibility, ESM, store-format, and generics gotchas. Read when a change spans runtimes or touches the stores/encryption.
+
+## Docs Update Rules
+
+> A PR that adds or changes public API, configuration, or integration patterns is **not complete** until the relevant docs are updated in the same PR.
+
+See [references/docs-update.md](references/docs-update.md) for the tracked-docs inventory and the code-to-docs mapping. The "update README.md / EXAMPLES.md in the same PR" rule is in Boundaries → Always Do.

--- a/packages/auth0-server-js/references/code-style.md
+++ b/packages/auth0-server-js/references/code-style.md
@@ -1,0 +1,44 @@
+# Code Style — @auth0/auth0-server-js
+
+## Naming & structure
+
+- PascalCase classes/types (`ServerClient`, `AbstractSessionStore`); camelCase members; `#private` fields on concrete stores.
+- `SCREAMING_SNAKE` module consts (`ENC`, `ALG`, `HKDF_INFO`, `MAX_PLAUSIBLE_UNIX_SECONDS`, `SESSION_EXPIRY_LEEWAY`); snake_case error `.code` strings.
+- `import type { ... }` for type-only imports; `.js` extensions on all relative imports.
+- Explicit return types on abstract/store methods (`Promise<void>`, `Promise<TData | undefined>`); some inference on private helpers.
+
+## Patterns
+
+- **Generics everywhere:** `TStoreOptions = unknown` threads through `ServerClient`, all stores, and `CookieHandler`; base is `AbstractStore<TData extends JWTPayload, TStoreOptions>`.
+- **Deep inheritance for stores:** `AbstractStore` → `AbstractStateStore` → `AbstractSessionStore` → concrete (`StatefulStateStore` / `StatelessStateStore`); pure utilities (`encryption`, `state/utils`, `telemetry`, `utils`) are exported free functions.
+- **Fail-safe decrypt:** swallow decryption failures (return `undefined`), rethrow everything else.
+- **Extensive JSDoc**, including long rationale comments on non-obvious constants.
+
+## ✅ Good (from `src/store/abstract-store.ts`)
+
+```typescript
+protected async decrypt<TData>(identifier: string, encryptedStateData: string) {
+  try {
+    return (await decrypt(encryptedStateData, this.options.secret, identifier)) as TData;
+  } catch (e: unknown) {
+    // A decryption failure likely means the session expired or the data is invalid — treat as absent.
+    if (isDecryptionError(e)) {
+      return;
+    }
+    throw e;
+  }
+}
+```
+
+## ❌ Bad
+
+```typescript
+// Swallows ALL errors (hides real bugs), no generic, double quotes
+protected async decrypt(identifier, encryptedStateData) {
+    try {
+        return await decrypt(encryptedStateData, this.options.secret, identifier)
+    } catch (e) {
+        return undefined
+    }
+}
+```

--- a/packages/auth0-server-js/references/commands.md
+++ b/packages/auth0-server-js/references/commands.md
@@ -1,0 +1,24 @@
+# Commands — @auth0/auth0-server-js
+
+Run from `packages/auth0-server-js` (or add `-w @auth0/auth0-server-js` from the repo root).
+
+```bash
+# Build (dual ESM/CJS via tsup → dist/)
+npm run build
+npm run build:watch          # rebuild on change
+
+# Clean build output
+npm run clean                # rm -rf ./dist
+
+# Unit tests (safe — no credentials; excludes workers specs)
+npm test                     # vitest run
+npm run test:ci              # vitest --watch false --coverage (CI command)
+
+# Cloudflare Workers runtime tier
+npm run test:workers         # vitest run --config vitest.config.workers.ts
+
+# Lint
+npm run lint                 # eslint "./**/*.ts*"
+```
+
+CI (`.github/workflows/test.yml`) builds this package after `auth0-auth-js`, then runs `test:ci` on Node 20 and 22 and `lint` on Node 24. The Bun, Deno, and Workers workflows build `auth0-auth-js` first, then this package.

--- a/packages/auth0-server-js/references/docs-update.md
+++ b/packages/auth0-server-js/references/docs-update.md
@@ -1,0 +1,22 @@
+# Docs Update Rules — @auth0/auth0-server-js
+
+## Tracked docs
+
+| Doc | Covers | Exists |
+|-----|--------|--------|
+| `README.md` | Install, client setup, store configuration, interactive login/logout, DB connections | ✅ |
+| `EXAMPLES.md` | Configuration (store/cookies/secret rotation/PrivateKeyJwt/mTLS), MCD, login/logout, backchannel, passkeys, token exchange, userinfo, session transfer, passwordless, session expiry, refresh-token revocation, backchannel logout, per-request options | ✅ |
+| `MFA.md` | MFA setup, handling MFA-required, list/enroll/challenge/verify authenticators, session persistence, error handling | ✅ |
+
+## When you change code, update these docs
+
+| When this changes | Update |
+|-------------------|--------|
+| `ServerClient` public method (added / removed / renamed) | `README.md` usage, `EXAMPLES.md` affected samples |
+| Store base classes, concrete stores, or `CookieHandler` | `README.md` store-configuration section, `EXAMPLES.md` configuration |
+| Configuration options (secret/rotation, cookies, PrivateKeyJwt, mTLS, store identifier) | `README.md` + `EXAMPLES.md` configuration |
+| MFA sub-client behaviour or flow | `MFA.md` |
+| A new flow (backchannel, passkeys, session transfer, passwordless, session expiry) | `README.md` + `EXAMPLES.md` (add an example) |
+| Install / package name / peer requirements | `README.md` install section |
+
+Update the doc **in the same PR** as the code — do not defer.

--- a/packages/auth0-server-js/references/pitfalls.md
+++ b/packages/auth0-server-js/references/pitfalls.md
@@ -1,0 +1,9 @@
+# Common Pitfalls — @auth0/auth0-server-js
+
+- **Four runtimes.** Code must work on Node, Bun, Deno, and Cloudflare Workers (each has its own CI workflow). Encryption uses `crypto.subtle` (Web Crypto) precisely so it runs everywhere — prefer Web-standard APIs over Node-only built-ins. A change that passes `npm test` can still fail the Workers/Bun/Deno tiers.
+- **ESM `.js` import extensions are mandatory** on relative imports even though sources are `.ts`.
+- **Changing the encrypted session/cookie format breaks live sessions.** The JWE payload shape, chunk size (3072 bytes), and HKDF salt are a storage contract — a change invalidates every existing cookie. Treat as a breaking change (Ask First).
+- **Thread `TStoreOptions` through.** New store or client methods must carry the generic, not `any` — `no-explicit-any` is enforced.
+- **Decrypt is fail-safe, not fail-silent.** Only swallow JWE decryption failures (via `isDecryptionError`); rethrow everything else so real bugs surface.
+- **Depends on `auth0-auth-js`.** OAuth/OIDC and telemetry are delegated to its `AuthClient`; a change there can shift behaviour here.
+- **`.version` vs `package.json` version.** The release workflow reads `.version`; keep both in sync.

--- a/packages/auth0-server-js/references/testing.md
+++ b/packages/auth0-server-js/references/testing.md
@@ -1,0 +1,26 @@
+# Testing — @auth0/auth0-server-js
+
+## Tiers
+
+| Tier | Command | Config | Files | Credentials |
+|------|---------|--------|-------|-------------|
+| Unit (default) | `npm test` | `vitest.config.ts` | `src/**/*.spec.ts` (excludes workers) | none |
+| Cloudflare Workers | `npm run test:workers` | `vitest.config.workers.ts` | `src/**/*.workers.spec.ts` | none (uses `wrangler.toml`) |
+
+No live-tenant tier. `src/per-request-options.integration.spec.ts` runs under the default unit config using MSW (no real credentials).
+
+## Conventions
+
+- **Framework:** Vitest 3. `import { expect, test, describe, vi, beforeAll, afterEach, ... } from 'vitest'`.
+- **Naming:** predominantly flat `test('...', async () => {...})` with `describe(...)` for grouping; descriptive `-`-separated titles (e.g. `'get - should throw when no storeOptions provided'`).
+- **Assertions:** `expect(...)` — `.toStrictEqual`, `objectContaining`, `rejects.toThrowError(...)`.
+
+## Mocking (MSW + cookie double)
+
+- `setupServer` from `msw/node` with `http` / `HttpResponse`, mocking the Auth0 `.well-known`, token, backchannel, and userinfo endpoints.
+- Store tests use a `TestCookieHandler` implementing `CookieHandler`, plus `DefaultStateStore` / `DefaultTransactionStore` and encryption/token helpers from `src/test-utils/`; `vi.fn()` spies on the cookie handler.
+- Lifecycle: `beforeAll`/`afterEach`/`afterAll` for MSW start/reset/close.
+
+## Build-time constants
+
+Telemetry constants (`__AUTH0_SERVER_JS_PACKAGE_NAME__` / `__AUTH0_SERVER_JS_PACKAGE_VERSION__`) are injected via `vitest.config.ts`'s `define` (mirroring `tsup.config.ts`, both reading `package.json`).


### PR DESCRIPTION
## Summary
Adds a layered set of `CLAUDE.md` / `AGENTS.md` files so AI coding agents have accurate, per-package context when working in this monorepo. A root file carries repo-wide orientation; each published package carries its own guardrails, commands, and conventions, with reference detail offloaded to `references/*.md`.

## Changes
- Add a root `CLAUDE.md` (persona, workspace-package map, git workflow) plus a matching `AGENTS.md` that imports it.
- Add a scoped `CLAUDE.md` + `AGENTS.md` for each published package (`auth0-auth-js`, `auth0-api-js`, `auth0-server-js`), each with its full Boundaries, Security Considerations, and Docs Update Rules.
- Offload commands, testing, code-style, pitfalls, and docs-update detail into per-package `references/*.md` behind on-demand pointers.
- Capture package-specific facts: telemetry wiring (Auth0-Client header for auth-js/server-js; none for the api-side verifier), the live-tenant integration tier on auth0-auth-js marked Ask-First, the `.version`/`package.json` version-sync rule, and the four-runtime (Node/Bun/Deno/Workers) compatibility constraint.

## Testing
- Verified the monorepo hierarchy: root has no Boundaries/Security/Docs; package files carry their own and don't restate the persona/git-workflow/workspace map; no root back-references.
- Confirmed every `references/*.md` pointer resolves and each `AGENTS.md` imports its co-located `@./CLAUDE.md`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive contributor and AI-agent guidance across the authentication SDK repository and its packages.
  - Documented coding standards, development commands, testing practices, security considerations, common pitfalls, supported runtimes, and documentation update requirements.
  - Added package-specific reference materials to help maintain consistent implementation, testing, and documentation practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->